### PR TITLE
fix: pin release XML assets to LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,4 @@
 # Ensure bash scripts stay executable on Linux
 *.sh text eol=lf
 *.sql text eol=lf
+*.xml text eol=lf

--- a/xtask/src/assets.rs
+++ b/xtask/src/assets.rs
@@ -509,6 +509,7 @@ fn nonblank(value: Option<&str>) -> Option<&str> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::process::Command;
 
     const HASH_A: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
     const HASH_B: &str = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
@@ -599,6 +600,30 @@ mod tests {
             .iter()
             .map(|(path, hash)| ((*path).to_string(), (*hash).to_string()))
             .collect()
+    }
+
+    #[test]
+    fn manifest_xml_assets_pin_lf_checkout() {
+        let paths = [
+            "apps/desktop/src-tauri/icons/android/mipmap-anydpi-v26/ic_launcher.xml",
+            "apps/desktop/src-tauri/icons/android/values/ic_launcher_background.xml",
+        ];
+        let output = Command::new("git")
+            .current_dir(crate::exec::root_dir())
+            .args(["check-attr", "eol", "--"])
+            .args(paths)
+            .output()
+            .expect("git check-attr must run for release asset validation");
+        assert!(output.status.success());
+        let stdout = String::from_utf8(output.stdout).expect("git check-attr output must be UTF-8");
+        for path in paths {
+            assert!(
+                stdout
+                    .lines()
+                    .any(|line| line == format!("{path}: eol: lf")),
+                "release manifest XML asset must pin LF checkout: {path}; attributes: {stdout}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Windows の release-check で Android icon XML が CRLF checkout され、ASSET_MANIFEST の SHA-256 と不一致になる問題を修正します。XML を LF checkout に固定し、manifest 対象 XML の Git attribute を検証する regression test を追加しました。 Validation: cargo test -p xtask; cargo xtask release-check v0.1.6-preview.1; scripts/release/test-create-preview-assets.ps1; cargo fmt --all -- --check