### PR TITLE
[codex][refactor:extract] Issue #748 Wave 2 surface renderer boundaries

### DIFF
--- a/apps/desktop/src/shell/page/DesktopShellAuxiliaryPanels.tsx
+++ b/apps/desktop/src/shell/page/DesktopShellAuxiliaryPanels.tsx
@@ -60,7 +60,7 @@ type NotificationItemView = NotificationView & {
   unread: boolean;
 };
 
-type MessagesWorkspaceProps = {
+export type DesktopShellMessagesSurfaceProps = {
   t: Translate;
   locale: SupportedLocale;
   viewModels: Pick<
@@ -82,7 +82,7 @@ type MessagesWorkspaceProps = {
   handleSendDirectMessage: (event: FormEvent<HTMLFormElement>) => Promise<void>;
 };
 
-export function DesktopShellMessagesWorkspace({
+export function DesktopShellMessagesSurface({
   t,
   locale,
   viewModels,
@@ -94,7 +94,7 @@ export function DesktopShellMessagesWorkspace({
   handleDirectMessageAttachmentSelection,
   handleRemoveDirectMessageDraftAttachment,
   handleSendDirectMessage,
-}: MessagesWorkspaceProps) {
+}: DesktopShellMessagesSurfaceProps) {
   const {
     directMessageAttachmentInputKey,
     directMessageComposer,
@@ -416,19 +416,23 @@ export function DesktopShellMessagesWorkspace({
   );
 }
 
-type NotificationsWorkspaceProps = {
+export function DesktopShellMessagesWorkspace(props: DesktopShellMessagesSurfaceProps) {
+  return <DesktopShellMessagesSurface {...props} />;
+}
+
+export type DesktopShellNotificationsSurfaceProps = {
   t: Translate;
   locale: SupportedLocale;
   onRefresh: () => void;
   handleOpenNotification: (notification: NotificationView) => Promise<void>;
 };
 
-export function DesktopShellNotificationsWorkspace({
+export function DesktopShellNotificationsSurface({
   t,
   locale,
   onRefresh,
   handleOpenNotification,
-}: NotificationsWorkspaceProps) {
+}: DesktopShellNotificationsSurfaceProps) {
   const {
     knownAuthorsByPubkey,
     mediaObjectUrls,
@@ -572,7 +576,11 @@ export function DesktopShellNotificationsWorkspace({
   );
 }
 
-type DetailPaneStackProps = {
+export function DesktopShellNotificationsWorkspace(props: DesktopShellNotificationsSurfaceProps) {
+  return <DesktopShellNotificationsSurface {...props} />;
+}
+
+export type DesktopShellDetailSurfaceStackProps = {
   api: DesktopApi;
   t: Translate;
   viewModels: Pick<
@@ -606,7 +614,7 @@ type DetailPaneStackProps = {
   openCommunityNodeSettings: () => void;
 };
 
-export function DesktopShellDetailPaneStack({
+export function DesktopShellDetailSurfaceStack({
   api,
   t,
   viewModels,
@@ -630,7 +638,7 @@ export function DesktopShellDetailPaneStack({
   handleMuteAction,
   handleOpenOriginalTopic,
   openCommunityNodeSettings,
-}: DetailPaneStackProps) {
+}: DesktopShellDetailSurfaceStackProps) {
   const {
     activeTopic,
     bookmarkedReactionAssets,
@@ -786,4 +794,8 @@ export function DesktopShellDetailPaneStack({
       ) : null}
     </>
   );
+}
+
+export function DesktopShellDetailPaneStack(props: DesktopShellDetailSurfaceStackProps) {
+  return <DesktopShellDetailSurfaceStack {...props} />;
 }

--- a/apps/desktop/src/shell/page/DesktopShellPrimaryWorkspace.tsx
+++ b/apps/desktop/src/shell/page/DesktopShellPrimaryWorkspace.tsx
@@ -44,7 +44,7 @@ import { useShallow } from 'zustand/react/shallow';
 
 type ViewModels = ReturnType<typeof useDesktopShellViewModels>;
 
-type DesktopShellPrimaryWorkspaceProps = {
+export type DesktopShellPrimarySurfaceProps = {
   t: Translate;
   api: DesktopApi;
   metaverseActions: MetaverseRoomActions;
@@ -113,7 +113,7 @@ type DesktopShellPrimaryWorkspaceProps = {
   columnMode?: boolean;
 };
 
-export function DesktopShellPrimaryWorkspace({
+export function DesktopShellPrimarySurface({
   t,
   api,
   metaverseActions,
@@ -156,7 +156,7 @@ export function DesktopShellPrimaryWorkspace({
   handleMuteAction,
   handleOpenOriginalTopic,
   columnMode = false,
-}: DesktopShellPrimaryWorkspaceProps) {
+}: DesktopShellPrimarySurfaceProps) {
   const {
     activeTopic,
     bookmarkedPosts,
@@ -640,4 +640,8 @@ export function DesktopShellPrimaryWorkspace({
       </section>
     </div>
   );
+}
+
+export function DesktopShellPrimaryWorkspace(props: DesktopShellPrimarySurfaceProps) {
+  return <DesktopShellPrimarySurface {...props} />;
 }


### PR DESCRIPTION
## 概要

Issue #748 Wave 2 の実装前準備として、既存の primary / messages / notifications / detail 表示を `*Surface` renderer として公開しました。既存の workspace / pane entrypoint は互換 wrapper として維持しています。

## 種別

- `refactor:extract`
- 振る舞い・DOM・accessible name・route・visual の変更なし

## 検証

- `cargo xtask desktop-ui-check`
- `cargo xtask check`
- `cargo xtask test`
- `cargo xtask oversized-files`
- `git diff --check`
- 既存 surface characterization: 38/38 passed

## リスク

低。既存 entrypoint は同一 props を surface renderer に転送するだけです。visual regression 14/14 も既存 baseline のまま通過しています。

Refs #748