### PR TITLE
[codex][fix] Recover lost Dome transition commit acknowledgements

### DIFF
--- a/apps/desktop/src/components/extended/metaverse/DomeTransitionCommitRecovery.test.ts
+++ b/apps/desktop/src/components/extended/metaverse/DomeTransitionCommitRecovery.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test, vi } from 'vitest';
+
+import type {
+  DomeHostingView,
+  DomeTransitionAdmissionTicketV1,
+} from '@/lib/api';
+import { recoverDomeTransitionCommit } from './DomeTransitionCommitRecovery';
+
+const ticket: DomeTransitionAdmissionTicketV1 = {
+  request: {
+    transition_id: 'transition-1',
+    connection_id: 'connection-1',
+    topology_digest: 'topology-1',
+    spatial_context: { kind: 'topic', topic_id: 'kukuri:topic:test' },
+    source_instance_id: 'dome-a',
+    source_instance_generation: 1,
+    target_instance_id: 'dome-b',
+    target_instance_generation: 1,
+    participant_pubkey: 'f'.repeat(64),
+    direction: 'north',
+    requested_at: 1_000,
+  },
+  target_lease_epoch: 7,
+  target_session_id: 'session-b',
+  expires_at: 16_000,
+};
+
+function hosting(leaseEpoch = 7, sessionId = 'session-b'): DomeHostingView {
+  return {
+    instance_id: 'dome-b',
+    state: {
+      kind: 'community_node_hosted',
+      host: { kind: 'community_node', node_id: 'cn-1', api_base_url: 'https://cn.example' },
+      lease_id: 'lease-b',
+      lease_epoch: leaseEpoch,
+      lease_expires_at: 60_000,
+      session_id: sessionId,
+      reason: null,
+      last_heartbeat_at: 1_000,
+    },
+    lease: null,
+    signed_lease_json: null,
+    signed_activation_json: null,
+    signed_close_json: null,
+    instance_manifest_json: '{}',
+    preset_manifest_json: '{}',
+    participants: 1,
+    sleeping: false,
+    resource_budget: {} as DomeHostingView['resource_budget'],
+    resource_metrics: {} as DomeHostingView['resource_metrics'],
+  };
+}
+
+describe('recoverDomeTransitionCommit', () => {
+  test('keeps the same commit pending across transient errors until an acknowledgement arrives', async () => {
+    const commit = vi.fn()
+      .mockRejectedValueOnce(new Error('connection reset'))
+      .mockRejectedValueOnce(new Error('timeout'))
+      .mockResolvedValue(undefined);
+    const wait = vi.fn().mockResolvedValue(undefined);
+
+    await expect(recoverDomeTransitionCommit({
+      ticket,
+      commit,
+      getHosting: vi.fn().mockResolvedValue(hosting()),
+      isCurrent: () => true,
+      wait,
+    })).resolves.toEqual({ status: 'committed' });
+
+    expect(commit).toHaveBeenCalledTimes(3);
+    expect(wait).toHaveBeenNthCalledWith(1, 0);
+    expect(wait).toHaveBeenNthCalledWith(2, 250);
+  });
+
+  test('rolls back only after the destination session is known to have changed', async () => {
+    const error = new Error('connection reset');
+    const commit = vi.fn().mockRejectedValue(error);
+
+    await expect(recoverDomeTransitionCommit({
+      ticket,
+      commit,
+      getHosting: vi.fn().mockResolvedValue(hosting(8, 'session-c')),
+      isCurrent: () => true,
+      wait: vi.fn().mockResolvedValue(undefined),
+    })).resolves.toEqual({ status: 'rollback', error });
+
+    expect(commit).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not infer rollback when the hosting lookup also fails', async () => {
+    const commit = vi.fn()
+      .mockRejectedValueOnce(new Error('connection reset'))
+      .mockResolvedValue(undefined);
+
+    await expect(recoverDomeTransitionCommit({
+      ticket,
+      commit,
+      getHosting: vi.fn().mockRejectedValue(new Error('offline')),
+      isCurrent: () => true,
+      wait: vi.fn().mockResolvedValue(undefined),
+    })).resolves.toEqual({ status: 'committed' });
+
+    expect(commit).toHaveBeenCalledTimes(2);
+  });
+
+  test('treats an authoritative invalid-ticket response as safe to roll back', async () => {
+    const error = new Error('DOME_TRANSITION_INVALID_TICKET');
+
+    await expect(recoverDomeTransitionCommit({
+      ticket,
+      commit: vi.fn().mockRejectedValue(error),
+      getHosting: vi.fn().mockResolvedValue(hosting()),
+      isCurrent: () => true,
+      wait: vi.fn().mockResolvedValue(undefined),
+    })).resolves.toEqual({ status: 'rollback', error });
+  });
+});

