### PR TITLE
feat: add Dome recovery and Return Home

### DIFF
--- a/apps/desktop/src/components/extended/MetaverseRoomPanel.stories.tsx
+++ b/apps/desktop/src/components/extended/MetaverseRoomPanel.stories.tsx
@@ -10,6 +10,7 @@ import { MetaverseRoomView } from './metaverse/MetaverseRoomView';
 import { createDefaultMetaverseRoomState } from './metaverse/DomeSceneModel';
 import type { DomeNeighborTransitionView } from './metaverse/DomeTransitionModel';
 import { createMetaverseRoomActions } from '@/shell/actions/metaverse';
+import { ONLINE_DOME_RECOVERY, type DomeRecoveryStatus } from './metaverse/useMetaverseRoomSession';
 
 const meta = {
   title: 'Extended/MetaverseRoomPanel',
@@ -131,7 +132,8 @@ function panel(rooms: GameRoomView[]) {
 function selectedRoom(
   initialHudOpen = true,
   initialChatOpen = true,
-  transitionNeighbors: DomeNeighborTransitionView[] = []
+  transitionNeighbors: DomeNeighborTransitionView[] = [],
+  domeRecovery: DomeRecoveryStatus = ONLINE_DOME_RECOVERY
 ) {
   return (
     <StoryFrame>
@@ -150,6 +152,7 @@ function selectedRoom(
         )}
         latestChatByPeer={{}}
         connectionState='live'
+        domeRecovery={domeRecovery}
         now={STORY_TIMESTAMP}
         knownPeerCount={2}
         lastSentSeq={12}
@@ -178,6 +181,7 @@ function selectedRoom(
         onLocalTransform={() => undefined}
         onAvatarAssetStatus={() => undefined}
         onLeaveRoom={() => undefined}
+        onReturnHome={() => undefined}
         onImportAvatar={() => undefined}
         onImportDefaultAvatar={() => undefined}
         onSaveCustomization={async () => undefined}
@@ -262,4 +266,24 @@ export const SelectedCollapsed: Story = {
 
 export const ReadyNorthTransition: Story = {
   render: () => selectedRoom(false, false, [readyNorthNeighbor]),
+};
+
+export const OfflineGraceBoundary: Story = {
+  render: () => selectedRoom(false, false, [{ ...readyNorthNeighbor, boundaryState: 'offline' }], {
+    state: 'offline', secondsRemaining: 9, reason: 'host_offline', targetTitle: null,
+  }),
+};
+
+export const DrainingBoundary: Story = {
+  render: () => selectedRoom(false, false, [{ ...readyNorthNeighbor, boundaryState: 'draining' }]),
+};
+
+export const BlockedBoundary: Story = {
+  render: () => selectedRoom(false, false, [{ ...readyNorthNeighbor, boundaryState: 'blocked' }]),
+};
+
+export const ClosedBoundary: Story = {
+  render: () => selectedRoom(false, false, [{ ...readyNorthNeighbor, boundaryState: 'closed' }], {
+    state: 'closed', secondsRemaining: 0, reason: 'host_offline', targetTitle: null,
+  }),
 };

--- a/apps/desktop/src/components/extended/MetaverseRoomPanel.tsx
+++ b/apps/desktop/src/components/extended/MetaverseRoomPanel.tsx
@@ -260,6 +260,7 @@ export function MetaverseRoomPanel({
         handoffTransform={session.handoffTransform}
         latestChatByPeer={session.latestChatByPeer}
         connectionState={session.roomConnectionState}
+        domeRecovery={session.domeRecovery}
         now={session.clockNow}
         knownPeerCount={session.knownPeerCount}
         lastSentSeq={session.lastSentSeq}
@@ -276,6 +277,7 @@ export function MetaverseRoomPanel({
         onLocalTransform={session.handleLocalTransform}
         onAvatarAssetStatus={setAvatarAssetStatus}
         onLeaveRoom={session.leaveRoom}
+        onReturnHome={session.returnHome}
         onImportAvatar={(file) => void importAvatarBlob(file, file.name)}
         onImportDefaultAvatar={() => void handleSampleAvatarImport()}
         onSaveCustomization={saveCustomization}

--- a/apps/desktop/src/components/extended/metaverse/DomeTransitionModel.test.ts
+++ b/apps/desktop/src/components/extended/metaverse/DomeTransitionModel.test.ts
@@ -74,6 +74,7 @@ function topology(): DomeConnectionTopologyView {
         lifecycle_generation: 1,
         lifecycle_actor: null,
         lifecycle_reason: null,
+        lifecycle_deadline_at: null,
       },
     }],
     resolution: {
@@ -122,6 +123,38 @@ describe('DomeTransitionModel', () => {
     expect(resolveActiveDomeNeighbors(topology(), current, [current, target], {}, {
       'dome-b': 'ready',
     })[0].boundaryState).toBe('loading');
+  });
+
+  it('distinguishes offline, draining, blocked, and closed boundaries', () => {
+    const current = room('dome-a');
+    const target = room('dome-b');
+    const offline = hosting('dome-b');
+    offline.state.kind = 'grace_period';
+    expect(resolveActiveDomeNeighbors(topology(), current, [current, target], {
+      'dome-b': offline,
+    })[0].boundaryState).toBe('offline');
+
+    const draining = topology();
+    draining.connections[0].record.status = 'draining';
+    draining.connections[0].record.lifecycle_actor = 'a'.repeat(64);
+    draining.connections[0].record.lifecycle_reason = 'owner_revoked';
+    draining.connections[0].record.lifecycle_deadline_at = 4_000;
+    expect(resolveActiveDomeNeighbors(draining, current, [current, target], {
+      'dome-b': hosting('dome-b'),
+    })[0].boundaryState).toBe('draining');
+
+    const blocked = topology();
+    blocked.connections[0].record.status = 'revoked';
+    blocked.connections[0].record.lifecycle_actor = 'a'.repeat(64);
+    blocked.connections[0].record.lifecycle_reason = 'owners_blocked';
+    blocked.resolution.topology.active_connection_ids = [];
+    blocked.resolution.topology.components = [];
+    expect(resolveActiveDomeNeighbors(blocked, current, [current, target], {})[0].boundaryState)
+      .toBe('blocked');
+
+    blocked.connections[0].record.lifecycle_reason = 'owner_revoked';
+    expect(resolveActiveDomeNeighbors(blocked, current, [current, target], {})[0].boundaryState)
+      .toBe('closed');
   });
 
   it('loading boundary stops before center while ready boundary reaches the far end', () => {

--- a/apps/desktop/src/components/extended/metaverse/DomeTransitionModel.ts
+++ b/apps/desktop/src/components/extended/metaverse/DomeTransitionModel.ts
@@ -13,6 +13,7 @@ import {
   DOME_CONNECTION_ZONE_DEPTH_CM,
   DOME_DIRECTIONS,
   DOME_INNER_RADIUS_CM,
+  domeDirectionOffset,
   openingContains,
 } from './DomeSceneModel';
 
@@ -43,7 +44,9 @@ function hostingBoundaryState(
   hosting: DomeHostingView | undefined
 ): DomeBoundaryStateV1 {
   if (!hosting) return 'loading';
-  if (hosting.state.kind === 'grace_period' || hosting.state.kind === 'transferring') return 'stale';
+  if (hosting.state.kind === 'grace_period') return 'offline';
+  if (hosting.state.kind === 'transferring') return 'loading';
+  if (hosting.state.kind === 'closed') return 'closed';
   if (
     (hosting.state.kind !== 'owner_hosted' && hosting.state.kind !== 'community_node_hosted') ||
     !hosting.state.session_id
@@ -66,8 +69,7 @@ export function resolveActiveDomeNeighbors(
   const component = topology.resolution.topology.components.find((candidate) =>
     candidate.instance_ids.includes(currentId)
   );
-  const currentCoordinate = component?.coordinates_cm[currentId];
-  if (!component || !currentCoordinate) return [];
+  const currentCoordinate = component?.coordinates_cm[currentId] ?? [0, 0, 0];
   const activeIds = new Set(topology.resolution.topology.active_connection_ids);
   const byInstance = new Map(
     rooms
@@ -76,7 +78,11 @@ export function resolveActiveDomeNeighbors(
   );
 
   return topology.connections
-    .filter(({ record }) => record.status === 'active' && activeIds.has(record.agreement.connection_id))
+    .filter(({ record }) =>
+      record.status === 'active'
+        ? activeIds.has(record.agreement.connection_id)
+        : record.status === 'draining' || record.status === 'revoked'
+    )
     .flatMap(({ record }) => {
       const { proposer, receiver, connection_id: connectionId } = record.agreement;
       const source = proposer.instance_id === currentId
@@ -87,9 +93,13 @@ export function resolveActiveDomeNeighbors(
       if (!source) return [];
       const target = source === proposer ? receiver : proposer;
       const room = byInstance.get(target.instance_id);
-      const coordinate = component.coordinates_cm[target.instance_id];
-      if (!room || !coordinate) return [];
-      let boundaryState = hostingBoundaryState(room, hostingByInstance[target.instance_id]);
+      const coordinate = component?.coordinates_cm[target.instance_id];
+      if (!room) return [];
+      let boundaryState: DomeBoundaryStateV1 = record.status === 'draining'
+        ? 'draining'
+        : record.status === 'revoked'
+          ? record.lifecycle_reason === 'owners_blocked' ? 'blocked' : 'closed'
+          : hostingBoundaryState(room, hostingByInstance[target.instance_id]);
       const assetState = assetStateByInstance[target.instance_id];
       if (boundaryState === 'ready' && assetState === 'loading') boundaryState = 'loading';
       if (boundaryState === 'ready' && assetState === 'error') boundaryState = 'error';
@@ -99,11 +109,11 @@ export function resolveActiveDomeNeighbors(
         direction: source.direction,
         targetDirection: target.direction,
         room,
-        relativeCoordinateCm: [
+        relativeCoordinateCm: coordinate ? [
           coordinate[0] - currentCoordinate[0],
           coordinate[1] - currentCoordinate[1],
           coordinate[2] - currentCoordinate[2],
-        ],
+        ] : domeDirectionOffset(source.direction),
         boundaryState,
         textureUrls: textureUrlsByInstance[target.instance_id] ?? { wall: null, floor: null },
       } satisfies DomeNeighborTransitionView];

--- a/apps/desktop/src/components/extended/metaverse/FixedDome.tsx
+++ b/apps/desktop/src/components/extended/metaverse/FixedDome.tsx
@@ -70,6 +70,9 @@ function directionTransform(direction: DomeDirection): {
 }
 
 function boundaryColor(state: DomeBoundaryStateV1): number {
+  if (state === 'offline') return 0xd69e2e;
+  if (state === 'draining') return 0xcf6f2e;
+  if (state === 'blocked') return 0xb42335;
   if (state === 'loading') return 0xd69e2e;
   if (state === 'full') return 0xc47f17;
   if (state === 'denied') return 0xb43b47;
@@ -135,18 +138,24 @@ function ConnectionZone({
         </mesh>
       </group>
       {boundaryState !== 'ready' ? (
-        <mesh
-          position={[0, (wallHeight + roofRadius) / 2, -0.02]}
-          userData={{ domeBoundaryState: boundaryState, avatarBarrier: true }}
-        >
-          <planeGeometry args={[width, wallHeight + roofRadius]} />
-          <meshStandardMaterial
-            color={boundaryColor(boundaryState)}
-            opacity={0.78}
-            transparent
-            side={THREE.DoubleSide}
-          />
-        </mesh>
+        <group userData={{ domeBoundaryState: boundaryState, avatarBarrier: true }}>
+          <mesh position={[0, (wallHeight + roofRadius) / 2, -0.02]}>
+            <planeGeometry args={[width, wallHeight + roofRadius]} />
+            <meshStandardMaterial
+              color={boundaryColor(boundaryState)}
+              opacity={boundaryState === 'offline' ? 0.48 : 0.78}
+              transparent
+              wireframe={boundaryState === 'offline'}
+              side={THREE.DoubleSide}
+            />
+          </mesh>
+          {(boundaryState === 'draining' || boundaryState === 'blocked') ? [0.25, 0.5, 0.75].map((ratio) => (
+            <mesh key={ratio} position={[0, (wallHeight + roofRadius) * ratio, -0.04]}>
+              <boxGeometry args={[width, 0.1, 0.08]} />
+              <meshBasicMaterial color={boundaryColor(boundaryState)} />
+            </mesh>
+          )) : null}
+        </group>
       ) : null}
     </group>
   );

--- a/apps/desktop/src/components/extended/metaverse/MetaverseRoomControls.test.tsx
+++ b/apps/desktop/src/components/extended/metaverse/MetaverseRoomControls.test.tsx
@@ -98,6 +98,25 @@ describe('MetaverseRoomControls', () => {
     );
   });
 
+  test('announces offline grace and exposes keyboard reachable Return Home', async () => {
+    const user = userEvent.setup();
+    const onReturnHome = vi.fn();
+    renderControls({
+      domeRecovery: {
+        state: 'offline',
+        secondsRemaining: 9,
+        reason: 'host_offline',
+        targetTitle: null,
+      },
+      onReturnHome,
+    });
+
+    expect(screen.getByRole('status')).toHaveTextContent('Host offline');
+    expect(screen.getByRole('status')).toHaveTextContent('9 seconds');
+    await user.click(screen.getByRole('button', { name: 'Return Home' }));
+    expect(onReturnHome).toHaveBeenCalledOnce();
+  });
+
   test('routes toolbar, avatar, and shared-object controls through callbacks', async () => {
     const user = userEvent.setup();
     const onLeaveRoom = vi.fn();

--- a/apps/desktop/src/components/extended/metaverse/MetaverseRoomControls.tsx
+++ b/apps/desktop/src/components/extended/metaverse/MetaverseRoomControls.tsx
@@ -2,6 +2,7 @@ import type { FormEventHandler, RefObject } from 'react';
 import {
   Box,
   ChevronDown,
+  House,
   LogOut,
   MessageSquare,
   MonitorPause,
@@ -32,6 +33,7 @@ import type {
   RoomChatMessage,
 } from '../MetaverseSceneModel';
 import { DomeCustomizationControls } from './DomeCustomizationControls';
+import { ONLINE_DOME_RECOVERY, type DomeRecoveryStatus } from './useMetaverseRoomSession';
 
 type MetaverseRoomControlsProps = {
   room: GameRoomView;
@@ -45,6 +47,7 @@ type MetaverseRoomControlsProps = {
   localAvatarAssetRef: MetaverseAssetRef | null;
   communityAssistAvailable: boolean;
   connectionState: MetaverseRoomConnectionState;
+  domeRecovery?: DomeRecoveryStatus;
   locale: SupportedLocale;
   pending: boolean;
   isOwner: boolean;
@@ -55,6 +58,7 @@ type MetaverseRoomControlsProps = {
   messageDraft: string;
   messageInputRef: RefObject<HTMLInputElement | null>;
   onLeaveRoom: () => void;
+  onReturnHome?: () => void;
   onToggleHud: () => void;
   onToggleHudDebug: () => void;
   onImportAvatar: (file: File) => void;
@@ -96,6 +100,7 @@ export function MetaverseRoomControls({
   localAvatarAssetRef,
   communityAssistAvailable,
   connectionState,
+  domeRecovery = ONLINE_DOME_RECOVERY,
   locale,
   pending,
   isOwner,
@@ -106,6 +111,7 @@ export function MetaverseRoomControls({
   messageDraft,
   messageInputRef,
   onLeaveRoom,
+  onReturnHome,
   onToggleHud,
   onToggleHudDebug,
   onImportAvatar,
@@ -133,6 +139,18 @@ export function MetaverseRoomControls({
         <ConnectionStateIcon state={connectionState} />
         <span>{t(`connection.states.${connectionState}`)}</span>
       </div>
+      {domeRecovery.state !== 'online' ? (
+        <div className='metaverse-recovery-banner' data-state={domeRecovery.state} role='status' aria-live='polite'>
+          <strong>{t(`recovery.states.${domeRecovery.state}`)}</strong>
+          <span>
+            {domeRecovery.state === 'offline'
+              ? t('recovery.offlineCountdown', { count: domeRecovery.secondsRemaining ?? 0 })
+              : domeRecovery.targetTitle
+                ? t('recovery.movingTo', { target: domeRecovery.targetTitle })
+                : t(`recovery.details.${domeRecovery.state}`)}
+          </span>
+        </div>
+      ) : null}
       <div className='metaverse-hud-toolbar' data-open={hudOpen}>
         <Button
           variant='ghost'
@@ -144,6 +162,18 @@ export function MetaverseRoomControls({
         >
           <LogOut className='size-4' aria-hidden='true' />
         </Button>
+        {onReturnHome ? <Button
+          variant='ghost'
+          size='icon'
+          className='metaverse-hud-icon-button'
+          type='button'
+          aria-label={t('recovery.returnHome')}
+          title={t('recovery.returnHomeDescription')}
+          disabled={domeRecovery.state === 'evacuating'}
+          onClick={onReturnHome}
+        >
+          <House className='size-4' aria-hidden='true' />
+        </Button> : null}
         {onToggleMicrophone ? (
           <Button
             variant={microphoneEnabled ? 'primary' : 'ghost'}

--- a/apps/desktop/src/components/extended/metaverse/MetaverseRoomView.tsx
+++ b/apps/desktop/src/components/extended/metaverse/MetaverseRoomView.tsx
@@ -27,6 +27,7 @@ import type {
   RoomChatMessage,
 } from '../MetaverseSceneModel';
 import { MetaverseRoomControls } from './MetaverseRoomControls';
+import { ONLINE_DOME_RECOVERY, type DomeRecoveryStatus } from './useMetaverseRoomSession';
 import { useColumnRuntime } from '@/shell/ColumnRuntimeContext';
 import type { DomeNeighborTransitionView } from './DomeTransitionModel';
 
@@ -45,6 +46,7 @@ export type MetaverseRoomViewProps = {
   handoffTransform?: AvatarTransform | null;
   latestChatByPeer: Record<string, LatestChatBubble>;
   connectionState: MetaverseRoomConnectionState;
+  domeRecovery?: DomeRecoveryStatus;
   now: number;
   knownPeerCount: number;
   lastSentSeq: number;
@@ -64,6 +66,7 @@ export type MetaverseRoomViewProps = {
   onLocalTransform: (transform: AvatarTransform) => void;
   onAvatarAssetStatus: (status: AvatarAssetStatus) => void;
   onLeaveRoom: () => void;
+  onReturnHome?: () => void;
   onImportAvatar: (file: File) => void;
   onImportDefaultAvatar: () => void;
   onSaveCustomization: (customization: DomeCustomizationV1) => Promise<void>;
@@ -99,6 +102,7 @@ export function MetaverseRoomView({
   handoffTransform,
   latestChatByPeer,
   connectionState,
+  domeRecovery = ONLINE_DOME_RECOVERY,
   now,
   knownPeerCount,
   lastSentSeq,
@@ -118,6 +122,7 @@ export function MetaverseRoomView({
   onLocalTransform,
   onAvatarAssetStatus,
   onLeaveRoom,
+  onReturnHome,
   onImportAvatar,
   onImportDefaultAvatar,
   onSaveCustomization,
@@ -220,6 +225,7 @@ export function MetaverseRoomView({
               localAvatarAssetRef={localAvatarAssetRef}
               communityAssistAvailable={communityAssistAvailable}
               connectionState={connectionState}
+              domeRecovery={domeRecovery}
               locale={locale}
               pending={pending}
               isOwner={isOwner}
@@ -230,6 +236,7 @@ export function MetaverseRoomView({
               messageDraft={messageDraft}
               messageInputRef={messageInputRef}
               onLeaveRoom={onLeaveRoom}
+              onReturnHome={onReturnHome}
               onToggleHud={() => setHudOpen((open) => !open)}
               onToggleHudDebug={() => setHudDebugOpen((open) => !open)}
               onImportAvatar={onImportAvatar}

--- a/apps/desktop/src/components/extended/metaverse/useMetaverseRoomSession.test.tsx
+++ b/apps/desktop/src/components/extended/metaverse/useMetaverseRoomSession.test.tsx
@@ -194,6 +194,40 @@ describe('useMetaverseRoomSession', () => {
     await waitFor(() => expect(session.result.current.admittedRoom?.room_id).toBe(room.room_id));
   });
 
+  test('Return Home keeps the source scene until the destination avatar is confirmed', async () => {
+    const target = {
+      ...room,
+      room_id: 'metaverse-room-2',
+      title: 'Safe Home',
+      metaverse: createDefaultMetaverseRoomState(8, { roomId: 'metaverse-room-2' }),
+    };
+    let resolveTarget!: (snapshot: DomePhysicsSnapshotV1) => void;
+    const submitDomeSessionInput = vi.fn((
+      _context: SpatialContextV1,
+      instanceId: string,
+      sequence: number
+    ) => {
+      if (instanceId === target.metaverse!.instance_id) {
+        return new Promise<DomePhysicsSnapshotV1>((resolve) => { resolveTarget = resolve; });
+      }
+      return Promise.resolve(physicsSnapshot(sequence, 0));
+    });
+    const api: DesktopApi = { ...createDesktopMockApi(), submitDomeSessionInput };
+    const session = renderSession({ api, rooms: [room, target], initialSelectedRoomId: room.room_id });
+    await waitFor(() => expect(session.result.current.admittedRoom?.room_id).toBe(room.room_id));
+
+    act(() => session.result.current.returnHome());
+    await waitFor(() => expect(session.result.current.domeRecovery.state).toBe('evacuating'));
+    expect(session.result.current.admittedRoom?.room_id).toBe(room.room_id);
+
+    await act(async () => resolveTarget({
+      ...physicsSnapshot(20, 0),
+      instance_id: target.metaverse!.instance_id,
+    }));
+    await waitFor(() => expect(session.result.current.admittedRoom?.room_id).toBe(target.room_id));
+    expect(session.result.current.domeRecovery.state).toBe('online');
+  });
+
   test('clears a missing selected room but preserves a pending created-room selection', async () => {
     const session = renderSession();
     await act(async () => {
@@ -405,6 +439,7 @@ describe('useMetaverseRoomSession', () => {
             lifecycle_generation: 1,
             lifecycle_actor: null,
             lifecycle_reason: null,
+            lifecycle_deadline_at: null,
           },
         }],
         resolution: {

--- a/apps/desktop/src/components/extended/metaverse/useMetaverseRoomSession.ts
+++ b/apps/desktop/src/components/extended/metaverse/useMetaverseRoomSession.ts
@@ -83,6 +83,20 @@ type TransitionAttempt = {
   cancelled: boolean;
 };
 
+export type DomeRecoveryStatus = {
+  state: 'online' | 'offline' | 'evacuating' | 'closed' | 'no_candidate';
+  secondsRemaining: number | null;
+  reason: 'host_offline' | 'access_revoked' | 'blocked' | 'user_requested' | null;
+  targetTitle: string | null;
+};
+
+export const ONLINE_DOME_RECOVERY: DomeRecoveryStatus = {
+  state: 'online',
+  secondsRemaining: null,
+  reason: null,
+  targetTitle: null,
+};
+
 const EMPTY_MUTED_AUTHOR_PUBKEYS = new Set<string>();
 
 const EMPTY_ROOM_CHAT_HISTORY: NonNullable<
@@ -120,6 +134,10 @@ export function useMetaverseRoomSession({
   const [lastSentSeq, setLastSentSeq] = useState(0);
   const [recoveringUntil, setRecoveringUntil] = useState(0);
   const [clockNow, setClockNow] = useState(() => Date.now());
+  const [domeRecovery, setDomeRecovery] = useState<DomeRecoveryStatus>(ONLINE_DOME_RECOVERY);
+  const [pendingEvacuationReason, setPendingEvacuationReason] = useState<
+    'access_revoked' | 'blocked' | null
+  >(null);
   const channelRef = useRef<BroadcastChannel | null>(null);
   const lastPhysicsSnapshotSequenceRef = useRef(0);
   const lastRecoveryAtRef = useRef(0);
@@ -132,6 +150,7 @@ export function useMetaverseRoomSession({
   const entryAttemptKeyRef = useRef<string | null>(null);
   const entryContextKeyRef = useRef<string | null>(null);
   const entryAutoDisabledRef = useRef(false);
+  const evacuationRunningRef = useRef(false);
   const avatarColliderPromiseRef = useRef<{
     assetUrl: string | null;
     promise: Promise<MetaverseColliderV1 | null>;
@@ -251,12 +270,14 @@ export function useMetaverseRoomSession({
   const transitionBoundaryStates = useMemo(() => {
     const states: Partial<Record<DomeDirection, DomeBoundaryStateV1>> = {};
     for (const neighbor of transitionNeighbors) {
-      states[neighbor.direction] = transitionPreparingDirections.has(neighbor.direction)
+      states[neighbor.direction] = domeRecovery.state === 'offline'
+        ? 'offline'
+        : transitionPreparingDirections.has(neighbor.direction)
         ? 'loading'
         : neighbor.boundaryState;
     }
     return states;
-  }, [transitionNeighbors, transitionPreparingDirections]);
+  }, [domeRecovery.state, transitionNeighbors, transitionPreparingDirections]);
 
   const nextSessionSequence = useCallback((instanceId: string, suggested = Date.now()) => {
     const next = Math.max(suggested, (sessionSequenceByInstanceRef.current.get(instanceId) ?? 0) + 1);
@@ -489,16 +510,34 @@ export function useMetaverseRoomSession({
   }, [admittedRoom, setLastRoomActivityAt, syncStatus.local_author_pubkey]);
 
   const submitAuthoritativeInput = useCallback((input: DomeSessionInputKindV1, sequence = Date.now()) => {
-    if (!admittedRoom?.metaverse) return;
+    if (!admittedRoom?.metaverse || domeRecovery.state !== 'online') return;
     void submitInputForRoom(admittedRoom, input, sequence)
       .then(applyPhysicsSnapshot)
       .catch(() => {
         // Hosting may not have been started yet; presence/chat remain available.
       });
-  }, [admittedRoom, applyPhysicsSnapshot, submitInputForRoom]);
+  }, [admittedRoom, applyPhysicsSnapshot, domeRecovery.state, submitInputForRoom]);
 
   useEffect(() => {
-    if (!admittedRoom) {
+    if (!admittedRoom?.metaverse || domeRecovery.state !== 'online') return;
+    const keepAlive = () => {
+      void submitInputForRoom(admittedRoom, { type: 'keep_alive' })
+        .then(applyPhysicsSnapshot)
+        .catch((error: unknown) => {
+          const message = error instanceof Error ? error.message : String(error);
+          if (message.includes('BLOCKED') || message.includes('VISITOR_BLOCKED')) {
+            setPendingEvacuationReason('blocked');
+          } else if (message.includes('ACCESS_DENIED') || message.includes('ACCESS_REVOKED')) {
+            setPendingEvacuationReason('access_revoked');
+          }
+        });
+    };
+    const intervalId = window.setInterval(keepAlive, 5_000);
+    return () => window.clearInterval(intervalId);
+  }, [admittedRoom, applyPhysicsSnapshot, domeRecovery.state, submitInputForRoom]);
+
+  useEffect(() => {
+    if (!admittedRoom || domeRecovery.state !== 'online') {
       return;
     }
     const joinedAt = Date.now();
@@ -540,8 +579,15 @@ export function useMetaverseRoomSession({
     localDisplayName,
     localPeerId,
     admittedRoom,
+    domeRecovery.state,
     submitAuthoritativeInput,
   ]);
+
+  useEffect(() => {
+    if (domeRecovery.state === 'online') return;
+    disableMicrophone();
+    stopSpatialAudio();
+  }, [disableMicrophone, domeRecovery.state, stopSpatialAudio]);
 
   useEffect(() => stopSpatialAudio(), [admittedRoom?.room_id, stopSpatialAudio, transitionNeighbors]);
 
@@ -572,6 +618,7 @@ export function useMetaverseRoomSession({
     setLastRoomActivityAt(Date.now());
     setRecoveringUntil(0);
     setLastSentSeq(0);
+    setDomeRecovery(ONLINE_DOME_RECOVERY);
     lastSentTransformRef.current = null;
     resetBackendEventCursor();
   }
@@ -742,14 +789,20 @@ export function useMetaverseRoomSession({
     })();
   }
 
-  const joinRoom = useCallback(async (roomId: string, reportError = true): Promise<boolean> => {
+  const joinRoom = useCallback(async (
+    roomId: string,
+    reportError = true,
+    preserveCurrent = false
+  ): Promise<boolean> => {
     const room = rooms.find((candidate) => candidate.room_id === roomId);
     if (!room?.metaverse) return false;
     const attempt = transitionAttemptRef.current;
     if (attempt) void abortTransitionAttempt(attempt);
-    setHandoffTransform(null);
-    setSelectedRoomId(roomId);
-    setAdmissionConfirmed(false);
+    if (!preserveCurrent) {
+      setHandoffTransform(null);
+      setSelectedRoomId(roomId);
+      setAdmissionConfirmed(false);
+    }
     setAdmissionStatus('admitting');
     try {
       const avatarCollider = await resolveLocalAvatarCollider();
@@ -775,6 +828,7 @@ export function useMetaverseRoomSession({
       applyPhysicsSnapshot(snapshot);
       setJoinedRoomIds((current) => new Set(current).add(roomId));
       setAdmissionConfirmed(true);
+      setSelectedRoomId(roomId);
       setAdmissionStatus('joined');
       writeLastVisitedDome(
         syncStatus.local_author_pubkey,
@@ -784,8 +838,12 @@ export function useMetaverseRoomSession({
       onError(null);
       return true;
     } catch (entryError) {
-      setAdmissionConfirmed(false);
-      setAdmissionStatus('selection');
+      if (!preserveCurrent) {
+        setAdmissionConfirmed(false);
+        setAdmissionStatus('selection');
+      } else {
+        setAdmissionStatus('joined');
+      }
       if (reportError) {
         onError(entryError instanceof Error ? entryError.message : 'Dome entry failed');
       }
@@ -801,6 +859,118 @@ export function useMetaverseRoomSession({
     submitInputForRoom,
     syncStatus.local_author_pubkey,
   ]);
+
+  const evacuate = useCallback(async (
+    reason: 'host_offline' | 'access_revoked' | 'blocked' | 'user_requested'
+  ): Promise<boolean> => {
+    if (!admittedRoom || evacuationRunningRef.current) return false;
+    evacuationRunningRef.current = true;
+    const sourceRoom = admittedRoom;
+    setDomeRecovery({ state: 'evacuating', secondsRemaining: null, reason, targetTitle: null });
+    const adjacent = transitionNeighbors
+      .filter((neighbor) => neighbor.boundaryState === 'ready')
+      .map((neighbor) => neighbor.room);
+    const ordered = reason === 'user_requested'
+      ? [...entryCandidates, ...adjacent]
+      : [...adjacent, ...entryCandidates];
+    const seen = new Set<string>([sourceRoom.room_id]);
+    const candidates = ordered.filter((candidate) => {
+      if (seen.has(candidate.room_id)) return false;
+      seen.add(candidate.room_id);
+      return true;
+    });
+    try {
+      for (const candidate of candidates) {
+        setDomeRecovery({
+          state: 'evacuating',
+          secondsRemaining: null,
+          reason,
+          targetTitle: candidate.title,
+        });
+        if (!await joinRoom(candidate.room_id, false, true)) continue;
+        await submitInputForRoom(sourceRoom, { type: 'leave' }).catch(() => undefined);
+        setJoinedRoomIds((current) => {
+          const next = new Set(current);
+          next.delete(sourceRoom.room_id);
+          next.add(candidate.room_id);
+          return next;
+        });
+        setDomeRecovery({ state: 'online', secondsRemaining: null, reason: null, targetTitle: null });
+        onError(t('recovery.moved', { target: candidate.title }));
+        return true;
+      }
+      setSelectedRoomId(null);
+      setAdmissionConfirmed(false);
+      setAdmissionStatus('selection');
+      entryAutoDisabledRef.current = true;
+      disableMicrophone();
+      stopSpatialAudio();
+      setDomeRecovery({ state: 'no_candidate', secondsRemaining: null, reason, targetTitle: null });
+      onError(t('recovery.noCandidate'));
+      return false;
+    } finally {
+      evacuationRunningRef.current = false;
+    }
+  }, [
+    admittedRoom,
+    disableMicrophone,
+    entryCandidates,
+    joinRoom,
+    onError,
+    stopSpatialAudio,
+    submitInputForRoom,
+    t,
+    transitionNeighbors,
+  ]);
+
+  useEffect(() => {
+    if (!pendingEvacuationReason) return;
+    const reason = pendingEvacuationReason;
+    setPendingEvacuationReason(null);
+    setDomeRecovery({ state: 'closed', secondsRemaining: 0, reason, targetTitle: null });
+    void evacuate(reason);
+  }, [evacuate, pendingEvacuationReason]);
+
+  useEffect(() => {
+    if (!admittedRoom?.metaverse) return;
+    let cancelled = false;
+    const pollHosting = async () => {
+      try {
+        const hosting = await actions.getHosting(
+          admittedRoom.metaverse!.spatial_context,
+          admittedRoom.metaverse!.instance_id
+        );
+        if (cancelled) return;
+        if (hosting.state.kind === 'grace_period') {
+          const deadline = (hosting.state.last_heartbeat_at ?? Date.now()) + 15_000;
+          setDomeRecovery({
+            state: 'offline',
+            secondsRemaining: Math.max(0, Math.ceil((deadline - Date.now()) / 1_000)),
+            reason: 'host_offline',
+            targetTitle: null,
+          });
+        } else if (hosting.state.kind === 'closed' && hosting.state.reason === 'heartbeat_timeout') {
+          setDomeRecovery({ state: 'closed', secondsRemaining: 0, reason: 'host_offline', targetTitle: null });
+          void evacuate('host_offline');
+        } else if (hosting.state.kind === 'owner_hosted' || hosting.state.kind === 'community_node_hosted') {
+          setDomeRecovery({ state: 'online', secondsRemaining: null, reason: null, targetTitle: null });
+        }
+      } catch {
+        setDomeRecovery((current) => current.state === 'online' ? {
+          state: 'offline',
+          secondsRemaining: 15,
+          reason: 'host_offline',
+          targetTitle: null,
+        } : current);
+      }
+    };
+    void pollHosting();
+    const intervalId = window.setInterval(() => void pollHosting(), 1_000);
+    return () => {
+      cancelled = true;
+      window.clearInterval(intervalId);
+    };
+  }, [actions, admittedRoom, evacuate]);
 
   useEffect(() => {
     const contextKey = spatialContextKey(entryContext);
@@ -880,6 +1050,7 @@ export function useMetaverseRoomSession({
   }
 
   function handleLocalTransform(transform: AvatarTransform) {
+    if (domeRecovery.state !== 'online') return;
     const previous = lastSentTransformRef.current;
     lastSentTransformRef.current = transform;
     setLastSentSeq(transform.seq);
@@ -913,7 +1084,7 @@ export function useMetaverseRoomSession({
 
   function handleSendMessage(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    if (!admittedRoom || !messageDraft.trim()) {
+    if (!admittedRoom || domeRecovery.state !== 'online' || !messageDraft.trim()) {
       return;
     }
     const message: RoomChatMessage = {
@@ -1083,6 +1254,8 @@ export function useMetaverseRoomSession({
     roomConnectionState,
     knownPeerCount,
     clockNow,
+    domeRecovery,
+    returnHome: () => void evacuate('user_requested'),
     joinRoom,
     selectCreatedRoom,
     leaveRoom,

--- a/apps/desktop/src/i18n/locales/en/metaverse.json
+++ b/apps/desktop/src/i18n/locales/en/metaverse.json
@@ -58,6 +58,16 @@
       "offline": "Peer connectivity is unavailable"
     }
   },
+  "recovery": {
+    "returnHome": "Return Home",
+    "returnHomeDescription": "Leave for the safest available Dome",
+    "offlineCountdown": "Host heartbeat stopped. Waiting {{count}} seconds before safe evacuation.",
+    "movingTo": "Confirming a safe spawn in {{target}}…",
+    "moved": "Moved safely to {{target}}.",
+    "noCandidate": "No safe Dome is available. Returned to Dome selection.",
+    "states": { "offline": "Host offline", "evacuating": "Evacuating", "closed": "Dome closed", "no_candidate": "No safe destination" },
+    "details": { "evacuating": "Checking destinations without discarding the current scene.", "closed": "The grace period expired.", "no_candidate": "Choose a hosted Dome to continue." }
+  },
   "hosting": {
     "title": "Dome Hosting",
     "states": { "closed": "Closed", "owner_hosted": "Hosted on owner device", "community_node_hosted": "Hosted on Community Node", "grace_period": "Grace period", "transferring": "Transferring" },

--- a/apps/desktop/src/i18n/locales/ja/metaverse.json
+++ b/apps/desktop/src/i18n/locales/ja/metaverse.json
@@ -58,6 +58,16 @@
       "offline": "ピア接続を利用できません"
     }
   },
+  "recovery": {
+    "returnHome": "ホームへ戻る",
+    "returnHomeDescription": "利用可能な最も安全なDomeへ退避します",
+    "offlineCountdown": "Host heartbeatが停止しました。安全退避まであと{{count}}秒待機します。",
+    "movingTo": "{{target}}の安全なspawn位置を確認しています…",
+    "moved": "{{target}}へ安全に移動しました。",
+    "noCandidate": "安全なDomeがありません。Dome選択へ戻りました。",
+    "states": { "offline": "ホストがオフライン", "evacuating": "退避中", "closed": "Dome停止", "no_candidate": "安全な移動先なし" },
+    "details": { "evacuating": "現在のsceneを保持したまま移動先を確認しています。", "closed": "Grace periodが終了しました。", "no_candidate": "Hosting中のDomeを選択してください。" }
+  },
   "hosting": {
     "title": "Domeホスティング",
     "states": { "closed": "停止中", "owner_hosted": "Owner端末で稼働中", "community_node_hosted": "Community Nodeで稼働中", "grace_period": "Grace期間", "transferring": "移管中" },

--- a/apps/desktop/src/i18n/locales/zh-CN/metaverse.json
+++ b/apps/desktop/src/i18n/locales/zh-CN/metaverse.json
@@ -58,6 +58,16 @@
       "offline": "对等连接不可用"
     }
   },
+  "recovery": {
+    "returnHome": "返回安全穹顶",
+    "returnHomeDescription": "撤离到当前最安全的可用 Dome",
+    "offlineCountdown": "Host heartbeat 已停止。将在 {{count}} 秒后安全撤离。",
+    "movingTo": "正在确认 {{target}} 的安全出生点…",
+    "moved": "已安全移动到 {{target}}。",
+    "noCandidate": "没有安全的 Dome。已返回 Dome 选择。",
+    "states": { "offline": "Host 离线", "evacuating": "撤离中", "closed": "Dome 已关闭", "no_candidate": "没有安全目的地" },
+    "details": { "evacuating": "保留当前场景并检查目的地。", "closed": "宽限期已结束。", "no_candidate": "请选择正在托管的 Dome。" }
+  },
   "hosting": {
     "title": "Dome 托管",
     "states": { "closed": "已停止", "owner_hosted": "由所有者设备托管", "community_node_hosted": "由社区节点托管", "grace_period": "宽限期", "transferring": "迁移中" },

--- a/apps/desktop/src/lib/api/__fixtures__/views/game_room_view.metaverse.json
+++ b/apps/desktop/src/lib/api/__fixtures__/views/game_room_view.metaverse.json
@@ -8,7 +8,7 @@
   "scores": [],
   "room_kind": "metaverse_room",
   "metaverse": {
-    "world_version": 6,
+    "world_version": 7,
     "instance_id": "room-2",
     "spatial_context": {
       "kind": "channel",

--- a/apps/desktop/src/lib/api/__fixtures__/viewsContract.ts
+++ b/apps/desktop/src/lib/api/__fixtures__/viewsContract.ts
@@ -554,7 +554,7 @@ export const gameRoomViewMetaverse = {
   "scores": [],
   "room_kind": "metaverse_room",
   "metaverse": {
-    "world_version": 6,
+    "world_version": 7,
     "instance_id": "room-2",
     "spatial_context": {
       "kind": "channel",

--- a/apps/desktop/src/lib/api/types.generated.ts
+++ b/apps/desktop/src/lib/api/types.generated.ts
@@ -131,7 +131,7 @@ export type MetaversePrimitive = "cube" | "sphere";
 
 export type DomeDirection = "north" | "east" | "south" | "west";
 
-export type DomeBoundaryStateV1 = "closed" | "loading" | "ready" | "denied" | "full" | "unhosted" | "error" | "stale";
+export type DomeBoundaryStateV1 = "closed" | "offline" | "draining" | "blocked" | "loading" | "ready" | "denied" | "full" | "unhosted" | "error" | "stale";
 
 export type DomeTransitionDenialReasonV1 = "host_unavailable" | "access_denied" | "owners_blocked" | "visitor_blocked" | "capacity_full" | "assets_unavailable" | "stale_topology" | "stale_session" | "invalid_ticket";
 
@@ -183,7 +183,7 @@ export type DomeConnectionStatusV1 = "accepted" | "active" | "draining" | "revok
 
 export type DomeConnectionTerminalReasonV1 = "owner_revoked" | "proposer_withdrew" | "proposer_slot_occupied" | "instance_detached" | "instance_deleted" | "owners_blocked";
 
-export type DomeConnectionRecordV1 = { agreement: DomeConnectionAgreementV1, receiver_slot_generation: number, observed_active_connection_ids: Array<string>, status: DomeConnectionStatusV1, lifecycle_generation: number, lifecycle_actor: Pubkey | null, lifecycle_reason: DomeConnectionTerminalReasonV1 | null, };
+export type DomeConnectionRecordV1 = { agreement: DomeConnectionAgreementV1, receiver_slot_generation: number, observed_active_connection_ids: Array<string>, status: DomeConnectionStatusV1, lifecycle_generation: number, lifecycle_actor: Pubkey | null, lifecycle_reason: DomeConnectionTerminalReasonV1 | null, lifecycle_deadline_at: number | null, };
 
 export type DomeProposalDerivedStatusV1 = "proposed" | "reserved" | "accepted" | "waiting_for_slot" | "discarded";
 
@@ -203,7 +203,7 @@ export type DomeHostingStateKindV1 = "closed" | "owner_hosted" | "community_node
 
 export type DomeHostingStateV1 = { kind: DomeHostingStateKindV1, host?: DomeHostTargetV1 | null, lease_id?: string | null, lease_epoch?: number | null, lease_expires_at?: number | null, session_id?: string | null, reason?: string | null, last_heartbeat_at?: number | null, };
 
-export type DomeSessionInputKindV1 = { "type": "join", avatar_collider?: MetaverseColliderV1 | null, } | { "type": "leave" } | { "type": "move", position: [number, number, number], rotation: [number, number, number], animation: string, } | { "type": "grab", prop_id: string, } | { "type": "throw", prop_id: string, impulse: [number, number, number], } | { "type": "push", prop_id: string, impulse: [number, number, number], } | { "type": "sit", prop_id: string, } | { "type": "prepare_transition", transition_id: string, direction: DomeDirection, } | { "type": "abort_transition", transition_id: string, } | { "type": "complete_transition", transition_id: string, } | { "type": "spawn_guest_prop", prop: MetaversePersistentPropV1, expires_at: number, } | { "type": "upsert_persistent_prop", prop: MetaversePersistentPropV1, } | { "type": "delete_persistent_prop", prop_id: string, };
+export type DomeSessionInputKindV1 = { "type": "join", avatar_collider?: MetaverseColliderV1 | null, } | { "type": "leave" } | { "type": "keep_alive" } | { "type": "move", position: [number, number, number], rotation: [number, number, number], animation: string, } | { "type": "grab", prop_id: string, } | { "type": "throw", prop_id: string, impulse: [number, number, number], } | { "type": "push", prop_id: string, impulse: [number, number, number], } | { "type": "sit", prop_id: string, } | { "type": "prepare_transition", transition_id: string, direction: DomeDirection, } | { "type": "abort_transition", transition_id: string, } | { "type": "complete_transition", transition_id: string, } | { "type": "spawn_guest_prop", prop: MetaversePersistentPropV1, expires_at: number, } | { "type": "upsert_persistent_prop", prop: MetaversePersistentPropV1, } | { "type": "delete_persistent_prop", prop_id: string, };
 
 export type DomePhysicsBodyKindV1 = "avatar" | "persistent_prop" | "guest_prop";
 

--- a/apps/desktop/src/mocks/api/liveGame.ts
+++ b/apps/desktop/src/mocks/api/liveGame.ts
@@ -632,6 +632,7 @@ export function createLiveGameMock(runtime: MockRuntime): LiveGameMock {
           lifecycle_generation: 1,
           lifecycle_actor: null,
           lifecycle_reason: null,
+          lifecycle_deadline_at: null,
         },
       };
       connectionViews.set(proposal.connection_id, connection);
@@ -675,6 +676,7 @@ export function createLiveGameMock(runtime: MockRuntime): LiveGameMock {
           lifecycle_generation: connection.record.lifecycle_generation + 2,
           lifecycle_actor: syncStatus.local_author_pubkey,
           lifecycle_reason: 'owner_revoked',
+          lifecycle_deadline_at: null,
         },
       };
       connectionViews.set(connectionId, revoked);

--- a/apps/desktop/src/styles/shell-phase1-part1.css
+++ b/apps/desktop/src/styles/shell-phase1-part1.css
@@ -331,6 +331,33 @@
   color: var(--danger);
 }
 
+.metaverse-recovery-banner {
+  position: absolute;
+  top: 3.5rem;
+  left: 0.75rem;
+  z-index: 2;
+  display: grid;
+  gap: 0.15rem;
+  max-width: min(24rem, calc(100% - 1.5rem));
+  padding: var(--space-sm);
+  border: 1px solid var(--warning);
+  border-radius: var(--radius-xs);
+  background: color-mix(in srgb, var(--surface-panel) 92%, transparent);
+  color: var(--foreground);
+  box-shadow: var(--shadow-panel);
+  backdrop-filter: blur(var(--blur-hud));
+}
+
+.metaverse-recovery-banner[data-state='closed'],
+.metaverse-recovery-banner[data-state='no_candidate'] {
+  border-color: var(--danger);
+}
+
+.metaverse-recovery-banner span {
+  color: var(--muted-foreground);
+  font-size: var(--text-caption);
+}
+
 .metaverse-room-hud {
   position: absolute;
   top: 4rem;

--- a/crates/app-api/src/dome_connections.rs
+++ b/crates/app-api/src/dome_connections.rs
@@ -341,6 +341,7 @@ impl AppService {
             lifecycle_generation: 1,
             lifecycle_actor: None,
             lifecycle_reason: None,
+            lifecycle_deadline_at: None,
         };
         validate_dome_connection_record(&record)?;
         let mut prospective = current_connections

--- a/crates/app-api/src/dome_hosting.rs
+++ b/crates/app-api/src/dome_hosting.rs
@@ -15,7 +15,8 @@ use kukuri_core::{
     SpatialContextV1, accept_dome_hosting_lease, activate_dome_hosting_lease,
     build_signed_dome_hosting_lease, build_signed_dome_layout_commit,
     build_signed_dome_session_input, close_dome_hosting_lease, dome_layout_candidate_digest,
-    resolve_dome_hosting_state, verify_signed_dome_layout_candidate,
+    resolve_dome_hosting_state, verify_signed_dome_host_heartbeat,
+    verify_signed_dome_layout_candidate,
 };
 
 const HOSTING_RECORD_PREFIX: &str = "metaverse/dome-hosting";
@@ -108,6 +109,11 @@ impl AppService {
             .lock()
             .await
             .insert(instance.instance_id.clone(), runtime);
+        self.spawn_owner_dome_heartbeat_task(
+            instance.spatial_context.clone(),
+            instance.instance_id.clone(),
+            session_id.clone(),
+        );
         let mut all_records = records;
         all_records.extend(new_records);
         self.publish_dome_hosting_hint(
@@ -247,7 +253,10 @@ impl AppService {
         &self,
         input: SubmitDomeSessionInput,
     ) -> Result<SignedDomePhysicsSnapshotV1> {
-        if matches!(&input.input, DomeSessionInputKindV1::Join { .. }) {
+        if matches!(
+            &input.input,
+            DomeSessionInputKindV1::Join { .. } | DomeSessionInputKindV1::KeepAlive
+        ) {
             let replica = self.hosting_context_replica(&input.spatial_context).await?;
             let instance = self
                 .hosting_instance(&replica, &input.instance_id)
@@ -798,7 +807,7 @@ impl AppService {
         records: &[DomeHostingRecordV1],
         now: i64,
     ) -> Result<DomeHostingView> {
-        let (local_heartbeat, participants, sleeping, resource_metrics) = {
+        let (local_heartbeat, mut participants, mut sleeping, resource_metrics) = {
             let mut sessions = self.dome_host_sessions.lock().await;
             match sessions.get_mut(&instance.instance_id) {
                 Some(runtime) => {
@@ -813,7 +822,54 @@ impl AppService {
                 None => (None, 0, true, Default::default()),
             }
         };
-        let state = resolve_dome_hosting_state(instance, records, now, local_heartbeat)?;
+        let mut heartbeat_at = local_heartbeat;
+        if heartbeat_at.is_none() {
+            let preliminary = resolve_dome_hosting_state(instance, records, now, Some(now))?;
+            if let (Some(lease), Some(session_id), Some(signed)) = (
+                current_unique_lease(records)?,
+                preliminary.session_id.as_deref(),
+                self.dome_host_heartbeats
+                    .lock()
+                    .await
+                    .get(&instance.instance_id)
+                    .cloned(),
+            ) {
+                if signed.heartbeat.sent_at <= now.saturating_add(5_000)
+                    && verify_signed_dome_host_heartbeat(&signed, &lease.lease, session_id).is_ok()
+                {
+                    heartbeat_at = Some(signed.heartbeat.sent_at);
+                    participants = signed.heartbeat.participants;
+                    sleeping = signed.heartbeat.sleeping;
+                } else {
+                    let mut heartbeats = self.dome_host_heartbeats.lock().await;
+                    if heartbeats
+                        .get(&instance.instance_id)
+                        .is_some_and(|current| current.envelope.id == signed.envelope.id)
+                    {
+                        heartbeats.remove(&instance.instance_id);
+                    }
+                }
+            }
+            if heartbeat_at.is_none()
+                && matches!(
+                    preliminary.kind,
+                    DomeHostingStateKindV1::OwnerHosted
+                        | DomeHostingStateKindV1::CommunityNodeHosted
+                )
+            {
+                heartbeat_at = preliminary.lease_epoch.and_then(|epoch| {
+                    records.iter().rev().find_map(|record| match record {
+                        DomeHostingRecordV1::LeaseActivated(signed)
+                            if signed.activation.lease_epoch == epoch =>
+                        {
+                            Some(signed.activation.activated_at)
+                        }
+                        _ => None,
+                    })
+                });
+            }
+        }
+        let state = resolve_dome_hosting_state(instance, records, now, heartbeat_at)?;
         self.services
             .projection_store
             .upsert_dome_hosting_projection(DomeHostingProjectionRow {
@@ -899,6 +955,53 @@ impl AppService {
                 },
             )
             .await
+    }
+
+    fn spawn_owner_dome_heartbeat_task(
+        &self,
+        context: SpatialContextV1,
+        instance_id: String,
+        session_id: String,
+    ) {
+        let sessions = Arc::clone(&self.dome_host_sessions);
+        let hint_transport = Arc::clone(&self.services.hint_transport);
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(std::time::Duration::from_millis(
+                kukuri_core::DOME_HOST_HEARTBEAT_INTERVAL_MILLIS as u64,
+            ));
+            interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+            loop {
+                interval.tick().await;
+                let signed = {
+                    let sessions = sessions.lock().await;
+                    let Some(runtime) = sessions.get(&instance_id) else {
+                        break;
+                    };
+                    if runtime.session_id() != session_id {
+                        break;
+                    }
+                    match runtime.signed_heartbeat(Utc::now().timestamp_millis()) {
+                        Ok(signed) => signed,
+                        Err(_) => break,
+                    }
+                };
+                let hint = GossipHint::DomeHostHeartbeat {
+                    topic_id: context.topic_id().clone(),
+                    instance_id: instance_id.clone(),
+                    heartbeat: Box::new(signed),
+                };
+                if hint_transport
+                    .publish_hint(
+                        &channel_hint_topic_for(context.topic_id().as_str(), context.channel_id()),
+                        hint,
+                    )
+                    .await
+                    .is_err()
+                {
+                    continue;
+                }
+            }
+        });
     }
 }
 

--- a/crates/app-api/src/service/dome_connection_support.rs
+++ b/crates/app-api/src/service/dome_connection_support.rs
@@ -61,14 +61,49 @@ impl AppService {
             anyhow::bail!("only an endpoint owner can terminate a Dome Connection");
         }
         if state.record.status != DomeConnectionStatusV1::Revoked {
-            state.record.status = DomeConnectionStatusV1::Draining;
-            state.record.lifecycle_generation += 1;
-            state.record.lifecycle_actor = Some(actor.clone());
-            state.record.lifecycle_reason = Some(reason);
-            self.persist_connection_lifecycle(&replica, &mut state)
+            let immediate = reason != DomeConnectionTerminalReasonV1::OwnerRevoked;
+            if !immediate && state.record.status != DomeConnectionStatusV1::Draining {
+                state.record.status = DomeConnectionStatusV1::Draining;
+                state.record.lifecycle_generation += 1;
+                state.record.lifecycle_actor = Some(actor.clone());
+                state.record.lifecycle_reason = Some(reason);
+                state.record.lifecycle_deadline_at = Some(
+                    Utc::now()
+                        .timestamp_millis()
+                        .saturating_add(kukuri_core::DOME_CONNECTION_DRAIN_MILLIS),
+                );
+                self.persist_connection_lifecycle(&replica, &mut state)
+                    .await?;
+                self.publish_dome_topology_hint(
+                    &state.record.agreement.spatial_context,
+                    &state.record.agreement.connection_id,
+                )
                 .await?;
+                let mut sessions = self.dome_host_sessions.lock().await;
+                for runtime in sessions.values_mut() {
+                    runtime.drain_connection(connection_id);
+                }
+            }
+            if let Some(deadline) = state.record.lifecycle_deadline_at {
+                let remaining = deadline.saturating_sub(Utc::now().timestamp_millis());
+                if remaining > 0 {
+                    tokio::time::sleep(std::time::Duration::from_millis(remaining as u64)).await;
+                }
+                state = self
+                    .fetch_dome_connection_state(&replica, connection_id)
+                    .await?
+                    .context("Dome Connection was not found after draining")?;
+            }
+            if state.record.status == DomeConnectionStatusV1::Revoked {
+                return Ok(DomeConnectionView {
+                    record: state.record,
+                });
+            }
             state.record.status = DomeConnectionStatusV1::Revoked;
             state.record.lifecycle_generation += 1;
+            state.record.lifecycle_actor = Some(actor);
+            state.record.lifecycle_reason = Some(reason);
+            state.record.lifecycle_deadline_at = None;
             self.persist_connection_lifecycle(&replica, &mut state)
                 .await?;
         }

--- a/crates/app-api/src/service/hydration_support.rs
+++ b/crates/app-api/src/service/hydration_support.rs
@@ -744,6 +744,7 @@ pub(crate) async fn hydrate_subscription_hint(
         | GossipHint::Typing { .. }
         | GossipHint::LivePresence { .. }
         | GossipHint::MetaverseRoomEvent { .. }
+        | GossipHint::DomeHostHeartbeat { .. }
         | GossipHint::DirectMessageFrame { .. }
         | GossipHint::DirectMessageAck { .. } => Ok(0),
     }
@@ -757,6 +758,7 @@ pub(crate) fn hint_targets_topic(hint: &GossipHint, topic: &str) -> bool {
         | GossipHint::SessionChanged { topic_id, .. }
         | GossipHint::LivePresence { topic_id, .. }
         | GossipHint::MetaverseRoomEvent { topic_id, .. }
+        | GossipHint::DomeHostHeartbeat { topic_id, .. }
         | GossipHint::DirectMessageFrame { topic_id, .. }
         | GossipHint::DirectMessageAck { topic_id, .. } => topic_id.as_str() == topic,
         GossipHint::ThreadUpdated { .. } | GossipHint::ProfileUpdated { .. } => true,

--- a/crates/app-api/src/service/mod.rs
+++ b/crates/app-api/src/service/mod.rs
@@ -374,6 +374,8 @@ pub struct AppService {
     pub(crate) subscription_registry: SubscriptionRegistry,
     pub(crate) joined_private_channels: Arc<Mutex<HashMap<String, JoinedPrivateChannelState>>>,
     pub(crate) metaverse_room_events: Arc<Mutex<HashMap<String, VecDeque<MetaverseRoomEventView>>>>,
+    pub(crate) dome_host_heartbeats:
+        Arc<Mutex<HashMap<String, kukuri_core::SignedDomeHostHeartbeatV1>>>,
     pub(crate) dome_host_sessions: Arc<Mutex<HashMap<String, DomeSessionRuntime>>>,
     pub(crate) metaverse_blob_cache: Arc<Mutex<MetaverseBlobCacheIndex>>,
     pub(crate) metaverse_resource_budget: kukuri_core::MetaverseResourceBudgetConfig,
@@ -539,6 +541,7 @@ impl AppService {
             subscription_registry: SubscriptionRegistry::default(),
             joined_private_channels: Arc::new(Mutex::new(HashMap::new())),
             metaverse_room_events: Arc::new(Mutex::new(HashMap::new())),
+            dome_host_heartbeats: Arc::new(Mutex::new(HashMap::new())),
             dome_host_sessions: Arc::new(Mutex::new(HashMap::new())),
             metaverse_blob_cache: Arc::new(Mutex::new(cache)),
             metaverse_resource_budget: budget,

--- a/crates/app-api/src/service/private_channels_support.rs
+++ b/crates/app-api/src/service/private_channels_support.rs
@@ -630,6 +630,7 @@ impl AppService {
     ) -> Result<()> {
         let services = self.services.clone();
         let metaverse_room_events = Arc::clone(&self.metaverse_room_events);
+        let dome_host_heartbeats = Arc::clone(&self.dome_host_heartbeats);
         let last_sync = Arc::clone(&self.last_sync_ts);
         let notification_inserted = Arc::clone(&self.notification_inserted_notify);
         let public_topic_delivery = Arc::clone(&self.public_topic_delivery);
@@ -854,6 +855,20 @@ impl AppService {
                                                 "failed to parse metaverse room event hint"
                                             );
                                         }
+                                    }
+                                }
+                                GossipHint::DomeHostHeartbeat { instance_id, heartbeat, .. } => {
+                                    let mut heartbeats = dome_host_heartbeats.lock().await;
+                                    let replace = heartbeats
+                                        .get(instance_id)
+                                        .is_none_or(|current| {
+                                            heartbeat.heartbeat.sequence > current.heartbeat.sequence
+                                                || (heartbeat.heartbeat.sequence == current.heartbeat.sequence
+                                                    && heartbeat.heartbeat.sent_at > current.heartbeat.sent_at)
+                                        });
+                                    if replace {
+                                        heartbeats.insert(instance_id.clone(), heartbeat.as_ref().clone());
+                                        *last_sync.lock().await = Some(Utc::now().timestamp_millis());
                                     }
                                 }
                                 GossipHint::LivePresence { session_id, author, ttl_ms, .. } => {

--- a/crates/app-api/src/tests/dome_connections.rs
+++ b/crates/app-api/src/tests/dome_connections.rs
@@ -118,13 +118,31 @@ async fn dome_connection_proposal_accept_and_revoke_round_trip() {
         DomeProposalDerivedStatusV1::Accepted
     );
 
-    receiver
-        .revoke_dome_connection(RevokeDomeConnectionInput {
-            spatial_context: context.clone(),
-            connection_id: connection.record.agreement.connection_id,
-        })
+    let revoke = receiver.revoke_dome_connection(RevokeDomeConnectionInput {
+        spatial_context: context.clone(),
+        connection_id: connection.record.agreement.connection_id,
+    });
+    tokio::pin!(revoke);
+    tokio::select! {
+        _ = tokio::time::sleep(std::time::Duration::from_millis(100)) => {}
+        _ = &mut revoke => panic!("normal revoke must expose the draining interval"),
+    }
+    let draining = proposer
+        .list_dome_connection_topology(context.clone())
         .await
-        .expect("revoke Connection");
+        .expect("draining topology");
+    assert_eq!(
+        draining.connections[0].record.status,
+        kukuri_core::DomeConnectionStatusV1::Draining
+    );
+    assert!(
+        draining.connections[0]
+            .record
+            .lifecycle_deadline_at
+            .is_some()
+    );
+    assert_eq!(draining.resolution.topology.components.len(), 1);
+    revoke.await.expect("revoke Connection");
     let split = proposer
         .list_dome_connection_topology(context)
         .await

--- a/crates/cn-protocol/src/dome_hosting.rs
+++ b/crates/cn-protocol/src/dome_hosting.rs
@@ -1,9 +1,10 @@
 use kukuri_core::{
     DomeHostingStateKindV1, DomeInstanceManifestV1, DomePresetManifestV1, DomeSpatialAccessProofV1,
     DomeTransitionAdmissionRequestV1, DomeTransitionAdmissionTicketV1,
-    MetaverseResourceBudgetConfig, MetaverseResourceMetricsV1, SignedDomeHostingAcceptanceV1,
-    SignedDomeHostingActivationV1, SignedDomeHostingCloseV1, SignedDomeHostingLeaseV1,
-    SignedDomeLayoutCandidateV1, SignedDomePhysicsSnapshotV1, SignedDomeSessionInputV1,
+    MetaverseResourceBudgetConfig, MetaverseResourceMetricsV1, SignedDomeHostHeartbeatV1,
+    SignedDomeHostingAcceptanceV1, SignedDomeHostingActivationV1, SignedDomeHostingCloseV1,
+    SignedDomeHostingLeaseV1, SignedDomeLayoutCandidateV1, SignedDomePhysicsSnapshotV1,
+    SignedDomeSessionInputV1,
 };
 use serde::{Deserialize, Serialize};
 
@@ -128,6 +129,7 @@ pub struct DomeHostingStatusResponse {
     pub session_id: Option<String>,
     pub participants: u32,
     pub sleeping: bool,
+    pub signed_heartbeat: Option<SignedDomeHostHeartbeatV1>,
     pub expires_at: i64,
     pub resource_budget: MetaverseResourceBudgetConfig,
     pub resource_metrics: MetaverseResourceMetricsV1,

--- a/crates/cn-user-api/src/dome_hosting.rs
+++ b/crates/cn-user-api/src/dome_hosting.rs
@@ -422,6 +422,7 @@ pub(crate) async fn release_dome_hosting(
         session_id: None,
         participants: 0,
         sleeping: true,
+        signed_heartbeat: None,
         expires_at: assignment.expires_at,
         resource_budget: hosting.budget.clone(),
         resource_metrics: Default::default(),
@@ -513,6 +514,7 @@ pub(crate) async fn submit_dome_hosting_input(
     if matches!(
         &request.signed_input.input.input,
         kukuri_core::DomeSessionInputKindV1::Join { .. }
+            | kukuri_core::DomeSessionInputKindV1::KeepAlive
     ) {
         let proof_valid = dome_entry_access_proof_is_valid(
             request.access_proof.as_ref(),
@@ -838,6 +840,11 @@ fn status_from_runtime(
             .map(|runtime| runtime.participant_count().try_into().unwrap_or(u32::MAX))
             .unwrap_or(0),
         sleeping: runtime.is_none_or(DomeSessionRuntime::is_sleeping),
+        signed_heartbeat: runtime.and_then(|runtime| {
+            runtime
+                .signed_heartbeat(chrono::Utc::now().timestamp_millis())
+                .ok()
+        }),
         expires_at,
         resource_budget: runtime
             .map(|runtime| runtime.budget().clone())

--- a/crates/core/src/dome_connections.rs
+++ b/crates/core/src/dome_connections.rs
@@ -12,6 +12,7 @@ use crate::{
 pub const DOME_CONNECTION_MAX_OPEN_OUTBOUND: usize = 32;
 pub const DOME_CONNECTION_MAX_PER_PEER_SLOT: usize = 4;
 pub const DOME_CONNECTION_MAX_RECEIVER_QUEUE: usize = 32;
+pub const DOME_CONNECTION_DRAIN_MILLIS: i64 = 3_000;
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[cfg_attr(feature = "ts", derive(ts_rs::TS))]
@@ -128,6 +129,7 @@ pub struct DomeConnectionRecordV1 {
     pub lifecycle_generation: u64,
     pub lifecycle_actor: Option<Pubkey>,
     pub lifecycle_reason: Option<DomeConnectionTerminalReasonV1>,
+    pub lifecycle_deadline_at: Option<i64>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -245,7 +247,7 @@ pub fn validate_dome_connection_record(record: &DomeConnectionRecordV1) -> Resul
     validate_unique_ids(&record.observed_active_connection_ids)?;
     match record.status {
         DomeConnectionStatusV1::Accepted | DomeConnectionStatusV1::Active => {
-            if record.lifecycle_reason.is_some() {
+            if record.lifecycle_reason.is_some() || record.lifecycle_deadline_at.is_some() {
                 bail!("non-terminal Dome Connection cannot have a terminal reason");
             }
         }
@@ -261,6 +263,16 @@ pub fn validate_dome_connection_record(record: &DomeConnectionRecordV1) -> Resul
             }
             if record.lifecycle_reason.is_none() {
                 bail!("Dome Connection terminal lifecycle requires a reason");
+            }
+            if record.status == DomeConnectionStatusV1::Draining
+                && record.lifecycle_deadline_at.is_none()
+            {
+                bail!("draining Dome Connection requires a deadline");
+            }
+            if record.status == DomeConnectionStatusV1::Revoked
+                && record.lifecycle_deadline_at.is_some()
+            {
+                bail!("revoked Dome Connection cannot retain a drain deadline");
             }
         }
     }

--- a/crates/core/src/dome_hosting.rs
+++ b/crates/core/src/dome_hosting.rs
@@ -11,7 +11,10 @@ use crate::{
 };
 
 pub const DOME_HOSTING_MAX_LEASE_MILLIS: i64 = 30 * 24 * 60 * 60 * 1_000;
+pub const DOME_HOST_HEARTBEAT_INTERVAL_MILLIS: i64 = 5_000;
 pub const DOME_HOSTING_HEARTBEAT_GRACE_MILLIS: i64 = 15_000;
+pub const DOME_PARTICIPANT_KEEPALIVE_INTERVAL_MILLIS: i64 = 5_000;
+pub const DOME_PARTICIPANT_TIMEOUT_MILLIS: i64 = 30_000;
 pub const DOME_SNAPSHOT_RING_CAPACITY: usize = 100;
 
 const LEASE_KIND: &str = "dome-hosting-lease";
@@ -190,6 +193,7 @@ pub enum DomeSessionInputKindV1 {
         avatar_collider: Option<crate::MetaverseColliderV1>,
     },
     Leave,
+    KeepAlive,
     Move {
         position: [i64; 3],
         rotation: [i64; 3],
@@ -310,6 +314,7 @@ pub struct DomeHostHeartbeatV1 {
     pub host_pubkey: Pubkey,
     pub participants: u32,
     pub sleeping: bool,
+    pub sequence: u64,
     pub sent_at: i64,
 }
 
@@ -622,10 +627,20 @@ pub fn resolve_dome_hosting_state(
         });
     };
 
-    let heartbeat_stale = last_heartbeat_at.is_some_and(|heartbeat| {
-        now_millis.saturating_sub(heartbeat) > DOME_HOSTING_HEARTBEAT_GRACE_MILLIS
-    });
-    let kind = if heartbeat_stale {
+    let liveness = crate::resolve_dome_host_liveness(last_heartbeat_at, now_millis);
+    if liveness == crate::DomeHostLivenessV1::Closed {
+        return Ok(DomeHostingStateV1 {
+            kind: DomeHostingStateKindV1::Closed,
+            host: Some(lease.host.clone()),
+            lease_id: Some(lease.lease_id.clone()),
+            lease_epoch: Some(lease.epoch),
+            lease_expires_at: Some(lease.expires_at),
+            session_id: Some(acceptance.acceptance.session_id.clone()),
+            reason: Some("heartbeat_timeout".into()),
+            last_heartbeat_at,
+        });
+    }
+    let kind = if liveness == crate::DomeHostLivenessV1::OfflineGrace {
         DomeHostingStateKindV1::GracePeriod
     } else {
         match lease.host {
@@ -640,7 +655,8 @@ pub fn resolve_dome_hosting_state(
         lease_epoch: Some(lease.epoch),
         lease_expires_at: Some(lease.expires_at),
         session_id: Some(acceptance.acceptance.session_id.clone()),
-        reason: heartbeat_stale.then(|| "heartbeat_timeout".into()),
+        reason: (liveness == crate::DomeHostLivenessV1::OfflineGrace)
+            .then(|| "heartbeat_missing".into()),
         last_heartbeat_at,
     })
 }
@@ -853,6 +869,9 @@ fn validate_dome_host_heartbeat(
         || heartbeat.lease_epoch != lease.epoch
         || heartbeat.session_id.trim().is_empty()
         || heartbeat.host_pubkey != *lease.host.signing_pubkey()
+        || heartbeat.sequence == 0
+        || heartbeat.sent_at < lease.issued_at
+        || heartbeat.sent_at >= lease.expires_at
     {
         bail!("Dome host heartbeat does not match active lease");
     }

--- a/crates/core/src/dome_recovery.rs
+++ b/crates/core/src/dome_recovery.rs
@@ -1,0 +1,107 @@
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
+
+use crate::{DOME_HOST_HEARTBEAT_INTERVAL_MILLIS, DOME_HOSTING_HEARTBEAT_GRACE_MILLIS};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[serde(rename_all = "snake_case")]
+pub enum DomeHostLivenessV1 {
+    Online,
+    OfflineGrace,
+    Closed,
+}
+
+pub fn resolve_dome_host_liveness(
+    last_heartbeat_at: Option<i64>,
+    now_millis: i64,
+) -> DomeHostLivenessV1 {
+    let Some(last_heartbeat_at) = last_heartbeat_at else {
+        return DomeHostLivenessV1::OfflineGrace;
+    };
+    let age = now_millis.saturating_sub(last_heartbeat_at);
+    if age > DOME_HOSTING_HEARTBEAT_GRACE_MILLIS {
+        DomeHostLivenessV1::Closed
+    } else if age > DOME_HOST_HEARTBEAT_INTERVAL_MILLIS {
+        DomeHostLivenessV1::OfflineGrace
+    } else {
+        DomeHostLivenessV1::Online
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[serde(rename_all = "snake_case")]
+pub enum DomeEvacuationReasonV1 {
+    HostOffline,
+    AccessRevoked,
+    Blocked,
+    TopologyInvalid,
+    UserRequested,
+}
+
+impl DomeEvacuationReasonV1 {
+    pub const fn code(self) -> &'static str {
+        match self {
+            Self::HostOffline => "DOME_EVACUATION_HOST_OFFLINE",
+            Self::AccessRevoked => "DOME_EVACUATION_ACCESS_REVOKED",
+            Self::Blocked => "DOME_EVACUATION_BLOCKED",
+            Self::TopologyInvalid => "DOME_EVACUATION_TOPOLOGY_INVALID",
+            Self::UserRequested => "DOME_EVACUATION_USER_REQUESTED",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[serde(rename_all = "snake_case")]
+pub enum DomeEvacuationPhaseV1 {
+    Idle,
+    Selecting,
+    Admitting,
+    Confirming,
+    CleaningSource,
+    Complete,
+    NoCandidate,
+    Failed,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[serde(rename_all = "snake_case")]
+pub enum DomeEvacuationCandidateKindV1 {
+    EstablishedTransition,
+    ActiveAdjacent,
+    OwnHosted,
+    LastVisited,
+    ChannelEntry,
+    StableFallback,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[serde(deny_unknown_fields)]
+pub struct DomeEvacuationCandidateV1 {
+    pub instance_id: String,
+    pub kind: DomeEvacuationCandidateKindV1,
+    pub available: bool,
+}
+
+pub fn order_dome_evacuation_candidates(
+    current_instance_id: &str,
+    candidates: &[DomeEvacuationCandidateV1],
+) -> Vec<DomeEvacuationCandidateV1> {
+    let mut ordered = candidates
+        .iter()
+        .filter(|candidate| candidate.available && candidate.instance_id != current_instance_id)
+        .cloned()
+        .collect::<Vec<_>>();
+    ordered.sort_by(|left, right| {
+        left.kind
+            .cmp(&right.kind)
+            .then_with(|| left.instance_id.cmp(&right.instance_id))
+    });
+    let mut seen_instance_ids = BTreeSet::new();
+    ordered.retain(|candidate| seen_instance_ids.insert(candidate.instance_id.clone()));
+    ordered
+}

--- a/crates/core/src/dome_transition.rs
+++ b/crates/core/src/dome_transition.rs
@@ -47,6 +47,9 @@ impl DomeTransitionDenialReasonV1 {
 #[serde(rename_all = "snake_case")]
 pub enum DomeBoundaryStateV1 {
     Closed,
+    Offline,
+    Draining,
+    Blocked,
     Loading,
     Ready,
     Denied,

--- a/crates/core/src/envelope.rs
+++ b/crates/core/src/envelope.rs
@@ -55,6 +55,11 @@ pub enum GossipHint {
         room_id: String,
         event: Box<KukuriEnvelope>,
     },
+    DomeHostHeartbeat {
+        topic_id: TopicId,
+        instance_id: String,
+        heartbeat: Box<crate::SignedDomeHostHeartbeatV1>,
+    },
     DirectMessageFrame {
         topic_id: TopicId,
         dm_id: String,

--- a/crates/core/src/game.rs
+++ b/crates/core/src/game.rs
@@ -93,7 +93,7 @@ pub enum MetaversePrimitive {
     Sphere,
 }
 
-pub const METAVERSE_WORLD_VERSION: u64 = 6;
+pub const METAVERSE_WORLD_VERSION: u64 = 7;
 pub const FIXED_DOME_SPEC_ID: &str = "fixed_dome_v1";
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -4,6 +4,7 @@ mod dome_connections;
 mod dome_envelopes;
 mod dome_hosting;
 mod dome_layout;
+mod dome_recovery;
 mod dome_transition;
 mod envelope;
 mod game;
@@ -33,15 +34,16 @@ pub use direct_messages::{
     encrypt_direct_message_attachment, encrypt_direct_message_frame,
 };
 pub use dome_connections::{
-    DOME_CONNECTION_MAX_OPEN_OUTBOUND, DOME_CONNECTION_MAX_PER_PEER_SLOT,
-    DOME_CONNECTION_MAX_RECEIVER_QUEUE, DomeComponentTopologyV1, DomeConnectionAgreementV1,
-    DomeConnectionEndpointV1, DomeConnectionProposalV1, DomeConnectionRecordV1,
-    DomeConnectionStatusV1, DomeConnectionTerminalReasonV1, DomeProposalDerivedStatusV1,
-    DomeProposalSelectionV1, DomeRejectedConnectionV1, DomeTopologyResolutionV1, DomeTopologyV1,
-    SignedDomeConnectionAgreementV1, build_dome_connection_agreement_envelope,
-    build_dome_connection_proposal_envelope, build_dome_connection_selection_envelope,
-    build_signed_dome_connection_agreement, derive_dome_proposal_status, opposite_dome_direction,
-    resolve_dome_topology, resolve_dome_topology_candidates, validate_dome_connection_agreement,
+    DOME_CONNECTION_DRAIN_MILLIS, DOME_CONNECTION_MAX_OPEN_OUTBOUND,
+    DOME_CONNECTION_MAX_PER_PEER_SLOT, DOME_CONNECTION_MAX_RECEIVER_QUEUE, DomeComponentTopologyV1,
+    DomeConnectionAgreementV1, DomeConnectionEndpointV1, DomeConnectionProposalV1,
+    DomeConnectionRecordV1, DomeConnectionStatusV1, DomeConnectionTerminalReasonV1,
+    DomeProposalDerivedStatusV1, DomeProposalSelectionV1, DomeRejectedConnectionV1,
+    DomeTopologyResolutionV1, DomeTopologyV1, SignedDomeConnectionAgreementV1,
+    build_dome_connection_agreement_envelope, build_dome_connection_proposal_envelope,
+    build_dome_connection_selection_envelope, build_signed_dome_connection_agreement,
+    derive_dome_proposal_status, opposite_dome_direction, resolve_dome_topology,
+    resolve_dome_topology_candidates, validate_dome_connection_agreement,
     validate_dome_connection_proposal, validate_dome_connection_record,
     validate_dome_connection_selection, verify_signed_dome_connection_agreement,
 };
@@ -49,25 +51,31 @@ pub use dome_envelopes::{
     build_dome_instance_envelope, build_dome_move_envelope, build_dome_preset_envelope,
 };
 pub use dome_hosting::{
-    DOME_HOSTING_HEARTBEAT_GRACE_MILLIS, DOME_HOSTING_MAX_LEASE_MILLIS,
-    DOME_SNAPSHOT_RING_CAPACITY, DomeHostHeartbeatV1, DomeHostTargetV1, DomeHostingAcceptanceV1,
-    DomeHostingActivationV1, DomeHostingCloseV1, DomeHostingLeaseV1, DomeHostingRecordV1,
-    DomeHostingStateKindV1, DomeHostingStateV1, DomePhysicsBodyKindV1, DomePhysicsBodyV1,
-    DomePhysicsSnapshotV1, DomeSessionInputKindV1, DomeSessionInputV1, SignedDomeHostHeartbeatV1,
-    SignedDomeHostingAcceptanceV1, SignedDomeHostingActivationV1, SignedDomeHostingCloseV1,
-    SignedDomeHostingLeaseV1, SignedDomePhysicsSnapshotV1, SignedDomeSessionInputV1,
-    accept_dome_hosting_lease, activate_dome_hosting_lease, build_signed_dome_host_heartbeat,
-    build_signed_dome_hosting_lease, build_signed_dome_physics_snapshot,
-    build_signed_dome_session_input, close_dome_hosting_lease, dome_hosting_lease_digest,
-    resolve_dome_hosting_state, validate_dome_hosting_lease, verify_signed_dome_host_heartbeat,
-    verify_signed_dome_hosting_lease, verify_signed_dome_physics_snapshot,
-    verify_signed_dome_session_input,
+    DOME_HOST_HEARTBEAT_INTERVAL_MILLIS, DOME_HOSTING_HEARTBEAT_GRACE_MILLIS,
+    DOME_HOSTING_MAX_LEASE_MILLIS, DOME_PARTICIPANT_KEEPALIVE_INTERVAL_MILLIS,
+    DOME_PARTICIPANT_TIMEOUT_MILLIS, DOME_SNAPSHOT_RING_CAPACITY, DomeHostHeartbeatV1,
+    DomeHostTargetV1, DomeHostingAcceptanceV1, DomeHostingActivationV1, DomeHostingCloseV1,
+    DomeHostingLeaseV1, DomeHostingRecordV1, DomeHostingStateKindV1, DomeHostingStateV1,
+    DomePhysicsBodyKindV1, DomePhysicsBodyV1, DomePhysicsSnapshotV1, DomeSessionInputKindV1,
+    DomeSessionInputV1, SignedDomeHostHeartbeatV1, SignedDomeHostingAcceptanceV1,
+    SignedDomeHostingActivationV1, SignedDomeHostingCloseV1, SignedDomeHostingLeaseV1,
+    SignedDomePhysicsSnapshotV1, SignedDomeSessionInputV1, accept_dome_hosting_lease,
+    activate_dome_hosting_lease, build_signed_dome_host_heartbeat, build_signed_dome_hosting_lease,
+    build_signed_dome_physics_snapshot, build_signed_dome_session_input, close_dome_hosting_lease,
+    dome_hosting_lease_digest, resolve_dome_hosting_state, validate_dome_hosting_lease,
+    verify_signed_dome_host_heartbeat, verify_signed_dome_hosting_lease,
+    verify_signed_dome_physics_snapshot, verify_signed_dome_session_input,
 };
 pub use dome_layout::{
     DOME_LAYOUT_COMMIT_MIN_INTERVAL_MILLIS, DomeLayoutCandidateV1, DomeLayoutCommitV1,
     SignedDomeLayoutCandidateV1, SignedDomeLayoutCommitV1, build_signed_dome_layout_candidate,
     build_signed_dome_layout_commit, dome_layout_candidate_digest,
     verify_signed_dome_layout_candidate, verify_signed_dome_layout_commit,
+};
+pub use dome_recovery::{
+    DomeEvacuationCandidateKindV1, DomeEvacuationCandidateV1, DomeEvacuationPhaseV1,
+    DomeEvacuationReasonV1, DomeHostLivenessV1, order_dome_evacuation_candidates,
+    resolve_dome_host_liveness,
 };
 pub use dome_transition::{
     DOME_ACCESS_PROOF_TTL_MILLIS, DOME_TRANSITION_CROSSING_HYSTERESIS_CM,

--- a/crates/core/src/tests/dome_connections.rs
+++ b/crates/core/src/tests/dome_connections.rs
@@ -66,6 +66,7 @@ fn active(agreement: DomeConnectionAgreementV1) -> DomeConnectionRecordV1 {
         lifecycle_generation: 1,
         lifecycle_actor: None,
         lifecycle_reason: None,
+        lifecycle_deadline_at: None,
     }
 }
 
@@ -86,6 +87,47 @@ fn dome_directions_have_fixed_opposites() {
     assert_eq!(
         opposite_dome_direction(DomeDirection::West),
         DomeDirection::East
+    );
+}
+
+#[test]
+fn draining_requires_deadline_and_keeps_topology_until_terminal_revoke() {
+    let proposer_keys = generate_keys();
+    let receiver_keys = generate_keys();
+    let proposer = instance(&proposer_keys, "dome-a");
+    let receiver = instance(&receiver_keys, "dome-b");
+    let mut connection = active(agreement(
+        "connection-ab",
+        "proposal-ab",
+        &proposer,
+        DomeDirection::East,
+        &receiver,
+        1,
+    ));
+    connection.status = DomeConnectionStatusV1::Draining;
+    connection.lifecycle_generation = 2;
+    connection.lifecycle_actor = Some(proposer.owner_pubkey.clone());
+    connection.lifecycle_reason = Some(DomeConnectionTerminalReasonV1::OwnerRevoked);
+    connection.lifecycle_deadline_at = Some(4_000);
+    validate_dome_connection_record(&connection).unwrap();
+    assert_eq!(
+        resolve_dome_topology(&[proposer.clone(), receiver.clone()], &[connection.clone()])
+            .unwrap()
+            .components
+            .len(),
+        1
+    );
+
+    connection.lifecycle_deadline_at = None;
+    assert!(validate_dome_connection_record(&connection).is_err());
+    connection.status = DomeConnectionStatusV1::Revoked;
+    validate_dome_connection_record(&connection).unwrap();
+    assert_eq!(
+        resolve_dome_topology(&[proposer, receiver], &[connection])
+            .unwrap()
+            .components
+            .len(),
+        2
     );
 }
 

--- a/crates/core/src/tests/dome_hosting.rs
+++ b/crates/core/src/tests/dome_hosting.rs
@@ -1,12 +1,13 @@
 use crate::{
-    DomeHostTargetV1, DomeHostingLeaseV1, DomeHostingRecordV1, DomeHostingStateKindV1,
-    DomeInstanceManifestV1, DomeInstanceStatusV1, DomeLayoutCandidateV1, DomeLayoutCommitV1,
-    DomePhysicsSnapshotV1, DomePresetRefV1, KukuriKeys, MetaverseRoomSpawnV1, SpatialContextV1,
-    TopicId, accept_dome_hosting_lease, activate_dome_hosting_lease,
-    build_signed_dome_hosting_lease, build_signed_dome_layout_candidate,
-    build_signed_dome_layout_commit, build_signed_dome_physics_snapshot, close_dome_hosting_lease,
-    dome_layout_candidate_digest, resolve_dome_hosting_state, verify_signed_dome_layout_commit,
-    verify_signed_dome_physics_snapshot,
+    DomeHostHeartbeatV1, DomeHostTargetV1, DomeHostingLeaseV1, DomeHostingRecordV1,
+    DomeHostingStateKindV1, DomeInstanceManifestV1, DomeInstanceStatusV1, DomeLayoutCandidateV1,
+    DomeLayoutCommitV1, DomePhysicsSnapshotV1, DomePresetRefV1, KukuriKeys, MetaverseRoomSpawnV1,
+    SpatialContextV1, TopicId, accept_dome_hosting_lease, activate_dome_hosting_lease,
+    build_signed_dome_host_heartbeat, build_signed_dome_hosting_lease,
+    build_signed_dome_layout_candidate, build_signed_dome_layout_commit,
+    build_signed_dome_physics_snapshot, close_dome_hosting_lease, dome_layout_candidate_digest,
+    resolve_dome_hosting_state, verify_signed_dome_host_heartbeat,
+    verify_signed_dome_layout_commit, verify_signed_dome_physics_snapshot,
 };
 
 fn instance(owner: &KukuriKeys) -> DomeInstanceManifestV1 {
@@ -38,6 +39,34 @@ fn instance(owner: &KukuriKeys) -> DomeInstanceManifestV1 {
         chat_history: Vec::new(),
         updated_at: 100,
     }
+}
+
+#[test]
+fn heartbeat_signature_is_bound_to_host_lease_epoch_session_and_sequence() {
+    let owner = KukuriKeys::generate();
+    let host = KukuriKeys::generate();
+    let lease = lease(&owner, &host, 1);
+    let signed = build_signed_dome_host_heartbeat(
+        &host,
+        &lease,
+        DomeHostHeartbeatV1 {
+            instance_id: lease.instance_id.clone(),
+            instance_generation: lease.instance_generation,
+            lease_epoch: lease.epoch,
+            session_id: "session-1".into(),
+            host_pubkey: host.public_key(),
+            participants: 2,
+            sleeping: false,
+            sequence: 7,
+            sent_at: 2_500,
+        },
+    )
+    .unwrap();
+    verify_signed_dome_host_heartbeat(&signed, &lease, "session-1").unwrap();
+
+    let mut tampered = signed;
+    tampered.heartbeat.sequence += 1;
+    assert!(verify_signed_dome_host_heartbeat(&tampered, &lease, "session-1").is_err());
 }
 
 fn lease(owner: &KukuriKeys, host: &KukuriKeys, epoch: u64) -> DomeHostingLeaseV1 {

--- a/crates/core/src/tests/dome_recovery.rs
+++ b/crates/core/src/tests/dome_recovery.rs
@@ -1,0 +1,95 @@
+use crate::*;
+
+#[test]
+fn host_liveness_uses_five_second_offline_and_fifteen_second_close_boundaries() {
+    assert_eq!(
+        resolve_dome_host_liveness(Some(1_000), 6_000),
+        DomeHostLivenessV1::Online
+    );
+    assert_eq!(
+        resolve_dome_host_liveness(Some(1_000), 6_001),
+        DomeHostLivenessV1::OfflineGrace
+    );
+    assert_eq!(
+        resolve_dome_host_liveness(Some(1_000), 16_000),
+        DomeHostLivenessV1::OfflineGrace
+    );
+    assert_eq!(
+        resolve_dome_host_liveness(Some(1_000), 16_001),
+        DomeHostLivenessV1::Closed
+    );
+    assert_eq!(
+        resolve_dome_host_liveness(None, 1_000),
+        DomeHostLivenessV1::OfflineGrace
+    );
+}
+
+#[test]
+fn evacuation_candidates_are_safe_ranked_stable_and_exclude_current() {
+    let candidates = vec![
+        DomeEvacuationCandidateV1 {
+            instance_id: "current".into(),
+            kind: DomeEvacuationCandidateKindV1::OwnHosted,
+            available: true,
+        },
+        DomeEvacuationCandidateV1 {
+            instance_id: "fallback-b".into(),
+            kind: DomeEvacuationCandidateKindV1::StableFallback,
+            available: true,
+        },
+        DomeEvacuationCandidateV1 {
+            instance_id: "adjacent".into(),
+            kind: DomeEvacuationCandidateKindV1::ActiveAdjacent,
+            available: true,
+        },
+        DomeEvacuationCandidateV1 {
+            instance_id: "adjacent".into(),
+            kind: DomeEvacuationCandidateKindV1::LastVisited,
+            available: true,
+        },
+        DomeEvacuationCandidateV1 {
+            instance_id: "unavailable".into(),
+            kind: DomeEvacuationCandidateKindV1::EstablishedTransition,
+            available: false,
+        },
+        DomeEvacuationCandidateV1 {
+            instance_id: "home".into(),
+            kind: DomeEvacuationCandidateKindV1::OwnHosted,
+            available: true,
+        },
+        DomeEvacuationCandidateV1 {
+            instance_id: "fallback-a".into(),
+            kind: DomeEvacuationCandidateKindV1::StableFallback,
+            available: true,
+        },
+    ];
+    let ids = order_dome_evacuation_candidates("current", &candidates)
+        .into_iter()
+        .map(|candidate| candidate.instance_id)
+        .collect::<Vec<_>>();
+    assert_eq!(ids, vec!["adjacent", "home", "fallback-a", "fallback-b"]);
+}
+
+#[test]
+fn recovery_reason_codes_are_stable() {
+    assert_eq!(
+        DomeEvacuationReasonV1::HostOffline.code(),
+        "DOME_EVACUATION_HOST_OFFLINE"
+    );
+    assert_eq!(
+        DomeEvacuationReasonV1::AccessRevoked.code(),
+        "DOME_EVACUATION_ACCESS_REVOKED"
+    );
+    assert_eq!(
+        DomeEvacuationReasonV1::Blocked.code(),
+        "DOME_EVACUATION_BLOCKED"
+    );
+    assert_eq!(
+        DomeEvacuationReasonV1::TopologyInvalid.code(),
+        "DOME_EVACUATION_TOPOLOGY_INVALID"
+    );
+    assert_eq!(
+        DomeEvacuationReasonV1::UserRequested.code(),
+        "DOME_EVACUATION_USER_REQUESTED"
+    );
+}

--- a/crates/core/src/tests/mod.rs
+++ b/crates/core/src/tests/mod.rs
@@ -2,6 +2,7 @@ mod derivation_golden;
 mod direct_messages;
 mod dome_connections;
 mod dome_hosting;
+mod dome_recovery;
 mod envelope;
 mod media_live_game;
 mod metaverse_resource_budget;

--- a/crates/desktop-runtime/src/runtime/mod.rs
+++ b/crates/desktop-runtime/src/runtime/mod.rs
@@ -34,7 +34,7 @@ use kukuri_core::{
     DomeInstanceManifestV1, DomePresetManifestV1, FriendOnlyGrantPreview, FriendPlusSharePreview,
     KukuriKeys, PrivateChannelInvitePreview, Profile, SignedDomeHostingActivationV1,
     SignedDomeHostingCloseV1, SignedDomeHostingLeaseV1, TopicId, build_signed_dome_session_input,
-    verify_signed_dome_physics_snapshot,
+    verify_signed_dome_host_heartbeat, verify_signed_dome_physics_snapshot,
 };
 use kukuri_docs_sync::{DocQuery, DocsSync};
 use kukuri_store::SqliteStore;
@@ -109,6 +109,8 @@ pub struct DesktopRuntime {
     pub(crate) discovery_config: Arc<Mutex<DiscoveryConfig>>,
     pub(crate) community_node_config: Arc<Mutex<CommunityNodeConfig>>,
     pub(crate) community_node_sessions: Arc<Mutex<HashMap<String, CommunityNodeSessionState>>>,
+    pub(crate) community_node_dome_heartbeats:
+        Arc<Mutex<HashMap<String, kukuri_core::SignedDomeHostHeartbeatV1>>>,
     pub(crate) community_node_rendezvous_seed_peers: Arc<Mutex<Vec<kukuri_transport::SeedPeer>>>,
     pub(crate) community_node_session_guard: Arc<Mutex<()>>,
     pub(crate) community_node_reconnect_state: Arc<Mutex<CommunityNodeReconnectState>>,
@@ -343,6 +345,7 @@ impl DesktopRuntime {
             discovery_config: Arc::new(Mutex::new(discovery_config)),
             community_node_config: Arc::new(Mutex::new(community_node_config)),
             community_node_sessions: Arc::new(Mutex::new(HashMap::new())),
+            community_node_dome_heartbeats: Arc::new(Mutex::new(HashMap::new())),
             community_node_rendezvous_seed_peers: Arc::new(Mutex::new(Vec::new())),
             community_node_session_guard: Arc::new(Mutex::new(())),
             community_node_reconnect_state: Arc::new(Mutex::new(

--- a/crates/desktop-runtime/src/runtime/private_channels_game_api.rs
+++ b/crates/desktop-runtime/src/runtime/private_channels_game_api.rs
@@ -235,11 +235,84 @@ impl DesktopRuntime {
         {
             let status = self
                 .get_dome_hosting_status_from_community_node(api_base_url, &request.instance_id)
-                .await?;
-            view.state.kind = status.state;
-            view.state.session_id = status.session_id;
-            view.participants = status.participants;
-            view.sleeping = status.sleeping;
+                .await;
+            if let Ok(status) = status {
+                let now = chrono::Utc::now().timestamp_millis();
+                if let (Some(lease), Some(session_id), Some(heartbeat)) = (
+                    view.lease.as_ref(),
+                    status.session_id.as_deref(),
+                    status.signed_heartbeat.as_ref(),
+                ) {
+                    verify_signed_dome_host_heartbeat(heartbeat, lease, session_id)?;
+                    if heartbeat.heartbeat.sent_at > now.saturating_add(5_000) {
+                        anyhow::bail!("Community Node Dome heartbeat is from the future");
+                    }
+                    let mut heartbeats = self.community_node_dome_heartbeats.lock().await;
+                    let replace = heartbeats.get(&request.instance_id).is_none_or(|current| {
+                        heartbeat.heartbeat.sequence > current.heartbeat.sequence
+                    });
+                    if replace {
+                        heartbeats.insert(request.instance_id.clone(), heartbeat.clone());
+                    }
+                    view.state.last_heartbeat_at = Some(heartbeat.heartbeat.sent_at);
+                    view.state.reason = None;
+                    view.state.kind = match kukuri_core::resolve_dome_host_liveness(
+                        Some(heartbeat.heartbeat.sent_at),
+                        now,
+                    ) {
+                        kukuri_core::DomeHostLivenessV1::Online => status.state,
+                        kukuri_core::DomeHostLivenessV1::OfflineGrace => {
+                            kukuri_core::DomeHostingStateKindV1::GracePeriod
+                        }
+                        kukuri_core::DomeHostLivenessV1::Closed => {
+                            kukuri_core::DomeHostingStateKindV1::Closed
+                        }
+                    };
+                } else {
+                    view.state.kind = match status.state {
+                        kukuri_core::DomeHostingStateKindV1::OwnerHosted
+                        | kukuri_core::DomeHostingStateKindV1::CommunityNodeHosted => {
+                            view.state.reason = Some("heartbeat_missing".into());
+                            kukuri_core::DomeHostingStateKindV1::GracePeriod
+                        }
+                        state => state,
+                    };
+                }
+                view.state.session_id = status.session_id;
+                view.participants = status.participants;
+                view.sleeping = status.sleeping;
+            } else if let Some(heartbeat) = self
+                .community_node_dome_heartbeats
+                .lock()
+                .await
+                .get(&request.instance_id)
+                .cloned()
+            {
+                let liveness = kukuri_core::resolve_dome_host_liveness(
+                    Some(heartbeat.heartbeat.sent_at),
+                    chrono::Utc::now().timestamp_millis(),
+                );
+                view.state.kind = match liveness {
+                    kukuri_core::DomeHostLivenessV1::Online => view.state.kind,
+                    kukuri_core::DomeHostLivenessV1::OfflineGrace => {
+                        kukuri_core::DomeHostingStateKindV1::GracePeriod
+                    }
+                    kukuri_core::DomeHostLivenessV1::Closed => {
+                        kukuri_core::DomeHostingStateKindV1::Closed
+                    }
+                };
+                view.state.last_heartbeat_at = Some(heartbeat.heartbeat.sent_at);
+                view.state.reason = Some(if liveness == kukuri_core::DomeHostLivenessV1::Closed {
+                    "heartbeat_timeout".into()
+                } else {
+                    "heartbeat_missing".into()
+                });
+                view.participants = heartbeat.heartbeat.participants;
+                view.sleeping = heartbeat.heartbeat.sleeping;
+            } else {
+                view.state.kind = kukuri_core::DomeHostingStateKindV1::GracePeriod;
+                view.state.reason = Some("heartbeat_missing".into());
+            }
         }
         Ok(view)
     }
@@ -384,6 +457,7 @@ impl DesktopRuntime {
                 let access_proof = if matches!(
                     &request.input,
                     kukuri_core::DomeSessionInputKindV1::Join { .. }
+                        | kukuri_core::DomeSessionInputKindV1::KeepAlive
                 ) {
                     Some(
                         self.app_service

--- a/crates/metaverse-host/src/lib.rs
+++ b/crates/metaverse-host/src/lib.rs
@@ -1,4 +1,5 @@
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use anyhow::{Context, Result, bail};
 use kukuri_core::{
@@ -75,6 +76,7 @@ pub struct DomeSessionRuntime {
     transition_entries: BTreeMap<String, DomeDirection>,
     seated_on: BTreeMap<String, String>,
     last_input_sequence: BTreeMap<String, u64>,
+    participant_last_seen_at: BTreeMap<String, i64>,
     bodies_by_id: BTreeMap<String, RuntimeBody>,
     pipeline: PhysicsPipeline,
     integration_parameters: IntegrationParameters,
@@ -88,6 +90,7 @@ pub struct DomeSessionRuntime {
     ccd_solver: CCDSolver,
     tick: u64,
     snapshot_sequence: u64,
+    heartbeat_sequence: AtomicU64,
     snapshot_ring: VecDeque<SignedDomePhysicsSnapshotV1>,
     last_simulated_at: i64,
     budget: MetaverseResourceBudgetConfig,
@@ -211,6 +214,7 @@ impl DomeSessionRuntime {
             transition_entries: BTreeMap::new(),
             seated_on: BTreeMap::new(),
             last_input_sequence: BTreeMap::new(),
+            participant_last_seen_at: BTreeMap::new(),
             bodies_by_id: BTreeMap::new(),
             pipeline: PhysicsPipeline::new(),
             integration_parameters: IntegrationParameters {
@@ -227,6 +231,7 @@ impl DomeSessionRuntime {
             ccd_solver: CCDSolver::new(),
             tick: 0,
             snapshot_sequence: 0,
+            heartbeat_sequence: AtomicU64::new(0),
             snapshot_ring: VecDeque::with_capacity(DOME_SNAPSHOT_RING_CAPACITY),
             last_simulated_at: started_at,
             budget,
@@ -340,6 +345,13 @@ impl DomeSessionRuntime {
             return Err(error);
         }
         self.apply_input(&signed.input)?;
+        let participant_id = signed.input.participant_pubkey.as_str().to_string();
+        if matches!(signed.input.input, DomeSessionInputKindV1::Leave) {
+            self.participant_last_seen_at.remove(&participant_id);
+        } else if self.participants.contains(&participant_id) {
+            self.participant_last_seen_at
+                .insert(participant_id, now_millis);
+        }
         self.clamp_bodies_to_dome();
         Ok(())
     }
@@ -349,6 +361,7 @@ impl DomeSessionRuntime {
             bail!("Dome session clock cannot move backwards");
         }
         self.expire_guest_props(now_millis);
+        self.expire_stale_participants(now_millis);
         if self.participants.is_empty() {
             self.last_simulated_at = now_millis;
             return Ok(());
@@ -542,6 +555,10 @@ impl DomeSessionRuntime {
     }
 
     pub fn signed_heartbeat(&self, now_millis: i64) -> Result<SignedDomeHostHeartbeatV1> {
+        let sequence = self
+            .heartbeat_sequence
+            .fetch_add(1, Ordering::Relaxed)
+            .saturating_add(1);
         build_signed_dome_host_heartbeat(
             &self.host_keys,
             &self.lease.lease,
@@ -553,6 +570,7 @@ impl DomeSessionRuntime {
                 host_pubkey: self.host_keys.public_key(),
                 participants: self.participant_count().try_into().unwrap_or(u32::MAX),
                 sleeping: self.is_sleeping(),
+                sequence,
                 sent_at: now_millis,
             },
         )
@@ -587,6 +605,9 @@ impl DomeSessionRuntime {
                         runtime_body.grabbed_by = None;
                     }
                 }
+            }
+            DomeSessionInputKindV1::KeepAlive => {
+                self.require_participant(&participant_id)?;
             }
             DomeSessionInputKindV1::Move {
                 position,
@@ -703,6 +724,21 @@ impl DomeSessionRuntime {
             bail!("Dome session input requires a joined participant");
         }
         Ok(())
+    }
+
+    fn expire_stale_participants(&mut self, now_millis: i64) {
+        let stale = self
+            .participant_last_seen_at
+            .iter()
+            .filter(|(_, last_seen)| {
+                now_millis.saturating_sub(**last_seen)
+                    > kukuri_core::DOME_PARTICIPANT_TIMEOUT_MILLIS
+            })
+            .map(|(participant_id, _)| participant_id.clone())
+            .collect::<Vec<_>>();
+        for participant_id in stale {
+            self.evict_participant(&kukuri_core::Pubkey::from(participant_id));
+        }
     }
 
     fn require_owner(&self, input: &DomeSessionInputV1) -> Result<()> {

--- a/crates/metaverse-host/src/tests.rs
+++ b/crates/metaverse-host/src/tests.rs
@@ -98,6 +98,53 @@ fn signed_input(
 }
 
 #[test]
+fn keepalive_preserves_participant_and_timeout_evicts_all_session_state() {
+    let (owner, lease, instance, preset) = fixture();
+    let mut runtime = DomeSessionRuntime::start_with_session_id(
+        lease,
+        owner,
+        &instance,
+        &preset,
+        "session-1",
+        1_000,
+    )
+    .unwrap();
+    let participant = KukuriKeys::generate();
+    runtime
+        .apply_signed_input_at(
+            &signed_input(
+                &participant,
+                1,
+                DomeSessionInputKindV1::Join {
+                    avatar_collider: None,
+                },
+            ),
+            1_001,
+        )
+        .unwrap();
+    runtime
+        .apply_signed_input_at(
+            &signed_input(&participant, 2, DomeSessionInputKindV1::KeepAlive),
+            20_000,
+        )
+        .unwrap();
+
+    runtime.advance_to(50_000).unwrap();
+    assert_eq!(runtime.participant_count(), 1);
+    runtime.advance_to(50_001).unwrap();
+    assert_eq!(runtime.participant_count(), 0);
+    assert!(
+        runtime
+            .signed_snapshot(50_001)
+            .unwrap()
+            .snapshot
+            .bodies
+            .iter()
+            .all(|body| body.entity_id != format!("avatar:{}", participant.public_key().as_str()))
+    );
+}
+
+#[test]
 fn join_uses_default_spawn_then_deterministically_evacuates_from_overlap() {
     let (owner, lease, instance, mut preset) = fixture();
     preset.dome.customization.persistent_props = vec![MetaversePersistentPropV1 {
@@ -625,6 +672,27 @@ fn joined_participant_wakes_physics_and_stale_input_is_rejected() {
     assert!(runtime.apply_signed_input(&join).is_err());
     runtime.advance_to(1_100).unwrap();
     assert!(runtime.signed_snapshot(1_200).unwrap().snapshot.sequence > 0);
+}
+
+#[test]
+fn heartbeat_sequence_is_monotonic_even_when_the_clock_does_not_advance() {
+    let (owner, lease, instance, preset) = fixture();
+    let runtime = DomeSessionRuntime::start_with_session_id(
+        lease,
+        owner,
+        &instance,
+        &preset,
+        "session-1",
+        1_000,
+    )
+    .unwrap();
+
+    let first = runtime.signed_heartbeat(1_000).unwrap();
+    let second = runtime.signed_heartbeat(1_000).unwrap();
+
+    assert_eq!(first.heartbeat.sequence, 1);
+    assert_eq!(second.heartbeat.sequence, 2);
+    assert_eq!(second.heartbeat.sent_at, first.heartbeat.sent_at);
 }
 
 #[test]

--- a/crates/metaverse-host/src/transition.rs
+++ b/crates/metaverse-host/src/transition.rs
@@ -38,12 +38,29 @@ impl DomeSessionRuntime {
         before.saturating_sub(self.transition_reservations.len())
     }
 
+    pub fn drain_connection(&mut self, connection_id: &str) -> usize {
+        let participants = self
+            .transition_reservations
+            .values()
+            .filter(|ticket| ticket.request.connection_id == connection_id)
+            .map(|ticket| ticket.request.participant_pubkey.as_str().to_string())
+            .collect::<Vec<_>>();
+        let before = self.transition_reservations.len();
+        self.transition_reservations
+            .retain(|_, ticket| ticket.request.connection_id != connection_id);
+        for participant in participants {
+            self.prepared_exits.remove(&participant);
+        }
+        before.saturating_sub(self.transition_reservations.len())
+    }
+
     pub fn evict_participant(&mut self, participant_pubkey: &kukuri_core::Pubkey) -> bool {
         let participant_id = participant_pubkey.as_str();
         self.revoke_transition_access(participant_pubkey, None);
         self.transition_entries.remove(participant_id);
         self.seated_on.remove(participant_id);
         self.last_input_sequence.remove(participant_id);
+        self.participant_last_seen_at.remove(participant_id);
         self.player_budgets.remove(participant_id);
         self.remove_body(&format!("avatar:{participant_id}"));
         for runtime_body in self.bodies_by_id.values_mut() {
@@ -149,6 +166,8 @@ impl DomeSessionRuntime {
         let participant_id = ticket.request.participant_pubkey.as_str().to_string();
         self.ensure_avatar(&participant_id, None)?;
         self.participants.insert(participant_id.clone());
+        self.participant_last_seen_at
+            .insert(participant_id.clone(), now_millis);
         self.set_avatar_transform(&participant_id, position, rotation)?;
         self.transition_entries.insert(
             participant_id.clone(),
@@ -244,6 +263,7 @@ impl DomeSessionRuntime {
             bail!("DOME_TRANSITION_INVALID_TICKET");
         }
         self.participants.remove(participant_id);
+        self.participant_last_seen_at.remove(participant_id);
         self.seated_on.remove(participant_id);
         self.remove_body(&format!("avatar:{participant_id}"));
         Ok(())

--- a/docs/README.md
+++ b/docs/README.md
@@ -39,6 +39,7 @@
 - Dome prop、layout commit、manifest/asset保持: `docs/adr/0040-dome-prop-layout-retention.md`
 - Metaverse resource budget: `docs/adr/0041-metaverse-resource-budget.md`
 - Spatial Context entryとauthoritative safe spawn: `docs/adr/0044-spatial-context-entry-safe-spawn.md`
+- Dome offline、Connection draining、Return Home: `docs/adr/0045-dome-offline-draining-return-home.md`
 - community node production rollout / live media verification / recovery: `docs/runbooks/community-node-production-rollout.md`
 - community node GCP Terraform デプロイ（deployment profile: low-cost / managed-db / ha）: `docs/runbooks/community-node-gcp-terraform.md`（実装は `infra/terraform/`）
 - community node 権利侵害申出の受付・審査・送信防止: `docs/runbooks/community-node-rights-infringement-requests.md`

--- a/docs/adr/0037-dome-connection-topology.md
+++ b/docs/adr/0037-dome-connection-topology.md
@@ -69,6 +69,8 @@ active agreementを決定論的な因果順とdigest順で処理し、次だけ�
 
 ## Consequences
 
+Issue #797の通常解除、draining deadline、安全上の即時terminal化は[ADR-0045](0045-dome-offline-draining-return-home.md)で追加定義する。
+
 - proposalの待機とConnectionの事実をDome assetから独立して保持できる。
 - 全peerは同じ署名済みrecord集合から同じforestと相対座標を得られる。
 - seamless transitionはこのtopology viewを利用できるが、scene描画・prefetch・physics handoffはIssue #790以降の責務である。

--- a/docs/adr/0038-dome-hosting-lease-session-lifecycle.md
+++ b/docs/adr/0038-dome-hosting-lease-session-lifecycle.md
@@ -75,6 +75,8 @@ Postgres は Dome ごとに active assignment を最大一件に制限する。N
 
 ## Consequences
 
+Issue #797の5秒heartbeat、15秒offline grace、30秒participant timeoutは[ADR-0045](0045-dome-offline-draining-return-home.md)で追加定義する。
+
 - ownerの明示操作なしにavailabilityを優先する自動failoverは行わない。
 - transfer中またはsplit-brain検出時は一時的にDomeへ入れなくても、二重authorityより安全側を選ぶ。
 - metaverseは実験機能のため、旧peer-authoritative wire contractとの互換decodeやmigrationは提供しない。

--- a/docs/adr/0042-seamless-dome-transition.md
+++ b/docs/adr/0042-seamless-dome-transition.md
@@ -43,6 +43,8 @@ ActiveなDome Connectionは恒常的なportalではなく、avatarが隣のDome�
 
 ## Consequences
 
+Issue #797のdraining中の新規transition停止と退避時のsource/target確定順は[ADR-0045](0045-dome-offline-draining-return-home.md)で追加定義する。
+
 - Seamlessに見えてもphysics authorityは中心線で明示的に切り替わり、cross-Dome prop simulationを導入しない。
 - Host不在、access不明、block、満員、asset失敗、stale topologyではavailabilityより整合性を優先して境界を閉じる。
 - Texture／materialは完全補間せず、隣接Dome表示と数値environment補間を優先する。

--- a/docs/adr/0043-dome-access-presence-spatial-audio.md
+++ b/docs/adr/0043-dome-access-presence-spatial-audio.md
@@ -41,6 +41,8 @@ Domeは独自のmember、role、moderatorを持たず、配置先のpublic topic
 
 ## Consequences
 
+Issue #797のparticipant keepalive access再検証、即時eviction、offline grace中のpresence/audio停止は[ADR-0045](0045-dome-offline-draining-return-home.md)で追加定義する。
+
 - Metaverse固有のmember/role/ban modelを追加せず、既存social graphとchannel policyの変更がDomeへ反映される。
 - Preview後のblock、leave、epoch rotationでもprepareが再判定するためTOCTOUで越境できない。
 - 実験機能のため旧Metaverse wire/configとの後方互換は提供しない。

--- a/docs/adr/0044-spatial-context-entry-safe-spawn.md
+++ b/docs/adr/0044-spatial-context-entry-safe-spawn.md
@@ -45,3 +45,4 @@ Spatial Contextを開いた時点では、複数のDomeが存在し、直前ま�
 - 優先Domeが利用不能でも、access不能な詳細やparticipant identityを公開せずに次候補へ進める。
 - Avatarはhostが参加と初期transformを同時に確定した後だけ見えるため、拒否時の一瞬表示とghost participantを避けられる。
 - Dome固有のmembership、role、moderatorは追加しない。
+- Issue #797のautomatic evacuationとReturn Homeは、このauthoritative Joinとsafe-spawnを再利用する。候補順とsource scene保持は[ADR-0045](0045-dome-offline-draining-return-home.md)で定義する。

--- a/docs/adr/0045-dome-offline-draining-return-home.md
+++ b/docs/adr/0045-dome-offline-draining-return-home.md
@@ -1,0 +1,46 @@
+# ADR-0045: Dome offline、Connection draining、Return Home
+
+- Status: Accepted
+- Date: 2026-08-29
+- Issue: #797
+
+## Context
+
+Connection recordが存在していても、host停止、通常解除、owner間block、participant access失効により通行できない場合がある。これらを一つの`closed`として扱うと、短い通信断でavatarを失う一方、安全上の失効に不要な猶予が生じる。
+
+## Decision
+
+### Hostとparticipant liveness
+
+- Owner-device hostはP2Pのephemeral hint、Community Node hostはstatus応答で、active lease epochとsessionへ束縛した署名済みheartbeatを5秒ごとに発行する。
+- Clientは署名、host identity、epoch、session、単調sequenceを検証し、最新値だけをmemoryに保持する。最終heartbeatから5秒超を`offline`、15秒まではgrace、15秒超を`closed/heartbeat_timeout`とする。
+- Grace中は最後のauthoritative snapshotとadmitted sceneを保持し、interaction、audio/presence送信、新規transitionを停止する。同じepoch/sessionが復帰すれば再Joinせず再開する。
+- Participantは5秒ごとの署名済み`KeepAlive`を送る。Community NodeではJoinと同じ短命access proofを再検証し、hostは30秒無入力のparticipantをavatar、grab、seat、reservationと共に除去する。
+
+### Connection lifecycle
+
+- Endpoint ownerによる通常解除はdurable `draining` recordと3秒のdeadlineを先にpublishする。drainingはtopology geometryには残すが、新規preview/prepare/通過は拒否し、未commit reservationをabortする。
+- Deadline後に`revoked/owner_revoked`へ確定し、残るrecordからsubcomponentを再計算する。分裂だけでは既存participantをevictしない。
+- `owners_blocked`、Instance detach/deleteなど安全またはauthority失効はdrainingを経由せず即時terminalとする。UnblockはConnectionを自動復元しない。
+
+### EvacuationとReturn Home
+
+- Automatic evacuationは成立済み遷移先、readyな隣接Dome、Issue #796のentry候補順でcurrentを除外して評価する。明示Return Homeはown-hostedを含むentry候補を先に評価する。
+- 候補ごとに既存のauthoritative `Join`とsafe-spawnを再利用し、target snapshotにlocal avatarが現れるまでsource sceneをcurrentとして保持する。確認後だけcurrentを切り替えてsource `Leave`をbest-effortで実行する。
+- 候補が無い場合はsceneを閉じてDome選択へ戻す。理由は`host_offline/access_revoked/blocked/topology_invalid/user_requested`、phaseはtransientな有界状態として扱う。
+- 境界は`offline`、`draining`、`blocked`、`closed`を色、barrier形状、文言、残り時間、操作可否で区別する。
+
+Metaverseは実験機能のため、変更したheartbeat、session input、Connection record、IPC schemaに旧形式との後方互換は設けない。
+
+## Feature Data Classification
+
+- Durable: Connection lifecycle status、generation、actor、reason、drain deadline。
+- Transient: host heartbeat、participant keepalive/access proof、recovery phase、candidate evaluation、最後のsnapshot。
+- Local-only: Issue #796のlast visited Dome。
+- Retention: heartbeatは最新1件、access proofは10秒、participant timeoutは30秒。raw input、proof本文、participant identityを診断logへ保存しない。
+
+## Consequences
+
+- 短いhost断ではavatar/sessionを保持しつつ、安全上の失効は猶予なく閉鎖できる。
+- 通常解除の3秒間は境界が閉じてもcomponent座標を保持し、terminal後だけ独立componentになる。
+- Community Node間failover、自動lease再割当、prop/seatのDome間退避は行わない。

--- a/docs/progress/2026-08-29-issue-797-dome-recovery.md
+++ b/docs/progress/2026-08-29-issue-797-dome-recovery.md
@@ -1,0 +1,19 @@
+# Issue #797 Dome recovery 実装記録
+
+## 実装した契約
+
+- 5秒host heartbeat、15秒offline grace、30秒participant timeoutをcore定数と決定的resolverへ集約した。
+- Owner hostは署名済みP2P heartbeat、Community Nodeは署名済みstatus heartbeatを返し、desktopは直前の検証済みheartbeatから通信失敗中のstateを導出する。
+- `KeepAlive`をsession inputへ追加し、Community Nodeではaccess proofを再検証する。timeout時はhost runtimeがparticipant関連stateを原子的に除去する。
+- 通常Connection解除は3秒のdurable `draining`を公開してからrevokeし、block等は即時terminal化する。draining中のreservationはcancelし、既存participantは維持する。
+- Desktopはoffline countdown中にsceneを保持して入力をfenceし、期限後はready隣接Domeからentry候補へ退避する。Return Homeはtarget avatarをhost snapshotで確認するまでsource sceneを保持する。
+- 境界はoffline、draining、blocked、closedを別stateとして描画し、HUD文言とReturn Home操作を追加した。
+
+## 検証
+
+- Core liveness/candidate ordering、metaverse-host keepalive/timeout、app-api draining/block、Desktop boundary/scene retention/keyboard操作を自動testで固定した。
+- Owner/CNは同じheartbeat署名検証、session input、safe-spawn primitiveを利用する。
+
+## Out of scope
+
+- Community Node failover、自動lease再割当、prop/seat/装着assetの退避。

--- a/docs/runbooks/dome-hosting.md
+++ b/docs/runbooks/dome-hosting.md
@@ -65,3 +65,14 @@ owner が online に戻っても自動 reclaim はしない。「この端末で
 Node 再起動時は有効な lease と保存済み manifest bundle を再検証し、新しい session id、manifest initial transform、velocity 0、grab/seatなし、guest propなしで開始する。
 
 `GracePeriod` または split-brain を観測した場合は、秘密情報を採取せず Context/Instance、lease epoch/digest、target host、session、last heartbeat、rejection reason を確認する。owner が同一 host を再開するか、より高い epoch で明示切替する。DB 行や replica record の手動書換えは行わない。
+
+## Offline、draining、Return Home
+
+- Hostは5秒ごとに署名済みheartbeatを発行する。5秒超の欠落では境界が`offline`となり、15秒まで同じsessionの復帰を待つ。期限後は`closed`となり、Clientはready隣接Domeからentry候補の順に安全退避する。
+- Grace中は最後のsceneを表示したままinput、presence/audio、新規transitionを停止する。同じlease epoch/sessionが復帰すれば再Joinは不要。
+- Participant keepaliveは5秒、host cleanupは30秒。Community Nodeでkeepaliveがaccess deniedになった場合は対象participantだけを退避させる。
+- 通常のConnection解除は3秒`draining`となる。新規通過は止まるが、terminal revokeまではcomponent座標を保持し、revoke後も既存participantを分裂だけで退去させない。
+- owner間block、Instance失効は即時`blocked/closed`。unblock後にConnectionは自動復元されない。
+- Return HomeはHUDの家アイコンから実行する。target admission確認前にsource sceneが消えないこと、候補なしではDome選択へ戻ることを確認する。
+
+診断ではContext/Instance、Connection ID、lease epoch/session、heartbeat age、recovery phase/reason、denial codeだけを採取し、heartbeat/access proof/raw input本文を保存しない。

--- a/docs/ui-reviews/2026-08-29-issue-797-dome-recovery.md
+++ b/docs/ui-reviews/2026-08-29-issue-797-dome-recovery.md
@@ -1,0 +1,16 @@
+# Issue #797 Dome recovery UI review
+
+Preview: Storybook `Extended/MetaverseRoomPanel` の `OfflineGraceBoundary`、`DrainingBoundary`、`BlockedBoundary`、`ClosedBoundary`。
+
+## Shneiderman eight golden rules
+
+- Consistency: 既存HUD toolbar、Button、warning/danger token、connection zone barrierを再利用した。
+- Shortcuts: host grace期限後はready隣接Domeを自動評価し、Return Homeは常時toolbarから実行できる。
+- Feedback: offline残り秒、evacuation target、closed/no-candidateを`aria-live` bannerで表示する。
+- Closure: target snapshotでlocal avatarを確認した時点だけsceneを切り替える。
+- Error prevention: offline/draining/blocked/closedではbarrierを閉じ、inputと新規transitionをfenceする。
+- Reversal: grace内の同一session復帰では再Joinせずcurrent sceneへ戻る。通常退出も従来通り残す。
+- User control: 自動退避とは別にReturn Homeと通常退出を選べる。
+- Memory load: 候補順序、last visit、safe spawn確認をsystemが扱い、利用者にInstance IDを要求しない。
+
+境界は色だけでなく、offlineのwireframe、draining/blockedの横bar、HUD文言と残り時間で区別する。Return Homeはaccessible nameとtooltipを持ち、keyboard focus順に含まれる。

--- a/harness/scenarios/desktop_smoke_metaverse_dome_recovery.yaml
+++ b/harness/scenarios/desktop_smoke_metaverse_dome_recovery.yaml
@@ -1,0 +1,24 @@
+name: desktop_smoke_metaverse_dome_recovery
+fixtures:
+  seed: 797
+  topic: kukuri:topic:metaverse-dome-recovery
+steps:
+  - action: launch_desktop
+  - action: select_topic
+    topic: kukuri:topic:metaverse-dome-recovery
+  - action: create_metaverse_dome
+    title: recovery-source
+    description: Offline, draining, and Return Home recovery scenario
+    max_peers: 8
+  - action: exercise_dome_connections
+    local_title: recovery-source
+  - action: revoke_local_dome_connection
+  - action: assert_dome_connection_topology
+    component_count: 2
+    active_connection_count: 1
+artifacts:
+  dump_logs: true
+  metrics_snapshot: true
+timeouts:
+  overall_ms: 120000
+  step_ms: 15000

--- a/xtask/oversized-baseline.json
+++ b/xtask/oversized-baseline.json
@@ -1,7 +1,11 @@
 {
   "files": [
     {
-      "lines": 1155,
+      "lines": 1272,
+      "path": "apps/desktop/src/components/extended/metaverse/useMetaverseRoomSession.ts"
+    },
+    {
+      "lines": 1191,
       "path": "crates/metaverse-host/src/lib.rs"
     },
     {
@@ -9,8 +13,16 @@
       "path": "crates/app-api/src/private_channels.rs"
     },
     {
-      "lines": 1099,
-      "path": "apps/desktop/src/components/extended/metaverse/useMetaverseRoomSession.ts"
+      "lines": 1100,
+      "path": "crates/desktop-runtime/src/runtime/private_channels_game_api.rs"
+    },
+    {
+      "lines": 1097,
+      "path": "crates/app-api/src/service/private_channels_support.rs"
+    },
+    {
+      "lines": 1096,
+      "path": "crates/app-api/src/dome_hosting.rs"
     },
     {
       "lines": 1096,
@@ -21,12 +33,8 @@
       "path": "crates/harness/src/scenarios/community_node.rs"
     },
     {
-      "lines": 1082,
-      "path": "crates/app-api/src/service/private_channels_support.rs"
-    },
-    {
-      "lines": 1026,
-      "path": "crates/desktop-runtime/src/runtime/private_channels_game_api.rs"
+      "lines": 1056,
+      "path": "crates/metaverse-host/src/tests.rs"
     },
     {
       "lines": 1016,

--- a/xtask/src/scenario.rs
+++ b/xtask/src/scenario.rs
@@ -66,6 +66,7 @@ pub(crate) fn scenario_ci_lane(name: &str) -> Option<&'static str> {
         | "desktop_smoke_metaverse_dome_connections"
         | "desktop_smoke_metaverse_dome_entry"
         | "desktop_smoke_metaverse_dome_transition"
+        | "desktop_smoke_metaverse_dome_recovery"
         | "dome_hosting_lifecycle"
         | "desktop_smoke_live_session_persist"
         | "pairwise_dm_offline_text_image_video_delivery_and_local_delete"
@@ -95,7 +96,7 @@ mod tests {
                     .into_owned()
             })
             .collect::<BTreeSet<_>>();
-        assert_eq!(scenario_names.len(), 17, "scenario inventory changed");
+        assert_eq!(scenario_names.len(), 18, "scenario inventory changed");
         let orphaned = scenario_names
             .iter()
             .filter(|name| scenario_ci_lane(name).is_none())


### PR DESCRIPTION
## Summary

- add signed 5-second owner/CN host heartbeats, offline grace, 15-second closure, participant keepalive, and atomic timeout cleanup
- add durable 3-second Connection draining for normal revocation while safety and authority invalidation close immediately
- fence input/presence/audio during host recovery, evacuate to safe adjacent/entry candidates after closure, and keep the source scene until target admission is confirmed
- add always-available Return Home controls, non-color-only boundary states, translations, ADR/runbook/progress records, and a dedicated harness scenario
- advance the experimental metaverse world schema to v7 without backward compatibility

## UI preview

Storybook: `Extended/MetaverseRoomPanel` — `OfflineGraceBoundary`, `DrainingBoundary`, `BlockedBoundary`, and `ClosedBoundary`.

## Validation

- `cargo nextest run --workspace --no-fail-fast` (691 passed, 3 skipped)
- `cargo xtask check`
- `cargo xtask cn-check`
- `cargo xtask cn-test`
- `cargo xtask desktop-ui-check` (910 unit tests, Storybook build, 44 browser E2E tests, 14 visual tests)
- `cargo xtask tauri-check`
- `cargo xtask ipc-types --check`
- `cargo xtask e2e-smoke`
- `cargo xtask scenario desktop_smoke_metaverse_dome_recovery`
- `cargo xtask oversized-files`
- `cargo fmt --all -- --check`
- `git diff --check`

## Oversized-file baseline

Issue #797 necessarily adds recovery integration points to existing metaverse host, app hosting/connection, desktop runtime, and frontend session state machines. Their ratchet entries were updated instead of mixing responsibility extraction into this feature PR, as required by `REFACTORING.md`. Follow-up split candidates are `apps/desktop/src/components/extended/metaverse/useMetaverseRoomSession.ts`, `crates/metaverse-host/src/lib.rs`, `crates/app-api/src/dome_hosting.rs`, and `crates/desktop-runtime/src/runtime/private_channels_game_api.rs`.

Closes #797
