### PR TITLE
feat: 配布素材の権利と再配布条件を管理する

### DIFF
--- a/.github/workflows/kukuri-fast.yml
+++ b/.github/workflows/kukuri-fast.yml
@@ -84,6 +84,9 @@ jobs:
       - name: Oversized file report
         run: cargo xtask oversized-files
 
+      - name: Asset rights manifest
+        run: cargo xtask asset-check
+
       - name: Rust checks
         run: cargo xtask rust-check
 

--- a/.github/workflows/kukuri-release.yml
+++ b/.github/workflows/kukuri-release.yml
@@ -154,7 +154,7 @@ jobs:
         working-directory: apps/desktop
         run: pnpm install --frozen-lockfile
 
-      - name: Third-party notices check
+      - name: Package and asset notices check
         shell: pwsh
         run: ./scripts/release/generate-third-party-notices.ps1 -Check
 
@@ -383,7 +383,7 @@ jobs:
         shell: pwsh
         run: ./scripts/release/test-create-preview-assets.ps1
 
-      - name: Third-party notice script smoke
+      - name: Package and asset notice script smoke
         shell: pwsh
         run: ./scripts/release/test-generate-third-party-notices.ps1
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7734,8 +7734,11 @@ name = "xtask"
 version = "0.1.5"
 dependencies = [
  "anyhow",
+ "hex",
  "kukuri-harness",
+ "serde",
  "serde_json",
+ "sha2 0.11.0",
  "tokio",
 ]
 

--- a/apps/desktop/src/components/shell/ColumnCanvas.test.tsx
+++ b/apps/desktop/src/components/shell/ColumnCanvas.test.tsx
@@ -394,6 +394,17 @@ describe('ColumnCanvas', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Go to Column 3 of 3' }));
     expect(onActivateColumn).toHaveBeenLastCalledWith('profile', true);
+
+    // A delayed settle from the previous page must not override a direct indicator jump.
+    fireEvent.scroll(canvas);
+    await act(async () => vi.advanceTimersByTime(120));
+    expect(onActivateColumn).toHaveBeenCalledTimes(2);
+    expect(onActivateColumn).toHaveBeenLastCalledWith('profile', true);
+
+    canvas.scrollLeft = 780;
+    fireEvent.scroll(canvas);
+    await act(async () => vi.advanceTimersByTime(120));
+    expect(onActivateColumn).toHaveBeenCalledTimes(2);
     vi.unstubAllGlobals();
     vi.useRealTimers();
   });