--- a/apps/desktop/src/components/extended/metaverse/DomeTransitionCommitRecovery.ts
+++ b/apps/desktop/src/components/extended/metaverse/DomeTransitionCommitRecovery.ts
@@ -1,0 +1,66 @@
+import type { DomeHostingView, DomeTransitionAdmissionTicketV1 } from '@/lib/api';
+
+const RETRY_DELAYS_MS = [0, 250, 1_000, 2_000, 5_000] as const;
+
+export type DomeTransitionCommitRecoveryResult =
+  | { status: 'committed' }
+  | { status: 'rollback'; error: unknown }
+  | { status: 'cancelled' };
+
+type DomeTransitionCommitRecoveryOptions = {
+  ticket: DomeTransitionAdmissionTicketV1;
+  commit: () => Promise<void>;
+  getHosting: () => Promise<DomeHostingView>;
+  isCurrent: () => boolean;
+  wait?: (delayMs: number) => Promise<void>;
+};
+
+function targetSessionWasReplaced(
+  hosting: DomeHostingView,
+  ticket: DomeTransitionAdmissionTicketV1
+): boolean {
+  if (hosting.state.kind === 'closed') return true;
+  if (hosting.state.lease_epoch == null || hosting.state.session_id == null) return false;
+  return hosting.state.lease_epoch !== ticket.target_lease_epoch
+    || hosting.state.session_id !== ticket.target_session_id;
+}
+
+function isDefinitiveCommitRejection(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.includes('DOME_TRANSITION_INVALID_TICKET')
+    || message.includes('Dome transition admission ticket is invalid or expired')
+    || message.includes('DOME_TRANSITION_STALE_TOPOLOGY')
+    || message.includes('DOME_TRANSITION_STALE_SESSION')
+    || message.includes('DOME_TRANSITION_OWNERS_BLOCKED')
+    || message.includes('DOME_TRANSITION_VISITOR_BLOCKED')
+    || message.includes('DOME_TRANSITION_ACCESS_DENIED');
+}
+
+export async function recoverDomeTransitionCommit({
+  ticket,
+  commit,
+  getHosting,
+  isCurrent,
+  wait = (delayMs) => new Promise((resolve) => window.setTimeout(resolve, delayMs)),
+}: DomeTransitionCommitRecoveryOptions): Promise<DomeTransitionCommitRecoveryResult> {
+  let retryIndex = 0;
+  while (isCurrent()) {
+    try {
+      await commit();
+      return { status: 'committed' };
+    } catch (error) {
+      try {
+        const hosting = await getHosting();
+        if (targetSessionWasReplaced(hosting, ticket) || isDefinitiveCommitRejection(error)) {
+          return { status: 'rollback', error };
+        }
+      } catch {
+        // A hosting lookup failure cannot distinguish an applied commit from an unapplied one.
+      }
+      const delay = RETRY_DELAYS_MS[Math.min(retryIndex, RETRY_DELAYS_MS.length - 1)];
+      retryIndex += 1;
+      await wait(delay);
+    }
+  }
+  return { status: 'cancelled' };
+}

--- a/apps/desktop/src/components/extended/metaverse/useMetaverseRoomSession.test.tsx
+++ b/apps/desktop/src/components/extended/metaverse/useMetaverseRoomSession.test.tsx
@@ -524,4 +524,180 @@ describe('useMetaverseRoomSession', () => {
     );
     expect(abortDomeTransition).not.toHaveBeenCalled();
   });