--- a/apps/desktop/src/components/shell/ColumnCanvas.tsx
+++ b/apps/desktop/src/components/shell/ColumnCanvas.tsx
@@ -122,7 +122,6 @@ export function ColumnCanvas({
       const mobile = isMobileViewport();
       const reducedMotion = prefersReducedMotion();
       if (mobile) {
-        programmaticScrollTargetRef.current = activeColumnId;
         if (scrollSettleTimeoutRef.current !== null) {
           window.clearTimeout(scrollSettleTimeoutRef.current);
           scrollSettleTimeoutRef.current = null;

--- a/apps/desktop/src/components/shell/ColumnCanvas.tsx
+++ b/apps/desktop/src/components/shell/ColumnCanvas.tsx
@@ -64,6 +64,7 @@ export function ColumnCanvas({
   } | null>(null);
   const swipeConsumedRef = useRef(false);
   const scrollSettleTimeoutRef = useRef<number | null>(null);
+  const programmaticScrollTargetRef = useRef<string | null>(null);
   const [dropTarget, setDropTarget] = useState<{ index: number; left: number } | null>(null);
   const [announcement, setAnnouncement] = useState('');
 
@@ -120,6 +121,13 @@ export function ColumnCanvas({
     if (typeof column?.scrollIntoView === 'function') {
       const mobile = isMobileViewport();
       const reducedMotion = prefersReducedMotion();
+      if (mobile) {
+        programmaticScrollTargetRef.current = activeColumnId;
+        if (scrollSettleTimeoutRef.current !== null) {
+          window.clearTimeout(scrollSettleTimeoutRef.current);
+          scrollSettleTimeoutRef.current = null;
+        }
+      }
       column.scrollIntoView({
         block: 'nearest',
         inline: mobile ? 'center' : 'nearest',
@@ -185,6 +193,11 @@ export function ColumnCanvas({
         return id ? [{ id, left: column.offsetLeft, width: column.offsetWidth }] : [];
       });
       const nearest = nearestColumnToViewportCenter(columns, canvas.scrollLeft, canvas.clientWidth);
+      const programmaticTarget = programmaticScrollTargetRef.current;
+      if (programmaticTarget) {
+        if (nearest === programmaticTarget) programmaticScrollTargetRef.current = null;
+        return;
+      }
       if (nearest && nearest !== activeColumnId) onActivateColumn(nearest, true);
     }, SCROLL_SETTLE_MS);
   };
@@ -247,6 +260,7 @@ export function ColumnCanvas({
         swipeConsumedRef.current = false;
       }}
       onPointerDownCapture={(event) => {
+        programmaticScrollTargetRef.current = null;
         if (!isMobileViewport() || columnIds.length < 2) return;
         if (swipeGestureRef.current) return;
         const canvas = canvasRef.current;
@@ -280,6 +294,7 @@ export function ColumnCanvas({
         window.setTimeout(() => {
           swipeConsumedRef.current = false;
         }, 0);
+        programmaticScrollTargetRef.current = columnIds[targetIndex];
         onActivateColumn(columnIds[targetIndex], true);
       }}
       onPointerCancelCapture={() => {
@@ -340,7 +355,14 @@ export function ColumnCanvas({
                 type='button'
                 aria-label={`Go to Column ${index + 1} of ${columnIds.length}`}
                 aria-current={columnId === activeColumnId ? 'page' : undefined}
-                onClick={() => onActivateColumn(columnId, true)}
+                onClick={() => {
+                  programmaticScrollTargetRef.current = columnId;
+                  if (scrollSettleTimeoutRef.current !== null) {
+                    window.clearTimeout(scrollSettleTimeoutRef.current);
+                    scrollSettleTimeoutRef.current = null;
+                  }
+                  onActivateColumn(columnId, true);
+                }}
               >
                 <span aria-hidden='true' />
               </button>

--- a/docs/ASSET_MANIFEST.json
+++ b/docs/ASSET_MANIFEST.json
@@ -1,0 +1,636 @@
+{
+  "schema_version": 1,
+  "assets": [
+    {
+      "id": "kukuri-app-icon",
+      "display_name": "kukuri application icon",
+      "origin": "authored",
+      "author": "KingYoSun",
+      "rights_holder": "KingYoSun",
+      "source": {
+        "created_on": "2026-03-26"
+      },
+      "license": {
+        "id": "MIT",
+        "text_path": "LICENSE",
+        "commercial_use": true,
+        "repository_redistribution": true,
+        "binary_redistribution": true,
+        "attribution_required": true,
+        "attribution": "Copyright (c) 2025 KingYoSun"
+      },
+      "modification": {
+        "modified": true,
+        "description": "The platform-specific sizes and formats are derived from apps/desktop/app-icon.png."
+      },
+      "generation": null,
+      "files": [
+        {
+          "path": "apps/desktop/app-icon.png",
+          "sha256": "e017fd5dac0704983984ce4c9483d826f53137dd692e789a4fb363b6ec5e6cc9",
+          "distribution": "source-only"
+        },
+        {
+          "path": "apps/desktop/src-tauri/icons/128x128.png",
+          "sha256": "7d00ebf76882760fa730e08b747a3153d8b3c08c97e826e6c2751324f57eff55",
+          "distribution": "bundled-binary"
+        },
+        {
+          "path": "apps/desktop/src-tauri/icons/128x128@2x.png",
+          "sha256": "2c05692d48888d6906d7662dd9dda54a8002ae5e90a99401d6dc1b008f99e55d",
+          "distribution": "bundled-binary"
+        },
+        {
+          "path": "apps/desktop/src-tauri/icons/32x32.png",
+          "sha256": "998ddb22ca39bda6a4f025d6c48c4a85a87268610e2cd4c682ef40e75a97c49f",
+          "distribution": "bundled-binary"
+        },
+        {
+          "path": "apps/desktop/src-tauri/icons/64x64.png",
+          "sha256": "fb3ae4c67d46231c288933d0d8ade24c0f413b01cecc81db6f9117ed1d2cb041",
+          "distribution": "bundled-binary"
+        },
+        {
+          "path": "apps/desktop/src-tauri/icons/Square107x107Logo.png",
+          "sha256": "b41b4ad8df097222c24f377e9e2113fc7ee318aaac8d20be7affd0885013ff10",
+          "distribution": "bundled-binary"
+        },
+        {
+          "path": "apps/desktop/src-tauri/icons/Square142x142Logo.png",
+          "sha256": "81a014f62837efe5c47961833861b57f8bc91a0d8ae71dc6dad5ca2d0b367515",
+          "distribution": "bundled-binary"
+        },
+        {
+          "path": "apps/desktop/src-tauri/icons/Square150x150Logo.png",
+          "sha256": "32d01f5ebdebf7bae1a60a61861cb47b7c921f65ddd648bb30995d8afbfaf896",
+          "distribution": "bundled-binary"
+        },
+        {
+          "path": "apps/desktop/src-tauri/icons/Square284x284Logo.png",
+          "sha256": "4d8eb8f4aaebcb2e87f91464a3b6966cad66f79a1b3f0eb17565920c9844b2ca",
+          "distribution": "bundled-binary"
+        },
+        {
+          "path": "apps/desktop/src-tauri/icons/Square30x30Logo.png",
+          "sha256": "a0456dd5c87e4469b4990e59e297cf97fc792a6143cfe2da3a535797d4bd3d90",
+          "distribution": "bundled-binary"
+        },
+        {
+          "path": "apps/desktop/src-tauri/icons/Square310x310Logo.png",
+          "sha256": "239f0c5dcfa7dcd9bd3014954f56af1f43bf181a3bd42492cd1791000d6af4c1",
+          "distribution": "bundled-binary"
+        },
+        {
+          "path": "apps/desktop/src-tauri/icons/Square44x44Logo.png",
+          "sha256": "180fde18c9fb51c49f6467d46429592c2daa4bf66ad5a072676361a9995fde89",
+          "distribution": "bundled-binary"
+        },
+        {
+          "path": "apps/desktop/src-tauri/icons/Square71x71Logo.png",
+          "sha256": "c26fd05b331cfef94070bb9db6f31c8d8b296651432f8f62707528716e913998",
+          "distribution": "bundled-binary"
+        },
+        {
+          "path": "apps/desktop/src-tauri/icons/Square89x89Logo.png",
+          "sha256": "302a0cdf8f936913289674262a01190660cf4df32fbec6d927c37a34015ff44d",
+          "distribution": "bundled-binary"
+        },
+        {
+          "path": "apps/desktop/src-tauri/icons/StoreLogo.png",
+          "sha256": "ae0bbf39ce125a6b9b5e45ec5ba0fc0a4a69723635f539cff3f94d847e25c6ed",
+          "distribution": "bundled-binary"
+        },
+        {
+          "path": "apps/desktop/src-tauri/icons/android/mipmap-anydpi-v26/ic_launcher.xml",
+          "sha256": "760d4b8a06bf7163dd010c33ad2cac9e4a75fa0177afaba042f83e311eef0c3e",
+          "distribution": "bundled-binary"
+        },
+        {
+          "path": "apps/desktop/src-tauri/icons/android/mipmap-hdpi/ic_launcher.png",
+          "sha256": "ab4944a6d4d5dacb440bd620368c589a9dd6d81fef7b88299ec1d157e17802b8",
+          "distribution": "bundled-binary"
+        },
+        {
+          "path": "apps/desktop/src-tauri/icons/android/mipmap-hdpi/ic_launcher_foreground.png",
+          "sha256": "13f28e2e81a1a2be84e8c4693be16032f670e70d0346819a1140095d64100bb7",
+          "distribution": "bundled-binary"
+        },
+        {
+          "path": "apps/desktop/src-tauri/icons/android/mipmap-hdpi/ic_launcher_round.png",
+          "sha256": "0e97badf41cd498bf3d94290a01ec6b33119607d2ec0709e4630c2a9d50b030e",
+          "distribution": "bundled-binary"
+        },
+        {
+          "path": "apps/desktop/src-tauri/icons/android/mipmap-mdpi/ic_launcher.png",
+          "sha256": "73b97e966b79425b172d51ce9a674d33d1ff7c16f99a55d4bd31a3cd3f7edc14",
+          "distribution": "bundled-binary"
+        },
+        {
+          "path": "apps/desktop/src-tauri/icons/android/mipmap-mdpi/ic_launcher_foreground.png",
+          "sha256": "e8cafcfd4bf43c16bb5a9d462f06e8e18784d02b5b90e3f2f1feeb5d15819ee0",
+          "distribution": "bundled-binary"
+        },
+        {
+          "path": "apps/desktop/src-tauri/icons/android/mipmap-mdpi/ic_launcher_round.png",
+          "sha256": "d1089c84da8796db7411f6ee3c4e678bd73964627caddf30aba0ab1060380a9c",
+          "distribution": "bundled-binary"
+        },
+        {
+          "path": "apps/desktop/src-tauri/icons/android/mipmap-xhdpi/ic_launcher.png",
+          "sha256": "6badd7c0e765b5ba3591160908ea610d939f95b7c777f84525fa617c5ade4947",
+          "distribution": "bundled-binary"
+        },
+        {
+          "path": "apps/desktop/src-tauri/icons/android/mipmap-xhdpi/ic_launcher_foreground.png",
+          "sha256": "6fd2fec54e7376b07279c2ac53d2a884657e5888447de8059f07a2de1b933713",
+          "distribution": "bundled-binary"
+        },
+        {
+          "path": "apps/desktop/src-tauri/icons/android/mipmap-xhdpi/ic_launcher_round.png",
+          "sha256": "0123bc8a06dff5b0bc3abfbd3dca8123781768daffc44a311ab465be449b030a",
+          "distribution": "bundled-binary"
+        },
+        {
+          "path": "apps/desktop/src-tauri/icons/android/mipmap-xxhdpi/ic_launcher.png",
+          "sha256": "4fbea26cf906982fe7ed9b76b5114476515a52445a75bd57c243c04174a458df",
+          "distribution": "bundled-binary"
+        },
+        {
+          "path": "apps/desktop/src-tauri/icons/android/mipmap-xxhdpi/ic_launcher_foreground.png",
+          "sha256": "bbe301287ffc99a3f4b1b4e46425bece00f4e3c288adc5577640fac6d6190f39",
+          "distribution": "bundled-binary"
+        },
+        {
+          "path": "apps/desktop/src-tauri/icons/android/mipmap-xxhdpi/ic_launcher_round.png",
+          "sha256": "2d7ab758a4bc9c8b1b04539950ae8e5470d7247a6ad0f5350fbb3b6eee4fb61a",
+          "distribution": "bundled-binary"
+        },
+        {
+          "path": "apps/desktop/src-tauri/icons/android/mipmap-xxxhdpi/ic_launcher.png",
+          "sha256": "276388deee22cb36ed0d73a776f4bf85d97a7208126ea001f2286ccbc03f7940",
+          "distribution": "bundled-binary"
+        },
+        {
+          "path": "apps/desktop/src-tauri/icons/android/mipmap-xxxhdpi/ic_launcher_foreground.png",
+          "sha256": "98e6d6c456625ae0857543dad0c12e6488ec477f10c740a18fe0bcf21e54fe46",
+          "distribution": "bundled-binary"
+        },
+        {
+          "path": "apps/desktop/src-tauri/icons/android/mipmap-xxxhdpi/ic_launcher_round.png",
+          "sha256": "256ae4fca82246411867e983b5d407bfd404cf13a245e018f2a6c2370cd8c793",
+          "distribution": "bundled-binary"
+        },
+        {
+          "path": "apps/desktop/src-tauri/icons/android/values/ic_launcher_background.xml",
+          "sha256": "0687336f0ccc6f7ee09c7c95110667c63b75931238df779a21af401fb864cd34",
+          "distribution": "bundled-binary"
+        },
+        {
+          "path": "apps/desktop/src-tauri/icons/icon.icns",
+          "sha256": "6d673541813dfea31c75d55cd012fd09fd85d30cb3095d7877513ad7616f19f2",
+          "distribution": "bundled-binary"
+        },
+        {
+          "path": "apps/desktop/src-tauri/icons/icon.ico",
+          "sha256": "0f25f42d1499007ccc585d9012d05854cf91c5f852d693f24b61908388bbb7b7",
+          "distribution": "bundled-binary"
+        },
+        {
+          "path": "apps/desktop/src-tauri/icons/icon.png",
+          "sha256": "ee1a0bba81298e00668ff6e31052cb16f73e1789471ddb79027dfdaf997e0592",
+          "distribution": "bundled-binary"
+        },
+        {
+          "path": "apps/desktop/src-tauri/icons/ios/AppIcon-20x20@1x.png",
+          "sha256": "8837613af3d3ae216ea7173e8b2b32385aa60126921b7cab52983b2097037edc",
+          "distribution": "bundled-binary"
+        },
+        {
+          "path": "apps/desktop/src-tauri/icons/ios/AppIcon-20x20@2x-1.png",
+          "sha256": "131fda20a74ec9d190e87b1df1571d91b9eb0c6aafffa2e9a25021b9134fff78",
+          "distribution": "bundled-binary"
+        },
+        {
+          "path": "apps/desktop/src-tauri/icons/ios/AppIcon-20x20@2x.png",
+          "sha256": "131fda20a74ec9d190e87b1df1571d91b9eb0c6aafffa2e9a25021b9134fff78",
+          "distribution": "bundled-binary"
+        },
+        {
+          "path": "apps/desktop/src-tauri/icons/ios/AppIcon-20x20@3x.png",
+          "sha256": "69a2b6fab40cc1a5bf4426d9ab0ceabec134c149deeb1dd1c6a3f245b7d05806",
+          "distribution": "bundled-binary"
+        },
+        {
+          "path": "apps/desktop/src-tauri/icons/ios/AppIcon-29x29@1x.png",
+          "sha256": "4125cadca9714020b5dfce58d57377e81a015cb6b5e95a22a37a8be576ed02c4",
+          "distribution": "bundled-binary"
+        },
+        {
+          "path": "apps/desktop/src-tauri/icons/ios/AppIcon-29x29@2x-1.png",
+          "sha256": "a2b38ec78250569ece791649e4e15025d325a93af0db522f5169335f217a7a6e",
+          "distribution": "bundled-binary"
+        },
+        {
+          "path": "apps/desktop/src-tauri/icons/ios/AppIcon-29x29@2x.png",
+          "sha256": "a2b38ec78250569ece791649e4e15025d325a93af0db522f5169335f217a7a6e",
+          "distribution": "bundled-binary"
+        },
+        {
+          "path": "apps/desktop/src-tauri/icons/ios/AppIcon-29x29@3x.png",
+          "sha256": "b7e7c07230ea7ee37566c4e378840b81c8a404c50a9e85024beb5cf11c9c7b04",
+          "distribution": "bundled-binary"
+        },
+        {
+          "path": "apps/desktop/src-tauri/icons/ios/AppIcon-40x40@1x.png",
+          "sha256": "131fda20a74ec9d190e87b1df1571d91b9eb0c6aafffa2e9a25021b9134fff78",
+          "distribution": "bundled-binary"
+        },
+        {
+          "path": "apps/desktop/src-tauri/icons/ios/AppIcon-40x40@2x-1.png",
+          "sha256": "19088ee4cd03e2f8c21094bd366ba836be5ed872b60924674b08f18297fba179",
+          "distribution": "bundled-binary"
+        },
+        {
+          "path": "apps/desktop/src-tauri/icons/ios/AppIcon-40x40@2x.png",
+          "sha256": "19088ee4cd03e2f8c21094bd366ba836be5ed872b60924674b08f18297fba179",
+          "distribution": "bundled-binary"
+        },
+        {
+          "path": "apps/desktop/src-tauri/icons/ios/AppIcon-40x40@3x.png",
+          "sha256": "e7db236d682d0a9d49b898022f7f5110a8b2d450f469bc22f191e39d2c7cb548",
+          "distribution": "bundled-binary"
+        },
+        {
+          "path": "apps/desktop/src-tauri/icons/ios/AppIcon-512@2x.png",
+          "sha256": "94c92a1298742bedc704788a728380e711e3f8790bc559eb6c4c3a51c4325e20",
+          "distribution": "bundled-binary"
+        },
+        {
+          "path": "apps/desktop/src-tauri/icons/ios/AppIcon-60x60@2x.png",
+          "sha256": "e7db236d682d0a9d49b898022f7f5110a8b2d450f469bc22f191e39d2c7cb548",
+          "distribution": "bundled-binary"
+        },
+        {
+          "path": "apps/desktop/src-tauri/icons/ios/AppIcon-60x60@3x.png",
+          "sha256": "378f65122f00096a2a8b4db17afbb36a66b24a5bb023ca047288dd7a9bab1228",
+          "distribution": "bundled-binary"
+        },
+        {
+          "path": "apps/desktop/src-tauri/icons/ios/AppIcon-76x76@1x.png",
+          "sha256": "eb2c60efcac1c40597f921c879a2d3fd658ee82ca9f5d1f22bffc5ab6136a703",
+          "distribution": "bundled-binary"
+        },
+        {
+          "path": "apps/desktop/src-tauri/icons/ios/AppIcon-76x76@2x.png",
+          "sha256": "49fd16e3a82668aa5ad069474419a794166c3204ce279ee814d13c94dcf831f8",
+          "distribution": "bundled-binary"
+        },
+        {
+          "path": "apps/desktop/src-tauri/icons/ios/AppIcon-83.5x83.5@2x.png",
+          "sha256": "fcce9caf360fe5c5eafecd79a30735628bcfa182aaf944e27191e73ece11d3b9",
+          "distribution": "bundled-binary"
+        }
+      ]
+    },
+    {
+      "id": "blumochichi-vrm",
+      "display_name": "blumochichi VRM avatar",
+      "origin": "authored",
+      "author": "KingYoSun",
+      "rights_holder": "KingYoSun",
+      "source": {
+        "created_on": "2026-05-28"
+      },
+      "license": {
+        "id": "MIT",
+        "text_path": "LICENSE",
+        "commercial_use": true,
+        "repository_redistribution": true,
+        "binary_redistribution": true,
+        "attribution_required": true,
+        "attribution": "Copyright (c) 2025 KingYoSun"
+      },
+      "modification": {
+        "modified": false
+      },
+      "generation": null,
+      "files": [
+        {
+          "path": "apps/desktop/public/blumochichi.vrm",
+          "sha256": "92403742e24ec75268dd10c277f32d314994a1e8732b1f9818f681b6480f0770",
+          "distribution": "bundled-binary"
+        }
+      ]
+    },
+    {
+      "id": "universal-animation-idle-loop",
+      "display_name": "Idle Loop VRMA",
+      "origin": "third_party",
+      "author": "Quaternius",
+      "rights_holder": "Quaternius",
+      "source": {
+        "url": "https://quaternius.com/packs/universalanimationlibrary.html",
+        "acquired_on": "2026-05-29"
+      },
+      "license": {
+        "id": "CC0-1.0",
+        "text_url": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "commercial_use": true,
+        "repository_redistribution": true,
+        "binary_redistribution": true,
+        "attribution_required": false,
+        "attribution": "Universal Animation Library by Quaternius (courtesy credit)"
+      },
+      "modification": {
+        "modified": false
+      },
+      "generation": null,
+      "files": [
+        {
+          "path": "apps/desktop/public/animation/Idle_Loop.vrma",
+          "sha256": "6de22a6f851cb2d45a7b896ea3183a02db58e335d83c3ee14dc1e1a79d6f96ac",
+          "distribution": "bundled-binary"
+        }
+      ]
+    },
+    {
+      "id": "universal-animation-jump-land",
+      "display_name": "Jump Land VRMA",
+      "origin": "third_party",
+      "author": "Quaternius",
+      "rights_holder": "Quaternius",
+      "source": {
+        "url": "https://quaternius.com/packs/universalanimationlibrary.html",
+        "acquired_on": "2026-05-29"
+      },
+      "license": {
+        "id": "CC0-1.0",
+        "text_url": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "commercial_use": true,
+        "repository_redistribution": true,
+        "binary_redistribution": true,
+        "attribution_required": false,
+        "attribution": "Universal Animation Library by Quaternius (courtesy credit)"
+      },
+      "modification": {
+        "modified": false
+      },
+      "generation": null,
+      "files": [
+        {
+          "path": "apps/desktop/public/animation/Jump_Land.vrma",
+          "sha256": "6fb8f9b6afb4a7058e14b702fc942cfefcc15a0e6408ecd7518648133936076b",
+          "distribution": "bundled-binary"
+        }
+      ]
+    },
+    {
+      "id": "universal-animation-jump-loop",
+      "display_name": "Jump Loop VRMA",
+      "origin": "third_party",
+      "author": "Quaternius",
+      "rights_holder": "Quaternius",
+      "source": {
+        "url": "https://quaternius.com/packs/universalanimationlibrary.html",
+        "acquired_on": "2026-05-29"
+      },
+      "license": {
+        "id": "CC0-1.0",
+        "text_url": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "commercial_use": true,
+        "repository_redistribution": true,
+        "binary_redistribution": true,
+        "attribution_required": false,
+        "attribution": "Universal Animation Library by Quaternius (courtesy credit)"
+      },
+      "modification": {
+        "modified": false
+      },
+      "generation": null,
+      "files": [
+        {
+          "path": "apps/desktop/public/animation/Jump_Loop.vrma",
+          "sha256": "d4f2c733378ac6e0dc2c6fcc288423ec23e708b04bb53a2d6506bd2fdf55dd22",
+          "distribution": "bundled-binary"
+        }
+      ]
+    },
+    {
+      "id": "universal-animation-jump-start",
+      "display_name": "Jump Start VRMA",
+      "origin": "third_party",
+      "author": "Quaternius",
+      "rights_holder": "Quaternius",
+      "source": {
+        "url": "https://quaternius.com/packs/universalanimationlibrary.html",
+        "acquired_on": "2026-05-29"
+      },
+      "license": {
+        "id": "CC0-1.0",
+        "text_url": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "commercial_use": true,
+        "repository_redistribution": true,
+        "binary_redistribution": true,
+        "attribution_required": false,
+        "attribution": "Universal Animation Library by Quaternius (courtesy credit)"
+      },
+      "modification": {
+        "modified": false
+      },
+      "generation": null,
+      "files": [
+        {
+          "path": "apps/desktop/public/animation/Jump_Start.vrma",
+          "sha256": "5bfd5d91651483f5f464051c693d445baba4708d0c20b853646e3d9b14cd2aa5",
+          "distribution": "bundled-binary"
+        }
+      ]
+    },
+    {
+      "id": "universal-animation-sitting-enter",
+      "display_name": "Sitting Enter VRMA",
+      "origin": "third_party",
+      "author": "Quaternius",
+      "rights_holder": "Quaternius",
+      "source": {
+        "url": "https://quaternius.com/packs/universalanimationlibrary.html",
+        "acquired_on": "2026-05-29"
+      },
+      "license": {
+        "id": "CC0-1.0",
+        "text_url": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "commercial_use": true,
+        "repository_redistribution": true,
+        "binary_redistribution": true,
+        "attribution_required": false,
+        "attribution": "Universal Animation Library by Quaternius (courtesy credit)"
+      },
+      "modification": {
+        "modified": false
+      },
+      "generation": null,
+      "files": [
+        {
+          "path": "apps/desktop/public/animation/Sitting_Enter.vrma",
+          "sha256": "0f2a05716168abc8e0829fd512884a3c29481048cfaf78f4aa04d137bc66f9fa",
+          "distribution": "bundled-binary"
+        }
+      ]
+    },
+    {
+      "id": "universal-animation-sitting-exit",
+      "display_name": "Sitting Exit VRMA",
+      "origin": "third_party",
+      "author": "Quaternius",
+      "rights_holder": "Quaternius",
+      "source": {
+        "url": "https://quaternius.com/packs/universalanimationlibrary.html",
+        "acquired_on": "2026-05-29"
+      },
+      "license": {
+        "id": "CC0-1.0",
+        "text_url": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "commercial_use": true,
+        "repository_redistribution": true,
+        "binary_redistribution": true,
+        "attribution_required": false,
+        "attribution": "Universal Animation Library by Quaternius (courtesy credit)"
+      },
+      "modification": {
+        "modified": false
+      },
+      "generation": null,
+      "files": [
+        {
+          "path": "apps/desktop/public/animation/Sitting_Exit.vrma",
+          "sha256": "e6323d4e80d4229ada36c4769ef021b64f1dd6e619bc2843fb17bf40730e09f3",
+          "distribution": "bundled-binary"
+        }
+      ]
+    },
+    {
+      "id": "universal-animation-sitting-idle-loop",
+      "display_name": "Sitting Idle Loop VRMA",
+      "origin": "third_party",
+      "author": "Quaternius",
+      "rights_holder": "Quaternius",
+      "source": {
+        "url": "https://quaternius.com/packs/universalanimationlibrary.html",
+        "acquired_on": "2026-05-29"
+      },
+      "license": {
+        "id": "CC0-1.0",
+        "text_url": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "commercial_use": true,
+        "repository_redistribution": true,
+        "binary_redistribution": true,
+        "attribution_required": false,
+        "attribution": "Universal Animation Library by Quaternius (courtesy credit)"
+      },
+      "modification": {
+        "modified": false
+      },
+      "generation": null,
+      "files": [
+        {
+          "path": "apps/desktop/public/animation/Sitting_Idle_Loop.vrma",
+          "sha256": "883b23e97a68c25ad06b0cbda09b27feab9711c848eab174a6e41ba034ff38eb",
+          "distribution": "bundled-binary"
+        }
+      ]
+    },
+    {
+      "id": "universal-animation-sitting-talking-loop",
+      "display_name": "Sitting Talking Loop VRMA",
+      "origin": "third_party",
+      "author": "Quaternius",
+      "rights_holder": "Quaternius",
+      "source": {
+        "url": "https://quaternius.com/packs/universalanimationlibrary.html",
+        "acquired_on": "2026-05-29"
+      },
+      "license": {
+        "id": "CC0-1.0",
+        "text_url": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "commercial_use": true,
+        "repository_redistribution": true,
+        "binary_redistribution": true,
+        "attribution_required": false,
+        "attribution": "Universal Animation Library by Quaternius (courtesy credit)"
+      },
+      "modification": {
+        "modified": false
+      },
+      "generation": null,
+      "files": [
+        {
+          "path": "apps/desktop/public/animation/Sitting_Talking_Loop.vrma",
+          "sha256": "a3b143123d7ff0db23be197a2c0ebdc61f18c54232efc92b30704f7cce448729",
+          "distribution": "bundled-binary"
+        }
+      ]
+    },
+    {
+      "id": "universal-animation-sprint-loop",
+      "display_name": "Sprint Loop VRMA",
+      "origin": "third_party",
+      "author": "Quaternius",
+      "rights_holder": "Quaternius",
+      "source": {
+        "url": "https://quaternius.com/packs/universalanimationlibrary.html",
+        "acquired_on": "2026-05-29"
+      },
+      "license": {
+        "id": "CC0-1.0",
+        "text_url": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "commercial_use": true,
+        "repository_redistribution": true,
+        "binary_redistribution": true,
+        "attribution_required": false,
+        "attribution": "Universal Animation Library by Quaternius (courtesy credit)"
+      },
+      "modification": {
+        "modified": false
+      },
+      "generation": null,
+      "files": [
+        {
+          "path": "apps/desktop/public/animation/Sprint_Loop.vrma",
+          "sha256": "b8c15043028452be057fe8c3ead26bac08644cf90db2fa8e0f3f435dd8214a62",
+          "distribution": "bundled-binary"
+        }
+      ]
+    },
+    {
+      "id": "universal-animation-walk-loop",
+      "display_name": "Walk Loop VRMA",
+      "origin": "third_party",
+      "author": "Quaternius",
+      "rights_holder": "Quaternius",
+      "source": {
+        "url": "https://quaternius.com/packs/universalanimationlibrary.html",
+        "acquired_on": "2026-05-29"
+      },
+      "license": {
+        "id": "CC0-1.0",
+        "text_url": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "commercial_use": true,
+        "repository_redistribution": true,
+        "binary_redistribution": true,
+        "attribution_required": false,
+        "attribution": "Universal Animation Library by Quaternius (courtesy credit)"
+      },
+      "modification": {
+        "modified": false
+      },
+      "generation": null,
+      "files": [
+        {
+          "path": "apps/desktop/public/animation/Walk_Loop.vrma",
+          "sha256": "41f3b7791690a9d5d281338945072717a1358e6af3d93474dee020854287c841",
+          "distribution": "bundled-binary"
+        }
+      ]
+    }
+  ]
+}

--- a/docs/THIRD_PARTY_NOTICES.md
+++ b/docs/THIRD_PARTY_NOTICES.md
@@ -1,8 +1,8 @@
-﻿# Third-party notices
+# Third-party notices
 
-kukuri preview builds include Rust crates, npm packages, and Tauri runtime components from third-party authors.
+kukuri preview builds include Rust crates, npm packages, Tauri runtime components, and non-code assets.
 
-This file is generated from the locked Rust and desktop npm dependency inventories.
+This file is generated from the locked Rust and desktop npm dependency inventories plus docs/ASSET_MANIFEST.json.
 
 Regenerate it from the repository root with:
 
@@ -10,11 +10,45 @@ Regenerate it from the repository root with:
 ./scripts/release/generate-third-party-notices.ps1
 ```
 
-Release owners must review these inventories before publishing a preview build and update this generator if a dependency requires attribution text beyond the package-level license inventory.
+Release owners must review these inventories before publishing a preview build and update the manifest or generator if a package or asset requires additional license or attribution text.
 
 ## Current distribution note
 
 The first preview targets Windows installer distribution through GitHub Releases. Linux remains source-run only for this preview scope. If Windows code signing is not configured, the release notes must state that the preview is unsigned and that SmartScreen warnings are expected.
+
+## Non-code asset notices
+
+The asset manifest records exact repository paths, SHA-256 digests, provenance, and source-only versus bundled-binary scope. The entries below are the distribution-facing license and credit summary.
+
+### Bundled first-party assets
+
+| Asset | Author / rights holder | Source / date | License | Modification | Distribution | Conditions | Credit |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| blumochichi VRM avatar | KingYoSun / KingYoSun | created 2026-05-28 | MIT (LICENSE) | None | bundled-binary: apps/desktop/public/blumochichi.vrm | commercial=yes; repository redistribution=yes; binary redistribution=yes | Required: Copyright (c) 2025 KingYoSun |
+| kukuri application icon | KingYoSun / KingYoSun | created 2026-03-26 | MIT (LICENSE) | The platform-specific sizes and formats are derived from apps/desktop/app-icon.png. | source-only: apps/desktop/app-icon.png; bundled-binary: apps/desktop/src-tauri/icons/** (52 files) | commercial=yes; repository redistribution=yes; binary redistribution=yes | Required: Copyright (c) 2025 KingYoSun |
+
+### Bundled third-party assets
+
+| Asset | Author / rights holder | Source / date | License | Modification | Distribution | Conditions | Credit |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| Idle Loop VRMA | Quaternius / Quaternius | https://quaternius.com/packs/universalanimationlibrary.html (acquired 2026-05-29) | CC0-1.0 (https://creativecommons.org/publicdomain/zero/1.0/) | None | bundled-binary: apps/desktop/public/animation/Idle_Loop.vrma | commercial=yes; repository redistribution=yes; binary redistribution=yes | Not required; Universal Animation Library by Quaternius (courtesy credit) |
+| Jump Land VRMA | Quaternius / Quaternius | https://quaternius.com/packs/universalanimationlibrary.html (acquired 2026-05-29) | CC0-1.0 (https://creativecommons.org/publicdomain/zero/1.0/) | None | bundled-binary: apps/desktop/public/animation/Jump_Land.vrma | commercial=yes; repository redistribution=yes; binary redistribution=yes | Not required; Universal Animation Library by Quaternius (courtesy credit) |
+| Jump Loop VRMA | Quaternius / Quaternius | https://quaternius.com/packs/universalanimationlibrary.html (acquired 2026-05-29) | CC0-1.0 (https://creativecommons.org/publicdomain/zero/1.0/) | None | bundled-binary: apps/desktop/public/animation/Jump_Loop.vrma | commercial=yes; repository redistribution=yes; binary redistribution=yes | Not required; Universal Animation Library by Quaternius (courtesy credit) |
+| Jump Start VRMA | Quaternius / Quaternius | https://quaternius.com/packs/universalanimationlibrary.html (acquired 2026-05-29) | CC0-1.0 (https://creativecommons.org/publicdomain/zero/1.0/) | None | bundled-binary: apps/desktop/public/animation/Jump_Start.vrma | commercial=yes; repository redistribution=yes; binary redistribution=yes | Not required; Universal Animation Library by Quaternius (courtesy credit) |
+| Sitting Enter VRMA | Quaternius / Quaternius | https://quaternius.com/packs/universalanimationlibrary.html (acquired 2026-05-29) | CC0-1.0 (https://creativecommons.org/publicdomain/zero/1.0/) | None | bundled-binary: apps/desktop/public/animation/Sitting_Enter.vrma | commercial=yes; repository redistribution=yes; binary redistribution=yes | Not required; Universal Animation Library by Quaternius (courtesy credit) |
+| Sitting Exit VRMA | Quaternius / Quaternius | https://quaternius.com/packs/universalanimationlibrary.html (acquired 2026-05-29) | CC0-1.0 (https://creativecommons.org/publicdomain/zero/1.0/) | None | bundled-binary: apps/desktop/public/animation/Sitting_Exit.vrma | commercial=yes; repository redistribution=yes; binary redistribution=yes | Not required; Universal Animation Library by Quaternius (courtesy credit) |
+| Sitting Idle Loop VRMA | Quaternius / Quaternius | https://quaternius.com/packs/universalanimationlibrary.html (acquired 2026-05-29) | CC0-1.0 (https://creativecommons.org/publicdomain/zero/1.0/) | None | bundled-binary: apps/desktop/public/animation/Sitting_Idle_Loop.vrma | commercial=yes; repository redistribution=yes; binary redistribution=yes | Not required; Universal Animation Library by Quaternius (courtesy credit) |
+| Sitting Talking Loop VRMA | Quaternius / Quaternius | https://quaternius.com/packs/universalanimationlibrary.html (acquired 2026-05-29) | CC0-1.0 (https://creativecommons.org/publicdomain/zero/1.0/) | None | bundled-binary: apps/desktop/public/animation/Sitting_Talking_Loop.vrma | commercial=yes; repository redistribution=yes; binary redistribution=yes | Not required; Universal Animation Library by Quaternius (courtesy credit) |
+| Sprint Loop VRMA | Quaternius / Quaternius | https://quaternius.com/packs/universalanimationlibrary.html (acquired 2026-05-29) | CC0-1.0 (https://creativecommons.org/publicdomain/zero/1.0/) | None | bundled-binary: apps/desktop/public/animation/Sprint_Loop.vrma | commercial=yes; repository redistribution=yes; binary redistribution=yes | Not required; Universal Animation Library by Quaternius (courtesy credit) |
+| Walk Loop VRMA | Quaternius / Quaternius | https://quaternius.com/packs/universalanimationlibrary.html (acquired 2026-05-29) | CC0-1.0 (https://creativecommons.org/publicdomain/zero/1.0/) | None | bundled-binary: apps/desktop/public/animation/Walk_Loop.vrma | commercial=yes; repository redistribution=yes; binary redistribution=yes | Not required; Universal Animation Library by Quaternius (courtesy credit) |
+
+### Bundled generated or generation-assisted assets
+
+None.
+
+### Source-only non-code assets
+
+None.
 
 ## Rust crates
 

--- a/docs/runbooks/release.md
+++ b/docs/runbooks/release.md
@@ -115,17 +115,35 @@ The `changelog` job needs `contents: write` and `pull-requests: write` permissio
 
 ## Third-party Notices
 
-Before publishing a preview release, generate and review the Rust and desktop npm dependency
-license inventories from the release tag.
+Before publishing a preview release, validate the non-code asset rights manifest, then generate
+and review the Rust, desktop npm, and bundled asset license inventories from the release tag.
 
 The distribution notice lives at `docs/THIRD_PARTY_NOTICES.md` and is included in the draft release
-assets as `THIRD_PARTY_NOTICES.md`. Update the generator if a dependency requires specific
-attribution text beyond the package-level license inventory.
+assets as `THIRD_PARTY_NOTICES.md`. Exact non-code asset paths, SHA-256 digests, provenance,
+source-only versus bundled-binary scope, modification status, redistribution conditions, and credit
+requirements live in `docs/ASSET_MANIFEST.json`. The repository root MIT license does not replace a
+third-party asset license.
 
 ```powershell
+cargo xtask asset-check
 ./scripts/release/generate-third-party-notices.ps1
 ./scripts/release/generate-third-party-notices.ps1 -Check
 ```
+
+For every non-code asset addition, update, or deletion under `apps/desktop/public/`,
+`apps/desktop/app-icon.png`, or `apps/desktop/src-tauri/icons/`:
+
+1. Update the manifest entry and exact file SHA-256. Do not reuse the previous digest after editing.
+2. Record the author and rights holder, source and acquisition or creation date, license text or URL,
+   modification status, commercial use, repository and binary redistribution, and credit condition.
+3. For generated or generation-assisted material, also record the service, model, input rights, and
+   output terms URL. Do not mark unknown provenance or redistribution as allowed.
+4. Run the three commands above and review the generated asset sections separately from the package
+   inventories.
+5. Confirm the draft release contains the generated `THIRD_PARTY_NOTICES.md` before publication.
+
+`cargo xtask asset-check` and `cargo xtask release-check` fail on unregistered, missing, duplicate,
+or changed files and on unknown or insufficient rights. Pull request CI runs the same asset check.
 
 ## Manual Smoke
 

--- a/scripts/release/generate-third-party-notices.ps1
+++ b/scripts/release/generate-third-party-notices.ps1
@@ -2,6 +2,7 @@ param(
   [string]$OutputPath,
   [string]$RustMetadataPath,
   [string]$NpmLicensesPath,
+  [string]$AssetManifestPath,
   [switch]$Check
 )
 
@@ -11,6 +12,9 @@ $repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..\..")
 $desktopDir = Join-Path $repoRoot "apps\desktop"
 if ([string]::IsNullOrWhiteSpace($OutputPath)) {
   $OutputPath = Join-Path $repoRoot "docs\THIRD_PARTY_NOTICES.md"
+}
+if ([string]::IsNullOrWhiteSpace($AssetManifestPath)) {
+  $AssetManifestPath = Join-Path $repoRoot "docs\ASSET_MANIFEST.json"
 }
 
 function Escape-MarkdownCell {
@@ -118,6 +122,151 @@ function Get-NpmInventory {
   return @(Sort-Inventory $packages)
 }
 
+function Get-AssetManifest {
+  if (-not (Test-Path -LiteralPath $AssetManifestPath)) {
+    throw "Asset manifest does not exist: $AssetManifestPath"
+  }
+  $manifest = Get-Content -LiteralPath $AssetManifestPath -Raw -Encoding UTF8 | ConvertFrom-Json
+  if ([int]$manifest.schema_version -ne 1) {
+    throw "Unsupported asset manifest schema version: $($manifest.schema_version)"
+  }
+  return $manifest
+}
+
+function Sort-AssetInventory {
+  param([object[]]$Items)
+
+  $list = [System.Collections.Generic.List[object]]::new()
+  if ($Items) { $list.AddRange([object[]]$Items) }
+  $comparison = [System.Comparison[object]] {
+    param($a, $b)
+    return [string]::CompareOrdinal([string]$a.Id, [string]$b.Id)
+  }
+  $list.Sort($comparison)
+  return , $list.ToArray()
+}
+
+function Get-CommonDirectorySummary {
+  param(
+    [string[]]$Paths,
+    [string]$Distribution
+  )
+
+  if ($Paths.Count -eq 1) {
+    return "$($Distribution): $($Paths[0])"
+  }
+  $directories = @($Paths | ForEach-Object {
+      $segments = @($_ -split "/")
+      if ($segments.Count -le 1) { return "" }
+      return ($segments[0..($segments.Count - 2)] -join "/")
+    })
+  $common = @($directories[0] -split "/")
+  foreach ($directory in $directories | Select-Object -Skip 1) {
+    $segments = @($directory -split "/")
+    $limit = [Math]::Min($common.Count, $segments.Count)
+    $matched = 0
+    while ($matched -lt $limit -and $common[$matched] -ceq $segments[$matched]) {
+      $matched++
+    }
+    if ($matched -eq 0) {
+      $common = @()
+      break
+    }
+    $common = @($common[0..($matched - 1)])
+  }
+  if ($common.Count -eq 0) {
+    return "$($Distribution): $($Paths.Count) files"
+  }
+  return "$($Distribution): $(($common -join "/"))/** ($($Paths.Count) files)"
+}
+
+function Get-AssetFileSummary {
+  param([object[]]$Files)
+
+  $parts = [System.Collections.Generic.List[string]]::new()
+  foreach ($distribution in @("source-only", "bundled-binary")) {
+    $paths = @($Files |
+        Where-Object { [string]$_.distribution -eq $distribution } |
+        ForEach-Object { [string]$_.path })
+    if ($paths.Count -gt 0) {
+      $parts.Add((Get-CommonDirectorySummary -Paths $paths -Distribution $distribution)) | Out-Null
+    }
+  }
+  return $parts -join "; "
+}
+
+function Get-AssetInventory {
+  $manifest = Get-AssetManifest
+  $items = foreach ($asset in @($manifest.assets)) {
+    $origin = [string]$asset.origin
+    $category = switch ($origin) {
+      "authored" { "First-party" }
+      "third_party" { "Third-party" }
+      "generated" { "Generated" }
+      "generated_assisted" { "Generated" }
+      default { throw "Unsupported asset origin in notice generator: $origin" }
+    }
+    $sourceDate = if (-not [string]::IsNullOrWhiteSpace([string]$asset.source.acquired_on)) {
+      "acquired $($asset.source.acquired_on)"
+    } else {
+      "created $($asset.source.created_on)"
+    }
+    $source = if ([string]::IsNullOrWhiteSpace([string]$asset.source.url)) {
+      $sourceDate
+    } else {
+      "$($asset.source.url) ($sourceDate)"
+    }
+    $licenseReference = if (-not [string]::IsNullOrWhiteSpace([string]$asset.license.text_url)) {
+      [string]$asset.license.text_url
+    } else {
+      [string]$asset.license.text_path
+    }
+    $modification = if ([bool]$asset.modification.modified) {
+      [string]$asset.modification.description
+    } else {
+      "None"
+    }
+    $credit = if ([bool]$asset.license.attribution_required) {
+      "Required: $($asset.license.attribution)"
+    } elseif (-not [string]::IsNullOrWhiteSpace([string]$asset.license.attribution)) {
+      "Not required; $($asset.license.attribution)"
+    } else {
+      "Not required"
+    }
+    $files = @($asset.files)
+    $hasBundledFiles = @($files | Where-Object { [string]$_.distribution -eq "bundled-binary" }).Count -gt 0
+    if (-not [bool]$asset.license.commercial_use) {
+      throw "Asset is not approved for commercial use: $($asset.id)"
+    }
+    if (-not [bool]$asset.license.repository_redistribution) {
+      throw "Asset is not approved for repository redistribution: $($asset.id)"
+    }
+    if ($hasBundledFiles -and -not [bool]$asset.license.binary_redistribution) {
+      throw "Bundled asset is not approved for binary redistribution: $($asset.id)"
+    }
+    if ([bool]$asset.license.attribution_required -and [string]::IsNullOrWhiteSpace([string]$asset.license.attribution)) {
+      throw "Asset requires attribution text: $($asset.id)"
+    }
+    $binaryRedistribution = if ([bool]$asset.license.binary_redistribution) { "yes" } else { "no" }
+    [pscustomobject]@{
+      Id = [string]$asset.id
+      Name = [string]$asset.display_name
+      Category = $category
+      Author = [string]$asset.author
+      RightsHolder = [string]$asset.rights_holder
+      Source = $source
+      License = [string]$asset.license.id
+      LicenseReference = $licenseReference
+      Modification = $modification
+      Distribution = Get-AssetFileSummary -Files $files
+      Conditions = "commercial=yes; repository redistribution=yes; binary redistribution=$binaryRedistribution"
+      Credit = $credit
+      HasBundledFiles = $hasBundledFiles
+    }
+  }
+  return @(Sort-AssetInventory $items)
+}
+
 function Add-InventorySection {
   param(
     [System.Collections.Generic.List[string]]$Lines,
@@ -139,8 +288,33 @@ function Add-InventorySection {
   $Lines.Add("") | Out-Null
 }
 
+function Add-AssetSection {
+  param(
+    [System.Collections.Generic.List[string]]$Lines,
+    [string]$Title,
+    [object[]]$Items
+  )
+
+  $Lines.Add("### $Title") | Out-Null
+  $Lines.Add("") | Out-Null
+  if ($Items.Count -eq 0) {
+    $Lines.Add("None.") | Out-Null
+    $Lines.Add("") | Out-Null
+    return
+  }
+  $Lines.Add("| Asset | Author / rights holder | Source / date | License | Modification | Distribution | Conditions | Credit |") | Out-Null
+  $Lines.Add("| --- | --- | --- | --- | --- | --- | --- | --- |") | Out-Null
+  foreach ($item in $Items) {
+    $Lines.Add(
+      "| $(Escape-MarkdownCell $item.Name) | $(Escape-MarkdownCell "$($item.Author) / $($item.RightsHolder)") | $(Escape-MarkdownCell $item.Source) | $(Escape-MarkdownCell "$($item.License) ($($item.LicenseReference))") | $(Escape-MarkdownCell $item.Modification) | $(Escape-MarkdownCell $item.Distribution) | $(Escape-MarkdownCell $item.Conditions) | $(Escape-MarkdownCell $item.Credit) |"
+    ) | Out-Null
+  }
+  $Lines.Add("") | Out-Null
+}
+
 $rustInventory = Get-RustInventory
 $npmInventory = Get-NpmInventory
+$assetInventory = Get-AssetInventory
 $unknown = @($rustInventory + $npmInventory | Where-Object { $_.License -eq "UNKNOWN" })
 if ($unknown.Count -gt 0) {
   $names = ($unknown | ForEach-Object { "$($_.Name)@$($_.Version)" }) -join ", "
@@ -150,9 +324,9 @@ if ($unknown.Count -gt 0) {
 $lines = [System.Collections.Generic.List[string]]::new()
 $lines.Add("# Third-party notices") | Out-Null
 $lines.Add("") | Out-Null
-$lines.Add("kukuri preview builds include Rust crates, npm packages, and Tauri runtime components from third-party authors.") | Out-Null
+$lines.Add("kukuri preview builds include Rust crates, npm packages, Tauri runtime components, and non-code assets.") | Out-Null
 $lines.Add("") | Out-Null
-$lines.Add("This file is generated from the locked Rust and desktop npm dependency inventories.") | Out-Null
+$lines.Add("This file is generated from the locked Rust and desktop npm dependency inventories plus docs/ASSET_MANIFEST.json.") | Out-Null
 $lines.Add("") | Out-Null
 $lines.Add("Regenerate it from the repository root with:") | Out-Null
 $lines.Add("") | Out-Null
@@ -160,12 +334,26 @@ $lines.Add('```powershell') | Out-Null
 $lines.Add("./scripts/release/generate-third-party-notices.ps1") | Out-Null
 $lines.Add('```') | Out-Null
 $lines.Add("") | Out-Null
-$lines.Add("Release owners must review these inventories before publishing a preview build and update this generator if a dependency requires attribution text beyond the package-level license inventory.") | Out-Null
+$lines.Add("Release owners must review these inventories before publishing a preview build and update the manifest or generator if a package or asset requires additional license or attribution text.") | Out-Null
 $lines.Add("") | Out-Null
 $lines.Add("## Current distribution note") | Out-Null
 $lines.Add("") | Out-Null
 $lines.Add("The first preview targets Windows installer distribution through GitHub Releases. Linux remains source-run only for this preview scope. If Windows code signing is not configured, the release notes must state that the preview is unsigned and that SmartScreen warnings are expected.") | Out-Null
 $lines.Add("") | Out-Null
+
+$lines.Add("## Non-code asset notices") | Out-Null
+$lines.Add("") | Out-Null
+$lines.Add("The asset manifest records exact repository paths, SHA-256 digests, provenance, and source-only versus bundled-binary scope. The entries below are the distribution-facing license and credit summary.") | Out-Null
+$lines.Add("") | Out-Null
+
+$bundledFirstParty = @($assetInventory | Where-Object { $_.HasBundledFiles -and $_.Category -eq "First-party" })
+$bundledThirdParty = @($assetInventory | Where-Object { $_.HasBundledFiles -and $_.Category -eq "Third-party" })
+$bundledGenerated = @($assetInventory | Where-Object { $_.HasBundledFiles -and $_.Category -eq "Generated" })
+$sourceOnly = @($assetInventory | Where-Object { -not $_.HasBundledFiles })
+Add-AssetSection -Lines $lines -Title "Bundled first-party assets" -Items $bundledFirstParty
+Add-AssetSection -Lines $lines -Title "Bundled third-party assets" -Items $bundledThirdParty
+Add-AssetSection -Lines $lines -Title "Bundled generated or generation-assisted assets" -Items $bundledGenerated
+Add-AssetSection -Lines $lines -Title "Source-only non-code assets" -Items $sourceOnly
 
 Add-InventorySection -Lines $lines -Title "Rust crates" -Items $rustInventory
 Add-InventorySection -Lines $lines -Title "Desktop npm packages" -Items $npmInventory

--- a/scripts/release/test-generate-third-party-notices.ps1
+++ b/scripts/release/test-generate-third-party-notices.ps1
@@ -4,6 +4,7 @@ $scriptPath = Join-Path $PSScriptRoot "generate-third-party-notices.ps1"
 $workDir = Join-Path ([System.IO.Path]::GetTempPath()) ("kukuri-third-party-notices-test-" + [System.Guid]::NewGuid())
 $rustMetadataPath = Join-Path $workDir "cargo-metadata.json"
 $npmLicensesPath = Join-Path $workDir "pnpm-licenses.json"
+$assetManifestPath = Join-Path $workDir "asset-manifest.json"
 $outputPath = Join-Path $workDir "THIRD_PARTY_NOTICES.md"
 
 try {
@@ -55,20 +56,85 @@ try {
 }
 "@ | Set-Content -LiteralPath $npmLicensesPath -Encoding UTF8
 
+  @"
+{
+  "schema_version": 1,
+  "assets": [
+    {
+      "id": "app-icon",
+      "display_name": "kukuri application icon",
+      "origin": "authored",
+      "author": "KingYoSun",
+      "rights_holder": "KingYoSun",
+      "source": { "created_on": "2026-03-26" },
+      "license": {
+        "id": "MIT",
+        "text_path": "LICENSE",
+        "commercial_use": true,
+        "repository_redistribution": true,
+        "binary_redistribution": true,
+        "attribution_required": true,
+        "attribution": "Copyright (c) 2025 KingYoSun"
+      },
+      "modification": { "modified": true, "description": "Derived platform sizes." },
+      "generation": null,
+      "files": [
+        { "path": "apps/desktop/app-icon.png", "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "distribution": "source-only" },
+        { "path": "apps/desktop/src-tauri/icons/icon.ico", "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "distribution": "bundled-binary" }
+      ]
+    },
+    {
+      "id": "idle-loop",
+      "display_name": "Idle Loop VRMA",
+      "origin": "third_party",
+      "author": "Quaternius",
+      "rights_holder": "Quaternius",
+      "source": { "url": "https://quaternius.com/packs/universalanimationlibrary.html", "acquired_on": "2026-05-29" },
+      "license": {
+        "id": "CC0-1.0",
+        "text_url": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "commercial_use": true,
+        "repository_redistribution": true,
+        "binary_redistribution": true,
+        "attribution_required": false,
+        "attribution": "Universal Animation Library by Quaternius (courtesy credit)"
+      },
+      "modification": { "modified": false },
+      "generation": null,
+      "files": [
+        { "path": "apps/desktop/public/animation/Idle_Loop.vrma", "sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc", "distribution": "bundled-binary" }
+      ]
+    }
+  ]
+}
+"@ | Set-Content -LiteralPath $assetManifestPath -Encoding UTF8
+
   & $scriptPath `
     -RustMetadataPath $rustMetadataPath `
     -NpmLicensesPath $npmLicensesPath `
+    -AssetManifestPath $assetManifestPath `
     -OutputPath $outputPath
 
   & $scriptPath `
     -RustMetadataPath $rustMetadataPath `
     -NpmLicensesPath $npmLicensesPath `
+    -AssetManifestPath $assetManifestPath `
     -OutputPath $outputPath `
     -Check
 
   $content = Get-Content -LiteralPath $outputPath -Raw -Encoding UTF8
   foreach ($requiredText in @(
       "# Third-party notices",
+      "## Non-code asset notices",
+      "### Bundled first-party assets",
+      "kukuri application icon",
+      "source-only: apps/desktop/app-icon.png; bundled-binary: apps/desktop/src-tauri/icons/icon.ico",
+      "### Bundled third-party assets",
+      "Idle Loop VRMA",
+      "CC0-1.0 (https://creativecommons.org/publicdomain/zero/1.0/)",
+      "Not required; Universal Animation Library by Quaternius (courtesy credit)",
+      "### Bundled generated or generation-assisted assets",
+      "### Source-only non-code assets",
       "| anyhow | 1.0.102 | MIT OR Apache-2.0 | https://crates.io/crates/anyhow |",
       "| serde | 1.0.228 | MIT OR Apache-2.0 | https://crates.io/crates/serde |",
       "| react | 19.2.5 | MIT | https://react.dev/ |",

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -6,7 +6,10 @@ license.workspace = true
 
 [dependencies]
 anyhow.workspace = true
+hex.workspace = true
+serde.workspace = true
 serde_json.workspace = true
+sha2.workspace = true
 tokio.workspace = true
 kukuri-harness = { path = "../crates/harness" }
 

--- a/xtask/src/assets.rs
+++ b/xtask/src/assets.rs
@@ -1,0 +1,743 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs::File;
+use std::io::{BufReader, Read};
+use std::path::{Component, Path};
+
+use anyhow::{Context, Result, bail};
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+
+#[allow(unused_imports)]
+use crate::*;
+
+const ASSET_MANIFEST_SCHEMA_VERSION: u32 = 1;
+const ASSET_MANIFEST_PATH: &str = "docs/ASSET_MANIFEST.json";
+const ASSET_INVENTORY_TARGETS: &[&str] = &[
+    "apps/desktop/app-icon.png",
+    "apps/desktop/public",
+    "apps/desktop/src-tauri/icons",
+];
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct AssetManifest {
+    schema_version: u32,
+    assets: Vec<AssetRecord>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct AssetRecord {
+    id: String,
+    display_name: String,
+    origin: AssetOrigin,
+    author: String,
+    rights_holder: String,
+    source: AssetSource,
+    license: AssetLicense,
+    modification: AssetModification,
+    generation: Option<GenerationInfo>,
+    files: Vec<AssetFile>,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "snake_case")]
+enum AssetOrigin {
+    Authored,
+    ThirdParty,
+    Generated,
+    GeneratedAssisted,
+    Unknown,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct AssetSource {
+    url: Option<String>,
+    acquired_on: Option<String>,
+    created_on: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct AssetLicense {
+    id: String,
+    text_url: Option<String>,
+    text_path: Option<String>,
+    commercial_use: bool,
+    repository_redistribution: bool,
+    binary_redistribution: bool,
+    attribution_required: bool,
+    attribution: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct AssetModification {
+    modified: bool,
+    description: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct GenerationInfo {
+    service: String,
+    model: String,
+    input_rights: String,
+    output_terms_url: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct AssetFile {
+    path: String,
+    sha256: String,
+    distribution: AssetDistribution,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+enum AssetDistribution {
+    SourceOnly,
+    BundledBinary,
+}
+
+pub(crate) fn asset_check() -> Result<()> {
+    let root = root_dir();
+    let manifest_path = root.join(ASSET_MANIFEST_PATH);
+    let content = std::fs::read_to_string(&manifest_path)
+        .with_context(|| format!("failed to read {}", manifest_path.display()))?;
+    let manifest: AssetManifest = serde_json::from_str(&content)
+        .with_context(|| format!("failed to parse {}", manifest_path.display()))?;
+    let inventory = collect_asset_inventory(&root)?;
+    validate_manifest_against_inventory(&manifest, &inventory)?;
+    validate_license_text_paths(&root, &manifest)?;
+    println!(
+        "[xtask] asset manifest ok: assets={} files={}",
+        manifest.assets.len(),
+        inventory.len()
+    );
+    Ok(())
+}
+
+fn validate_manifest_against_inventory(
+    manifest: &AssetManifest,
+    inventory: &BTreeMap<String, String>,
+) -> Result<()> {
+    if manifest.schema_version != ASSET_MANIFEST_SCHEMA_VERSION {
+        bail!(
+            "unsupported asset manifest schema version: expected {}, got {}",
+            ASSET_MANIFEST_SCHEMA_VERSION,
+            manifest.schema_version
+        );
+    }
+    if manifest.assets.is_empty() {
+        bail!("asset manifest must contain at least one asset");
+    }
+
+    let mut ids = BTreeSet::new();
+    let mut registered = BTreeMap::new();
+    for asset in &manifest.assets {
+        validate_asset(asset)?;
+        if !ids.insert(asset.id.as_str()) {
+            bail!("duplicate asset id: {}", asset.id);
+        }
+        for file in &asset.files {
+            if registered
+                .insert(file.path.as_str(), file.sha256.as_str())
+                .is_some()
+            {
+                bail!("asset path is registered more than once: {}", file.path);
+            }
+        }
+    }
+
+    let registered_paths = registered.keys().copied().collect::<BTreeSet<_>>();
+    let inventory_paths = inventory
+        .keys()
+        .map(String::as_str)
+        .collect::<BTreeSet<_>>();
+    let unregistered = inventory_paths
+        .difference(&registered_paths)
+        .copied()
+        .collect::<Vec<_>>();
+    if !unregistered.is_empty() {
+        bail!(
+            "asset manifest is missing files: {}",
+            unregistered.join(", ")
+        );
+    }
+    let missing = registered_paths
+        .difference(&inventory_paths)
+        .copied()
+        .collect::<Vec<_>>();
+    if !missing.is_empty() {
+        bail!(
+            "asset manifest references missing files: {}",
+            missing.join(", ")
+        );
+    }
+    for (path, expected_hash) in registered {
+        let actual_hash = inventory
+            .get(path)
+            .with_context(|| format!("asset inventory is missing {path}"))?;
+        if actual_hash != expected_hash {
+            bail!(
+                "asset content changed without a manifest update: {path} (expected {expected_hash}, got {actual_hash})"
+            );
+        }
+    }
+    Ok(())
+}
+
+fn validate_asset(asset: &AssetRecord) -> Result<()> {
+    require_nonblank("asset id", &asset.id)?;
+    if !asset
+        .id
+        .bytes()
+        .all(|value| value.is_ascii_lowercase() || value.is_ascii_digit() || value == b'-')
+    {
+        bail!(
+            "asset id must use lowercase ASCII letters, digits, and hyphens: {}",
+            asset.id
+        );
+    }
+    require_nonblank("asset display name", &asset.display_name)?;
+    require_nonblank("asset author", &asset.author)?;
+    require_nonblank("asset rights holder", &asset.rights_holder)?;
+
+    match asset.origin {
+        AssetOrigin::Unknown => bail!("asset origin must be known: {}", asset.id),
+        AssetOrigin::Authored => {
+            validate_optional_https_url("source url", asset.source.url.as_deref())?;
+            validate_required_date("created_on", asset.source.created_on.as_deref())?;
+        }
+        AssetOrigin::ThirdParty => {
+            validate_required_https_url("source url", asset.source.url.as_deref())?;
+            validate_required_date("acquired_on", asset.source.acquired_on.as_deref())?;
+        }
+        AssetOrigin::Generated | AssetOrigin::GeneratedAssisted => {
+            validate_optional_https_url("source url", asset.source.url.as_deref())?;
+            validate_required_date("created_on", asset.source.created_on.as_deref())?;
+        }
+    }
+    if let Some(value) = asset.source.acquired_on.as_deref() {
+        validate_date("acquired_on", value)?;
+    }
+    if let Some(value) = asset.source.created_on.as_deref() {
+        validate_date("created_on", value)?;
+    }
+
+    let generated = matches!(
+        asset.origin,
+        AssetOrigin::Generated | AssetOrigin::GeneratedAssisted
+    );
+    match (generated, asset.generation.as_ref()) {
+        (true, Some(generation)) => validate_generation(generation)?,
+        (true, None) => bail!(
+            "generated asset is missing generation provenance: {}",
+            asset.id
+        ),
+        (false, Some(_)) => bail!(
+            "non-generated asset must not contain generation provenance: {}",
+            asset.id
+        ),
+        (false, None) => {}
+    }
+
+    validate_license(asset)?;
+    match (
+        asset.modification.modified,
+        nonblank(asset.modification.description.as_deref()),
+    ) {
+        (true, None) => bail!(
+            "modified asset is missing a modification description: {}",
+            asset.id
+        ),
+        (false, Some(_)) => bail!(
+            "unmodified asset must not contain a modification description: {}",
+            asset.id
+        ),
+        _ => {}
+    }
+    if asset.files.is_empty() {
+        bail!("asset must register at least one file: {}", asset.id);
+    }
+    for file in &asset.files {
+        validate_relative_path("asset file path", &file.path)?;
+        validate_sha256(&file.path, &file.sha256)?;
+    }
+    Ok(())
+}
+
+fn validate_license(asset: &AssetRecord) -> Result<()> {
+    let license = &asset.license;
+    require_nonblank("asset license id", &license.id)?;
+    let normalized_id = license.id.trim().to_ascii_uppercase();
+    if matches!(
+        normalized_id.as_str(),
+        "UNKNOWN" | "NOASSERTION" | "NONE" | "UNLICENSED"
+    ) {
+        bail!("asset has an unknown or unusable license: {}", asset.id);
+    }
+    if license.text_url.is_none() && license.text_path.is_none() {
+        bail!(
+            "asset license must provide text_url or text_path: {}",
+            asset.id
+        );
+    }
+    validate_optional_https_url("license text url", license.text_url.as_deref())?;
+    if let Some(path) = license.text_path.as_deref() {
+        validate_relative_path("license text path", path)?;
+    }
+    if !license.commercial_use {
+        bail!("asset is not approved for commercial use: {}", asset.id);
+    }
+    if !license.repository_redistribution {
+        bail!(
+            "asset is not approved for repository redistribution: {}",
+            asset.id
+        );
+    }
+    if asset
+        .files
+        .iter()
+        .any(|file| file.distribution == AssetDistribution::BundledBinary)
+        && !license.binary_redistribution
+    {
+        bail!(
+            "asset is bundled but not approved for binary redistribution: {}",
+            asset.id
+        );
+    }
+    if license.attribution_required && nonblank(license.attribution.as_deref()).is_none() {
+        bail!(
+            "asset requires attribution but attribution text is missing: {}",
+            asset.id
+        );
+    }
+    Ok(())
+}
+
+fn validate_generation(generation: &GenerationInfo) -> Result<()> {
+    require_nonblank("generation service", &generation.service)?;
+    require_nonblank("generation model", &generation.model)?;
+    require_nonblank("generation input rights", &generation.input_rights)?;
+    validate_required_https_url(
+        "generation output terms url",
+        Some(&generation.output_terms_url),
+    )
+}
+
+fn validate_license_text_paths(root: &Path, manifest: &AssetManifest) -> Result<()> {
+    for asset in &manifest.assets {
+        if let Some(path) = asset.license.text_path.as_deref() {
+            let resolved = root.join(path);
+            if !resolved.is_file() {
+                bail!(
+                    "asset license text file does not exist for {}: {}",
+                    asset.id,
+                    resolved.display()
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+fn collect_asset_inventory(root: &Path) -> Result<BTreeMap<String, String>> {
+    let mut inventory = BTreeMap::new();
+    for relative in ASSET_INVENTORY_TARGETS {
+        let path = root.join(relative);
+        collect_inventory_path(root, &path, &mut inventory)?;
+    }
+    Ok(inventory)
+}
+
+fn collect_inventory_path(
+    root: &Path,
+    path: &Path,
+    inventory: &mut BTreeMap<String, String>,
+) -> Result<()> {
+    let metadata = std::fs::symlink_metadata(path)
+        .with_context(|| format!("asset inventory target is missing: {}", path.display()))?;
+    if metadata.file_type().is_symlink() {
+        bail!(
+            "asset inventory must not contain symlinks: {}",
+            path.display()
+        );
+    }
+    if metadata.is_dir() {
+        let mut children = std::fs::read_dir(path)
+            .with_context(|| format!("failed to read asset directory {}", path.display()))?
+            .map(|entry| entry.map(|value| value.path()))
+            .collect::<std::io::Result<Vec<_>>>()?;
+        children.sort();
+        for child in children {
+            collect_inventory_path(root, &child, inventory)?;
+        }
+        return Ok(());
+    }
+    if !metadata.is_file() {
+        bail!("asset inventory entry is not a file: {}", path.display());
+    }
+    let relative = path
+        .strip_prefix(root)
+        .with_context(|| format!("asset path is outside repository: {}", path.display()))?;
+    let normalized = relative
+        .components()
+        .map(|component| component.as_os_str().to_string_lossy())
+        .collect::<Vec<_>>()
+        .join("/");
+    let hash = sha256_file(path)?;
+    if inventory.insert(normalized.clone(), hash).is_some() {
+        bail!("asset inventory contains a duplicate path: {normalized}");
+    }
+    Ok(())
+}
+
+fn sha256_file(path: &Path) -> Result<String> {
+    let file = File::open(path)
+        .with_context(|| format!("failed to open asset for hashing: {}", path.display()))?;
+    let mut reader = BufReader::new(file);
+    let mut hasher = Sha256::new();
+    let mut buffer = [0_u8; 64 * 1024];
+    loop {
+        let read = reader
+            .read(&mut buffer)
+            .with_context(|| format!("failed to hash asset: {}", path.display()))?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+    Ok(hex::encode(hasher.finalize()))
+}
+
+fn validate_relative_path(label: &str, value: &str) -> Result<()> {
+    require_nonblank(label, value)?;
+    if value.contains('\\') || value.contains(':') {
+        bail!("{label} must use a repository-relative slash path: {value}");
+    }
+    let path = Path::new(value);
+    if path.is_absolute()
+        || path.components().any(|component| {
+            !matches!(component, Component::Normal(_))
+                || matches!(component, Component::ParentDir | Component::RootDir)
+        })
+    {
+        bail!("{label} must not escape the repository: {value}");
+    }
+    Ok(())
+}
+
+fn validate_sha256(path: &str, value: &str) -> Result<()> {
+    if value.len() != 64
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        bail!("asset sha256 must be 64 lowercase hexadecimal characters: {path}");
+    }
+    Ok(())
+}
+
+fn validate_required_https_url(label: &str, value: Option<&str>) -> Result<()> {
+    let value = nonblank(value).with_context(|| format!("{label} is required"))?;
+    validate_https_url(label, value)
+}
+
+fn validate_optional_https_url(label: &str, value: Option<&str>) -> Result<()> {
+    if let Some(value) = nonblank(value) {
+        validate_https_url(label, value)?;
+    }
+    Ok(())
+}
+
+fn validate_https_url(label: &str, value: &str) -> Result<()> {
+    if !value.starts_with("https://") || value.len() <= "https://".len() {
+        bail!("{label} must be an https URL: {value}");
+    }
+    Ok(())
+}
+
+fn validate_required_date(label: &str, value: Option<&str>) -> Result<()> {
+    let value = nonblank(value).with_context(|| format!("{label} is required"))?;
+    validate_date(label, value)
+}
+
+fn validate_date(label: &str, value: &str) -> Result<()> {
+    let parts = value.split('-').collect::<Vec<_>>();
+    if parts.len() != 3 || parts[0].len() != 4 || parts[1].len() != 2 || parts[2].len() != 2 {
+        bail!("{label} must use YYYY-MM-DD: {value}");
+    }
+    let year = parts[0]
+        .parse::<u32>()
+        .with_context(|| format!("{label} has an invalid year: {value}"))?;
+    let month = parts[1]
+        .parse::<u32>()
+        .with_context(|| format!("{label} has an invalid month: {value}"))?;
+    let day = parts[2]
+        .parse::<u32>()
+        .with_context(|| format!("{label} has an invalid day: {value}"))?;
+    let days_in_month = match month {
+        1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
+        4 | 6 | 9 | 11 => 30,
+        2 if year.is_multiple_of(400) || (year.is_multiple_of(4) && !year.is_multiple_of(100)) => {
+            29
+        }
+        2 => 28,
+        _ => 0,
+    };
+    if year == 0 || day == 0 || day > days_in_month {
+        bail!("{label} is not a valid calendar date: {value}");
+    }
+    Ok(())
+}
+
+fn require_nonblank(label: &str, value: &str) -> Result<()> {
+    if value.trim().is_empty() {
+        bail!("{label} must not be blank");
+    }
+    Ok(())
+}
+
+fn nonblank(value: Option<&str>) -> Option<&str> {
+    value.map(str::trim).filter(|value| !value.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const HASH_A: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const HASH_B: &str = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+    fn authored_asset(path: &str, hash: &str) -> AssetRecord {
+        AssetRecord {
+            id: "app-icon".to_string(),
+            display_name: "kukuri application icon".to_string(),
+            origin: AssetOrigin::Authored,
+            author: "KingYoSun".to_string(),
+            rights_holder: "KingYoSun".to_string(),
+            source: AssetSource {
+                url: None,
+                acquired_on: None,
+                created_on: Some("2026-03-26".to_string()),
+            },
+            license: AssetLicense {
+                id: "MIT".to_string(),
+                text_url: None,
+                text_path: Some("LICENSE".to_string()),
+                commercial_use: true,
+                repository_redistribution: true,
+                binary_redistribution: true,
+                attribution_required: true,
+                attribution: Some("Copyright (c) KingYoSun".to_string()),
+            },
+            modification: AssetModification {
+                modified: false,
+                description: None,
+            },
+            generation: None,
+            files: vec![AssetFile {
+                path: path.to_string(),
+                sha256: hash.to_string(),
+                distribution: AssetDistribution::SourceOnly,
+            }],
+        }
+    }
+
+    fn third_party_asset(path: &str, hash: &str) -> AssetRecord {
+        AssetRecord {
+            id: "idle-loop".to_string(),
+            display_name: "Idle Loop VRMA".to_string(),
+            origin: AssetOrigin::ThirdParty,
+            author: "Quaternius".to_string(),
+            rights_holder: "Quaternius".to_string(),
+            source: AssetSource {
+                url: Some(
+                    "https://quaternius.com/packs/universalanimationlibrary.html".to_string(),
+                ),
+                acquired_on: Some("2026-05-29".to_string()),
+                created_on: None,
+            },
+            license: AssetLicense {
+                id: "CC0-1.0".to_string(),
+                text_url: Some("https://creativecommons.org/publicdomain/zero/1.0/".to_string()),
+                text_path: None,
+                commercial_use: true,
+                repository_redistribution: true,
+                binary_redistribution: true,
+                attribution_required: false,
+                attribution: Some(
+                    "Universal Animation Library by Quaternius (courtesy credit)".to_string(),
+                ),
+            },
+            modification: AssetModification {
+                modified: false,
+                description: None,
+            },
+            generation: None,
+            files: vec![AssetFile {
+                path: path.to_string(),
+                sha256: hash.to_string(),
+                distribution: AssetDistribution::BundledBinary,
+            }],
+        }
+    }
+
+    fn manifest(asset: AssetRecord) -> AssetManifest {
+        AssetManifest {
+            schema_version: ASSET_MANIFEST_SCHEMA_VERSION,
+            assets: vec![asset],
+        }
+    }
+
+    fn inventory(entries: &[(&str, &str)]) -> BTreeMap<String, String> {
+        entries
+            .iter()
+            .map(|(path, hash)| ((*path).to_string(), (*hash).to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn valid_authored_asset_matches_inventory() {
+        let manifest = manifest(authored_asset("apps/desktop/app-icon.png", HASH_A));
+        let inventory = inventory(&[("apps/desktop/app-icon.png", HASH_A)]);
+
+        assert!(validate_manifest_against_inventory(&manifest, &inventory).is_ok());
+    }
+
+    #[test]
+    fn source_only_asset_does_not_require_binary_redistribution() {
+        let mut asset = authored_asset("apps/desktop/app-icon.png", HASH_A);
+        asset.license.binary_redistribution = false;
+        let manifest = manifest(asset);
+        let inventory = inventory(&[("apps/desktop/app-icon.png", HASH_A)]);
+
+        assert!(validate_manifest_against_inventory(&manifest, &inventory).is_ok());
+    }
+
+    #[test]
+    fn valid_third_party_asset_matches_inventory() {
+        let path = "apps/desktop/public/animation/Idle_Loop.vrma";
+        let manifest = manifest(third_party_asset(path, HASH_A));
+        let inventory = inventory(&[(path, HASH_A)]);
+
+        assert!(validate_manifest_against_inventory(&manifest, &inventory).is_ok());
+    }
+
+    #[test]
+    fn inventory_drift_is_rejected() {
+        let manifest = manifest(authored_asset("apps/desktop/app-icon.png", HASH_A));
+        let added = inventory(&[
+            ("apps/desktop/app-icon.png", HASH_A),
+            ("apps/desktop/public/new.png", HASH_B),
+        ]);
+        let missing = BTreeMap::new();
+        let changed = inventory(&[("apps/desktop/app-icon.png", HASH_B)]);
+
+        assert!(validate_manifest_against_inventory(&manifest, &added).is_err());
+        assert!(validate_manifest_against_inventory(&manifest, &missing).is_err());
+        assert!(validate_manifest_against_inventory(&manifest, &changed).is_err());
+    }
+
+    #[test]
+    fn unknown_or_non_redistributable_license_is_rejected() {
+        let mut unknown = authored_asset("apps/desktop/app-icon.png", HASH_A);
+        unknown.license.id = "UNKNOWN".to_string();
+        let mut denied = authored_asset("apps/desktop/app-icon.png", HASH_A);
+        denied.license.repository_redistribution = false;
+        let inventory = inventory(&[("apps/desktop/app-icon.png", HASH_A)]);
+
+        assert!(validate_manifest_against_inventory(&manifest(unknown), &inventory).is_err());
+        assert!(validate_manifest_against_inventory(&manifest(denied), &inventory).is_err());
+    }
+
+    #[test]
+    fn bundled_asset_requires_binary_redistribution_and_required_credit() {
+        let path = "apps/desktop/public/animation/Idle_Loop.vrma";
+        let inventory = inventory(&[(path, HASH_A)]);
+        let mut denied = third_party_asset(path, HASH_A);
+        denied.license.binary_redistribution = false;
+        let mut missing_credit = third_party_asset(path, HASH_A);
+        missing_credit.license.attribution_required = true;
+        missing_credit.license.attribution = None;
+
+        assert!(validate_manifest_against_inventory(&manifest(denied), &inventory).is_err());
+        assert!(
+            validate_manifest_against_inventory(&manifest(missing_credit), &inventory).is_err()
+        );
+    }
+
+    #[test]
+    fn generated_assets_require_generation_provenance() {
+        let mut generated = authored_asset("apps/desktop/app-icon.png", HASH_A);
+        generated.origin = AssetOrigin::Generated;
+        generated.source.created_on = None;
+        let inventory = inventory(&[("apps/desktop/app-icon.png", HASH_A)]);
+
+        assert!(validate_manifest_against_inventory(&manifest(generated), &inventory).is_err());
+    }
+
+    #[test]
+    fn generated_assets_accept_complete_generation_provenance() {
+        let mut generated = authored_asset("apps/desktop/app-icon.png", HASH_A);
+        generated.origin = AssetOrigin::GeneratedAssisted;
+        generated.generation = Some(GenerationInfo {
+            service: "Example service".to_string(),
+            model: "Example model".to_string(),
+            input_rights: "All inputs are owned by KingYoSun".to_string(),
+            output_terms_url: "https://example.com/output-terms".to_string(),
+        });
+        let inventory = inventory(&[("apps/desktop/app-icon.png", HASH_A)]);
+
+        assert!(validate_manifest_against_inventory(&manifest(generated), &inventory).is_ok());
+    }
+
+    #[test]
+    fn unknown_origin_bad_schema_and_unsafe_path_are_rejected() {
+        let inventory = inventory(&[("apps/desktop/app-icon.png", HASH_A)]);
+        let mut unknown = authored_asset("apps/desktop/app-icon.png", HASH_A);
+        unknown.origin = AssetOrigin::Unknown;
+        let mut bad_schema = manifest(authored_asset("apps/desktop/app-icon.png", HASH_A));
+        bad_schema.schema_version += 1;
+        let unsafe_path = manifest(authored_asset("../app-icon.png", HASH_A));
+
+        assert!(validate_manifest_against_inventory(&manifest(unknown), &inventory).is_err());
+        assert!(validate_manifest_against_inventory(&bad_schema, &inventory).is_err());
+        assert!(validate_manifest_against_inventory(&unsafe_path, &inventory).is_err());
+    }
+
+    #[test]
+    fn duplicate_ids_and_paths_are_rejected() {
+        let first = authored_asset("apps/desktop/app-icon.png", HASH_A);
+        let mut duplicate_id = third_party_asset("apps/desktop/public/asset.vrma", HASH_B);
+        duplicate_id.id = first.id.clone();
+        let duplicate_id_manifest = AssetManifest {
+            schema_version: ASSET_MANIFEST_SCHEMA_VERSION,
+            assets: vec![first, duplicate_id],
+        };
+        let full_inventory = inventory(&[
+            ("apps/desktop/app-icon.png", HASH_A),
+            ("apps/desktop/public/asset.vrma", HASH_B),
+        ]);
+        assert!(
+            validate_manifest_against_inventory(&duplicate_id_manifest, &full_inventory).is_err()
+        );
+
+        let first = authored_asset("apps/desktop/app-icon.png", HASH_A);
+        let mut duplicate_path = third_party_asset("apps/desktop/app-icon.png", HASH_A);
+        duplicate_path.id = "other-asset".to_string();
+        let duplicate_path_manifest = AssetManifest {
+            schema_version: ASSET_MANIFEST_SCHEMA_VERSION,
+            assets: vec![first, duplicate_path],
+        };
+        let single_inventory = inventory(&[("apps/desktop/app-icon.png", HASH_A)]);
+        assert!(
+            validate_manifest_against_inventory(&duplicate_path_manifest, &single_inventory)
+                .is_err()
+        );
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, Result, bail};
 
+mod assets;
 mod cn;
 mod desktop;
 mod exec;
@@ -10,6 +11,7 @@ mod release;
 mod rust;
 mod scenario;
 
+pub(crate) use assets::*;
 pub(crate) use cn::*;
 pub(crate) use desktop::*;
 pub(crate) use exec::*;
@@ -45,6 +47,7 @@ fn main() -> Result<()> {
         "cn-test" => cn_test(),
         "cn-e2e" => cn_e2e(),
         "desktop-package" => desktop_package(),
+        "asset-check" => asset_check(),
         "release-check" => {
             let tag = args.next();
             release_check(tag.as_deref())
@@ -108,6 +111,6 @@ fn doctor() -> Result<()> {
 
 fn print_usage() {
     eprintln!(
-        "usage: cargo xtask <doctor|check|test|rust-check|rust-test|app-api-slow-test|tauri-check|desktop-lint|desktop-test|desktop-storybook|desktop-browser-test|desktop-visual-test|desktop-ui-check|cn-check|cn-test|cn-e2e|desktop-package|release-check [tag]|oversized-files [--update-baseline]|ipc-types [--check]|e2e-smoke|scenario <name>>"
+        "usage: cargo xtask <doctor|check|test|rust-check|rust-test|app-api-slow-test|tauri-check|desktop-lint|desktop-test|desktop-storybook|desktop-browser-test|desktop-visual-test|desktop-ui-check|cn-check|cn-test|cn-e2e|desktop-package|asset-check|release-check [tag]|oversized-files [--update-baseline]|ipc-types [--check]|e2e-smoke|scenario <name>>"
     );
 }

--- a/xtask/src/release.rs
+++ b/xtask/src/release.rs
@@ -8,6 +8,7 @@ use crate::*;
 
 pub(crate) fn release_check(tag: Option<&str>) -> Result<()> {
     let root = root_dir();
+    asset_check()?;
     let workspace_version = read_workspace_version(&root.join("Cargo.toml"))?;
     let tauri_version = read_package_version(&desktop_dir().join("src-tauri").join("Cargo.toml"))?;
     let desktop_package_version = read_json_version(&desktop_dir().join("package.json"))


### PR DESCRIPTION
## 概要

- 配布対象の非コード素材を、由来・権利者・ライセンス・改変・配布範囲・SHA-256とともに `docs/ASSET_MANIFEST.json` へ登録
- 自作アイコンと `blumochichi.vrm` を KingYoSun / MIT、Universal Animation Library由来のVRMA 10件を Quaternius / CC0-1.0として明示
- 未登録、削除、内容変更、重複、権利条件不足を拒否する `cargo xtask asset-check` を追加し、release checkと通常CIへ接続
- 素材台帳から自作・第三者・生成素材・ソースのみを区別して `THIRD_PARTY_NOTICES.md` へ生成
- release runbookへ素材追加・更新・削除時の確認手順を追加
- CIで顕在化したmobile Columnのprogrammatic scroll競合を抑止し、ページ直接移動を安定化

## 検証

- `cargo fmt --all -- --check`
- `cargo clippy -p xtask --all-targets -- -D warnings`
- `cargo test -p xtask`
- `cargo xtask asset-check`
- `cargo xtask release-check v0.1.5-preview.1`
- `./scripts/release/test-generate-third-party-notices.ps1`
- `./scripts/release/generate-third-party-notices.ps1 -Check`
- Windows PowerShell 5.1でnotice生成試験
- `cargo xtask check`
- `cargo xtask test`（Rust 602件、直列ハーネス18件、デスクトップ864件）
- `cargo xtask desktop-browser-test`（35件）
- mobile Column 3 viewport × 5反復（15件）
- `cargo xtask oversized-files`
- `git diff --check`

Closes #764