+
+  test('retries the same destination commit when the first acknowledgement is lost', async () => {
+    const domeA = {
+      ...room,
+      room_id: 'dome-a',
+      metaverse: createDefaultMetaverseRoomState(8, {
+        roomId: 'dome-a',
+        topicId: 'kukuri:topic:demo',
+      }),
+    };
+    const domeB = {
+      ...room,
+      room_id: 'dome-b',
+      title: 'Neighbor',
+      metaverse: createDefaultMetaverseRoomState(8, {
+        roomId: 'dome-b',
+        topicId: 'kukuri:topic:demo',
+      }),
+    };
+    const hosted = (instanceId: string): DomeHostingView => ({
+      instance_id: instanceId,
+      state: {
+        kind: 'community_node_hosted',
+        host: { kind: 'community_node', node_id: 'cn-1', api_base_url: 'https://cn.example' },
+        lease_id: `lease-${instanceId}`,
+        lease_epoch: 1,
+        lease_expires_at: Date.now() + 60_000,
+        session_id: `session-${instanceId}`,
+        reason: null,
+        last_heartbeat_at: Date.now(),
+      },
+      lease: null,
+      signed_lease_json: null,
+      signed_activation_json: null,
+      signed_close_json: null,
+      instance_manifest_json: '{}',
+      preset_manifest_json: '{}',
+      participants: 0,
+      sleeping: false,
+      resource_budget: {} as DomeHostingView['resource_budget'],
+      resource_metrics: {} as DomeHostingView['resource_metrics'],
+    });
+    const prepareDomeTransition = vi.fn(async (request) => ({
+      request,
+      target_lease_epoch: 1,
+      target_session_id: 'session-dome-b',
+      expires_at: Date.now() + 15_000,
+    }));
+    const commitDomeTransition = vi.fn()
+      .mockRejectedValueOnce(new Error('response lost after commit'))
+      .mockResolvedValue(undefined);
+    const abortDomeTransition = vi.fn().mockResolvedValue(undefined);
+    const submitDomeSessionInput = vi.fn(async (
+      _context: SpatialContextV1,
+      instanceId: string,
+      sequence: number
+    ): Promise<DomePhysicsSnapshotV1> => ({
+      instance_id: instanceId,
+      instance_generation: 1,
+      lease_epoch: 1,
+      session_id: `session-${instanceId}`,
+      host_pubkey: 'e'.repeat(64),
+      sequence,
+      simulated_at: Date.now(),
+      sleeping: false,
+      bodies: [{
+        entity_id: `avatar:${'f'.repeat(64)}`,
+        kind: 'avatar',
+        position: [0, 0, 260],
+        rotation: [0, 180, 0],
+        linear_velocity: [0, 0, 0],
+        animation: 'idle',
+        grabbed_by: null,
+        expires_at: null,
+      }],
+    }));
+    const api: DesktopApi = {
+      ...createDesktopMockApi(),
+      listDomeConnectionTopology: vi.fn().mockResolvedValue({
+        proposals: [],
+        connections: [{
+          record: {
+            agreement: {
+              connection_id: 'connection-1',
+              proposal_id: 'proposal-1',
+              spatial_context: domeA.metaverse.spatial_context,
+              proposer: {
+                instance_id: 'dome-a',
+                instance_generation: 1,
+                owner_pubkey: domeA.host_pubkey,
+                direction: 'north',
+              },
+              receiver: {
+                instance_id: 'dome-b',
+                instance_generation: 1,
+                owner_pubkey: domeB.host_pubkey,
+                direction: 'south',
+              },
+              activation_generation: 1,
+            },
+            receiver_slot_generation: 1,
+            observed_active_connection_ids: [],
+            status: 'active',
+            lifecycle_generation: 1,
+            lifecycle_actor: null,
+            lifecycle_reason: null,
+            lifecycle_deadline_at: null,
+          },
+        }],
+        resolution: {
+          topology: {
+            spatial_context: domeA.metaverse.spatial_context,
+            components: [{
+              root_instance_id: 'dome-a',
+              instance_ids: ['dome-a', 'dome-b'],
+              connection_ids: ['connection-1'],
+              coordinates_cm: { 'dome-a': [0, 0, 0], 'dome-b': [0, 0, -5_700] },
+            }],
+            active_connection_ids: ['connection-1'],
+            topology_digest: 'topology-1',
+          },
+          rejected_connections: [],
+        },
+      }),
+      getDomeHosting: vi.fn(async (_context, instanceId) => hosted(instanceId)),
+      submitDomeSessionInput,
+      prepareDomeTransition,
+      commitDomeTransition,
+      abortDomeTransition,
+    };
+    const session = renderSession({
+      api,
+      rooms: [domeA, domeB],
+      initialSelectedRoomId: 'dome-a',
+    });
+    await waitFor(() =>
+      expect(session.result.current.transitionNeighbors[0]?.boundaryState).toBe('ready')
+    );
+
+    act(() => session.result.current.handleLocalTransform({
+      roomId: 'dome-a',
+      peerId: 'local-peer',
+      seq: 1,
+      position: [0, 90, -2_200],
+      rotation: [0, 0, 0],
+      animation: 'walk',
+      sentAt: Date.now(),
+    }));
+    await waitFor(() => expect(prepareDomeTransition).toHaveBeenCalledTimes(1));
+    act(() => session.result.current.handleLocalTransform({
+      roomId: 'dome-a',
+      peerId: 'local-peer',
+      seq: 2,
+      position: [0, 90, -2_870],
+      rotation: [0, 0, 0],
+      animation: 'walk',
+      sentAt: Date.now(),
+    }));
+
+    await waitFor(() => expect(commitDomeTransition).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(session.result.current.selectedRoomId).toBe('dome-b'));
+    expect(commitDomeTransition.mock.calls[1]).toEqual(commitDomeTransition.mock.calls[0]);
+    expect(abortDomeTransition).not.toHaveBeenCalled();
+    expect(submitDomeSessionInput).not.toHaveBeenCalledWith(
+      expect.anything(),
+      'dome-a',
+      expect.anything(),
+      expect.objectContaining({ type: 'abort_transition' })
+    );
+    expect(submitDomeSessionInput).toHaveBeenCalledWith(
+      expect.anything(),
+      'dome-a',
+      expect.anything(),
+      expect.objectContaining({ type: 'complete_transition' })
+    );
+  });
 });

--- a/apps/desktop/src/components/extended/metaverse/useMetaverseRoomSession.ts
+++ b/apps/desktop/src/components/extended/metaverse/useMetaverseRoomSession.ts
@@ -57,6 +57,7 @@ import {
   writeLastVisitedDome,
 } from './DomeEntryModel';
 import { loadAvatarCollider } from './AvatarColliderModel';
+import { recoverDomeTransitionCommit } from './DomeTransitionCommitRecovery';
 
 type UseMetaverseRoomSessionArgs = {
   actions: MetaverseRoomActions;
@@ -633,7 +634,7 @@ export function useMetaverseRoomSession({
   }
 
   const abortTransitionAttempt = useCallback(async (attempt: TransitionAttempt) => {
-    if (attempt.phase === 'target_committed') return;
+    if (attempt.phase === 'committing' || attempt.phase === 'target_committed') return;
     attempt.cancelled = true;
     if (attempt.ticket) {
       await actions.abortTransition(attempt.ticket).catch(() => undefined);
@@ -711,80 +712,79 @@ export function useMetaverseRoomSession({
   function commitTransitionAttempt(attempt: TransitionAttempt, transform: AvatarTransform) {
     if (attempt.phase !== 'provisional' || attempt.cancelled || !attempt.ticket) return;
     attempt.phase = 'committing';
-    const targetPosition = transformAvatarBetweenDomes(
-      transform.position,
-      attempt.neighbor.relativeCoordinateCm
-    );
+    const targetPosition = transformAvatarBetweenDomes(transform.position, attempt.neighbor.relativeCoordinateCm);
     const targetTransform: AvatarTransform = {
-      ...transform,
-      roomId: attempt.neighbor.room.room_id,
-      seq: 0,
-      position: targetPosition,
-      sentAt: Date.now(),
+      ...transform, roomId: attempt.neighbor.room.room_id, seq: 0,
+      position: targetPosition, sentAt: Date.now(),
     };
     void (async () => {
-      try {
-        await actions.commitTransition(attempt.ticket!, targetPosition, transform.rotation);
-        attempt.phase = 'target_committed';
-        transitionAttemptRef.current = null;
-        setTransitionPreparing(attempt.neighbor.direction, false);
-        setHandoffTransform(targetTransform);
-        lastSentTransformRef.current = targetTransform;
-        setLastSentSeq(0);
-        setJoinedRoomIds((current) => {
-          const next = new Set(current);
-          next.delete(attempt.sourceRoom.room_id);
-          next.add(attempt.neighbor.room.room_id);
-          return next;
-        });
-        setSelectedRoomId(attempt.neighbor.room.room_id);
-        if (attempt.neighbor.room.metaverse) {
-          writeLastVisitedDome(
-            syncStatus.local_author_pubkey,
-            attempt.neighbor.room.metaverse.spatial_context,
-            attempt.neighbor.room.metaverse.instance_id
-          );
-        }
-        onError(null);
-        let sourceCompleted = false;
-        for (const retryDelay of [0, 250, 1_000]) {
-          if (retryDelay > 0) {
-            await new Promise((resolve) => window.setTimeout(resolve, retryDelay));
-          }
-          try {
-            await submitInputForRoom(attempt.sourceRoom, {
-              type: 'complete_transition',
-              transition_id: attempt.id,
-            });
-            sourceCompleted = true;
-            break;
-          } catch {
-            // The destination remains authoritative; retry only source cleanup.
-          }
-        }
-        if (sourceCompleted) {
-          const leftAt = Date.now();
-          await actions.publishRoomEvent(attempt.sourceRoom.room_id, localPeerId, leftAt, {
-            type: 'presence_leave',
-            room_id: attempt.sourceRoom.room_id,
-            peer_id: localPeerId,
-            left_at: leftAt,
-          }).catch(() => undefined);
-        } else {
-          onError('Destination committed; source Dome cleanup will require resynchronization');
-        }
-      } catch (transitionError) {
+      const recovery = await recoverDomeTransitionCommit({
+        ticket: attempt.ticket!,
+        commit: () => actions.commitTransition(attempt.ticket!, targetPosition, transform.rotation),
+        getHosting: () => actions.getHosting(attempt.ticket!.request.spatial_context, attempt.ticket!.request.target_instance_id),
+        isCurrent: () => transitionAttemptRef.current === attempt && !attempt.cancelled,
+      });
+      if (recovery.status === 'cancelled') return;
+      if (recovery.status === 'rollback') {
+        attempt.phase = 'provisional';
         await abortTransitionAttempt(attempt);
         setTransitionNeighbors((current) => current.map((candidate) =>
           candidate.connectionId === attempt.neighbor.connectionId
             ? { ...candidate, boundaryState: 'error' }
             : candidate
         ));
-        onError(
-          transitionError instanceof Error
-            ? transitionError.message
-            : 'Dome transition commit failed'
+        onError(recovery.error instanceof Error
+          ? recovery.error.message
+          : 'Dome transition commit failed');
+        return;
+      }
+      attempt.phase = 'target_committed';
+      transitionAttemptRef.current = null;
+      setTransitionPreparing(attempt.neighbor.direction, false);
+      setHandoffTransform(targetTransform);
+      lastSentTransformRef.current = targetTransform;
+      setLastSentSeq(0);
+      setJoinedRoomIds((current) => {
+        const next = new Set(current);
+        next.delete(attempt.sourceRoom.room_id);
+        next.add(attempt.neighbor.room.room_id);
+        return next;
+      });
+      setSelectedRoomId(attempt.neighbor.room.room_id);
+      if (attempt.neighbor.room.metaverse) {
+        writeLastVisitedDome(
+          syncStatus.local_author_pubkey,
+          attempt.neighbor.room.metaverse.spatial_context,
+          attempt.neighbor.room.metaverse.instance_id
         );
+      }
+      onError(null);
+      let sourceCompleted = false;
+      for (const retryDelay of [0, 250, 1_000]) {
+        if (retryDelay > 0) {
+          await new Promise((resolve) => window.setTimeout(resolve, retryDelay));
+        }
+        try {
+          await submitInputForRoom(attempt.sourceRoom, {
+            type: 'complete_transition',
+            transition_id: attempt.id,
+          });
+          sourceCompleted = true;
+          break;
+        } catch {
+          // The destination remains authoritative; retry only source cleanup.
+        }
+      }
+      if (sourceCompleted) {
+        const leftAt = Date.now();
+        await actions.publishRoomEvent(attempt.sourceRoom.room_id, localPeerId, leftAt, {
+          type: 'presence_leave',
+          room_id: attempt.sourceRoom.room_id,
+          peer_id: localPeerId,
+          left_at: leftAt,
+        }).catch(() => undefined);
+      } else {
+        onError('Destination committed; source Dome cleanup will require resynchronization');
       }
     })();
   }

--- a/docs/adr/0042-seamless-dome-transition.md
+++ b/docs/adr/0042-seamless-dome-transition.md
@@ -29,7 +29,7 @@ ActiveなDome Connectionは恒常的なportalではなく、avatarが隣のDome�
 - Destination hostはtransition id、Connection id、topology digest、participant、両Instance／generation、target lease epoch／session、expiryへ束縛した短期admission ticketを発行する。
 - Provisional reservationは定員へ算入する。Prepare、refresh、commit、abortはtransition id単位で冪等とし、expiry、host restart、lease／session／generation／topology変更で無効化する。
 - Source `prepare_transition`はgrabを解除し、seat stateを解除し、base avatar identity／collider以外の追加装着assetをhandoff payloadから除外する。Propとseat bodyはsource側のcollisionに残し、destinationへ送らない。
-- Clientはdestination provisional reservationの完了後、hysteresis付きで中心線を進行方向へ越えた時だけcommitする。Destination commitのack後にcurrent Domeを切り替え、source leaveを冪等に完了する。
+- Clientはdestination provisional reservationの完了後、hysteresis付きで中心線を進行方向へ越えた時だけcommitする。Destination commitのack後にcurrent Domeを切り替え、source leaveを冪等に完了する。Commit要求を送信した後のtransport errorは適用結果不明として扱い、target lease epoch／sessionが同じ間は同一ticketとtransformでcommitを再送する。Ack取得前にdestination reservationまたはsource prepareをabortしてはならない。
 - Commit前の失敗はdestination reservationをabortしてsource側へ戻す。Commit後にsource leaveが失敗した場合はdestinationをcurrentのままsource leaveを再試行し、sourceはtransition idで旧inputをfenceする。これによりclient current Domeを一つ、authoritative参加先を最大一つへ収束させる。
 
 ## Feature Data Classification

--- a/docs/progress/2026-08-29-issue-790-seamless-dome-transition.md
+++ b/docs/progress/2026-08-29-issue-790-seamless-dome-transition.md
@@ -6,6 +6,7 @@
 - neighborのHosting、capacity、assetを先読みし、`closed/loading/ready/denied/full/unhosted/error/stale`の境界状態を導入した。`ready`以外は中心線手前でavatarを停止する。
 - transition ID、Connection、topology digest、source/target Instance generation、participant、target lease epoch/sessionを固定する15秒のreservation ticketを追加した。owner-device hostとCommunity Node hostは同じhost runtimeでprepare/commit/abortする。
 - 中心線通過前はrollbackでき、通過時は宛先commitを先に確定する。宛先確定後はcurrent Domeを戻さず、送信元の退出だけを再試行して二重presenceを解消する。
+- 宛先commitの応答だけが失われた場合は、同じlease epoch／sessionを確認しながら同一ticketとtransformを再送する。結果不明のcommitをpre-commit失敗としてabortせず、ack取得後にだけcurrent Dome切替と送信元退出へ進む。
 - avatarのcomponent座標、環境光、ambient、fog、gravityをconnection zone内で補間する。propは移送せず、host physicsで半球内に拘束する。
 - Rust unit test、React hook/model test、異なるowner-device host間のdeterministic harness scenarioを追加した。
 


### PR DESCRIPTION
## 概要

宛先Domeでcommitが適用された後に応答だけが失われた場合、同一ticketとtransformを冪等再送してackへ収束させます。

## 種別

fix

## 挙動変更

- commit送信後の一時的な通信失敗ではsource／targetをabortしません。
- target lease epoch／sessionが同じ間は上限付きbackoffで同一commitを再送します。
- target session置換または確定的ticket拒否を確認した場合だけsourceへrollbackします。
- ack後のtarget切替とsource退出は従来どおり一度だけ実行します。

## 検証

- `cargo test -p kukuri-metaverse-host transition_reservation_counts_capacity_and_commit_is_idempotent`
- 対象Vitest 14件
- `cargo xtask oversized-files`
- `cargo xtask desktop-ui-check`（unit 915件、browser 44件、visual 14件）
- `cargo xtask check`
- `cargo xtask test`（Rust 691件、harness 22件、frontend 915件）
- `git diff --check`

## リスク

結果不明中は整合性を優先してsourceをpreparedのまま保持します。通信が長時間復旧しない場合、再試行は5秒間隔で継続します。

## 後続対応

実機・multi-peer動作確認は別途実施します。

Closes #790