### PR TITLE
[codex][fix] Discard blocked Dome connection proposals

### DIFF
--- a/crates/app-api/src/dome_connections.rs
+++ b/crates/app-api/src/dome_connections.rs
@@ -265,6 +265,21 @@ impl AppService {
         if proposal_state.proposal.receiver.owner_pubkey.as_str() != self.current_author_pubkey() {
             anyhow::bail!("only the receiver Dome owner can accept this proposal");
         }
+        if self
+            .authors_blocked_either_direction(
+                proposal_state.proposal.proposer.owner_pubkey.as_str(),
+                proposal_state.proposal.receiver.owner_pubkey.as_str(),
+            )
+            .await?
+        {
+            self.terminate_dome_connection_proposal_with_reason(
+                &proposal_state.proposal.spatial_context,
+                proposal_state.proposal.proposal_id.as_str(),
+                DomeConnectionTerminalReasonV1::OwnersBlocked,
+            )
+            .await?;
+            anyhow::bail!("DOME_CONNECTION_OWNERS_BLOCKED");
+        }
         if let Some(existing) = self
             .fetch_dome_connection_state(&replica, &proposal_state.connection_id)
             .await?
@@ -398,33 +413,64 @@ impl AppService {
         let replica = self
             .dome_connection_context_replica(&input.spatial_context)
             .await?;
-        let mut state = self
+        let state = self
             .fetch_dome_proposal_state(&replica, input.proposal_id.as_str())
             .await?
             .context("Dome Connection proposal was not found")?;
         if state.proposal.proposer.owner_pubkey.as_str() != self.current_author_pubkey() {
             anyhow::bail!("only the proposer can withdraw this proposal");
         }
-        if state.terminal_reason.is_none() {
-            let event = DomeProposalTerminalEventV1 {
-                proposal_id: state.proposal.proposal_id.clone(),
-                spatial_context: state.proposal.spatial_context.clone(),
-                actor_pubkey: state.proposal.proposer.owner_pubkey.clone(),
-                reason: DomeConnectionTerminalReasonV1::ProposerWithdrew,
-                updated_at: Utc::now().timestamp_millis(),
-            };
-            let envelope = sign_envelope_json(
-                self.services.keys.as_ref(),
-                "dome-connection-proposal-terminal",
-                vec![vec!["proposal".into(), event.proposal_id.clone()]],
-                &event,
-            )?;
-            self.persist_connection_envelope(&replica, &envelope)
-                .await?;
-            state.terminal_reason = Some(event.reason);
-            state.terminal_event_envelope_id = Some(envelope.id);
-            self.persist_dome_proposal_state(&replica, &state).await?;
+        self.terminate_dome_connection_proposal_with_reason(
+            &input.spatial_context,
+            input.proposal_id.as_str(),
+            DomeConnectionTerminalReasonV1::ProposerWithdrew,
+        )
+        .await
+    }
+
+    pub(crate) async fn terminate_dome_connection_proposal_with_reason(
+        &self,
+        spatial_context: &SpatialContextV1,
+        proposal_id: &str,
+        reason: DomeConnectionTerminalReasonV1,
+    ) -> Result<DomeConnectionProposalView> {
+        let replica = self
+            .dome_connection_context_replica(spatial_context)
+            .await?;
+        let mut state = self
+            .fetch_dome_proposal_state(&replica, proposal_id)
+            .await?
+            .context("Dome Connection proposal was not found")?;
+        if state.terminal_reason.is_some()
+            || self
+                .fetch_dome_connection_state(&replica, &state.connection_id)
+                .await?
+                .is_some()
+        {
+            return self.proposal_view_from_state(&replica, state).await;
         }
+        let actor = Pubkey::from(self.current_author_pubkey());
+        validate_dome_proposal_terminal_actor(&state.proposal, &actor, reason)?;
+        let event = DomeProposalTerminalEventV1 {
+            proposal_id: state.proposal.proposal_id.clone(),
+            spatial_context: state.proposal.spatial_context.clone(),
+            actor_pubkey: actor,
+            reason,
+            updated_at: Utc::now().timestamp_millis(),
+        };
+        let envelope = sign_envelope_json(
+            self.services.keys.as_ref(),
+            "dome-connection-proposal-terminal",
+            vec![vec!["proposal".into(), event.proposal_id.clone()]],
+            &event,
+        )?;
+        self.persist_connection_envelope(&replica, &envelope)
+            .await?;
+        state.terminal_reason = Some(event.reason);
+        state.terminal_event_envelope_id = Some(envelope.id);
+        self.persist_dome_proposal_state(&replica, &state).await?;
+        self.publish_dome_topology_hint(&state.proposal.spatial_context, &state.connection_id)
+            .await?;
         self.proposal_view_from_state(&replica, state).await
     }
 
@@ -633,21 +679,8 @@ impl AppService {
             state.terminal_event_envelope_id.as_ref(),
         ) {
             (Some(reason), Some(envelope_id)) => {
-                let event: DomeProposalTerminalEventV1 = fetch_verified_dome_envelope(
-                    self.services.docs_sync.as_ref(),
-                    replica,
-                    envelope_id,
-                    "dome-connection-proposal-terminal",
-                    &state.proposal.proposer.owner_pubkey,
-                )
-                .await?;
-                if event.proposal_id != state.proposal.proposal_id
-                    || event.spatial_context != state.proposal.spatial_context
-                    || event.actor_pubkey != state.proposal.proposer.owner_pubkey
-                    || event.reason != reason
-                {
-                    anyhow::bail!("signed Dome Connection terminal event does not match state");
-                }
+                let envelope = self.fetch_connection_envelope(replica, envelope_id).await?;
+                verify_dome_proposal_terminal_event(state, envelope_id, reason, &envelope)?;
             }
             (None, None) => {}
             _ => anyhow::bail!("Dome Connection terminal state is incomplete"),

--- a/crates/app-api/src/service/dome_connection_support.rs
+++ b/crates/app-api/src/service/dome_connection_support.rs
@@ -1,5 +1,5 @@
 use crate::service::*;
-use kukuri_core::SpatialContextV1;
+use kukuri_core::{DomeProposalDerivedStatusV1, SpatialContextV1};
 use serde::{Deserialize, Serialize};
 
 pub(crate) const PROPOSAL_PREFIX: &str = "metaverse/dome-connections/proposals";
@@ -38,6 +38,48 @@ pub(crate) struct DomeProposalTerminalEventV1 {
     pub(crate) actor_pubkey: Pubkey,
     pub(crate) reason: DomeConnectionTerminalReasonV1,
     pub(crate) updated_at: i64,
+}
+
+pub(crate) fn validate_dome_proposal_terminal_actor(
+    proposal: &DomeConnectionProposalV1,
+    actor: &Pubkey,
+    reason: DomeConnectionTerminalReasonV1,
+) -> Result<()> {
+    let authorized = match reason {
+        DomeConnectionTerminalReasonV1::ProposerWithdrew => {
+            actor == &proposal.proposer.owner_pubkey
+        }
+        DomeConnectionTerminalReasonV1::OwnersBlocked => {
+            actor == &proposal.proposer.owner_pubkey || actor == &proposal.receiver.owner_pubkey
+        }
+        _ => false,
+    };
+    if !authorized {
+        anyhow::bail!("Dome Connection proposal terminal actor is not authorized");
+    }
+    Ok(())
+}
+
+pub(crate) fn verify_dome_proposal_terminal_event(
+    state: &DomeProposalStateDocV1,
+    envelope_id: &EnvelopeId,
+    reason: DomeConnectionTerminalReasonV1,
+    envelope: &KukuriEnvelope,
+) -> Result<()> {
+    let event: DomeProposalTerminalEventV1 = serde_json::from_str(envelope.content.as_str())?;
+    if envelope.id != *envelope_id
+        || envelope.kind != "dome-connection-proposal-terminal"
+        || envelope.pubkey != event.actor_pubkey
+    {
+        anyhow::bail!("signed Dome Connection terminal envelope identity mismatch");
+    }
+    if event.proposal_id != state.proposal.proposal_id
+        || event.spatial_context != state.proposal.spatial_context
+        || event.reason != reason
+    {
+        anyhow::bail!("signed Dome Connection terminal event does not match state");
+    }
+    validate_dome_proposal_terminal_actor(&state.proposal, &event.actor_pubkey, event.reason)
 }
 
 impl AppService {
@@ -150,6 +192,25 @@ impl AppService {
             let Ok(topology) = self.list_dome_connection_topology(context.clone()).await else {
                 continue;
             };
+            for proposal in topology.proposals.iter().filter(|proposal| {
+                !matches!(
+                    proposal.status,
+                    DomeProposalDerivedStatusV1::Accepted | DomeProposalDerivedStatusV1::Discarded
+                )
+            }) {
+                let owners_match = (proposal.proposal.proposer.owner_pubkey == local_owner
+                    && proposal.proposal.receiver.owner_pubkey == *target_pubkey)
+                    || (proposal.proposal.receiver.owner_pubkey == local_owner
+                        && proposal.proposal.proposer.owner_pubkey == *target_pubkey);
+                if owners_match {
+                    self.terminate_dome_connection_proposal_with_reason(
+                        &context,
+                        proposal.proposal.proposal_id.as_str(),
+                        DomeConnectionTerminalReasonV1::OwnersBlocked,
+                    )
+                    .await?;
+                }
+            }
             for connection in topology.connections {
                 let agreement = &connection.record.agreement;
                 let owners_match = (agreement.proposer.owner_pubkey == local_owner

--- a/crates/app-api/src/tests/dome_connections.rs
+++ b/crates/app-api/src/tests/dome_connections.rs
@@ -19,6 +19,63 @@ fn app_with_shared_dome_services(
     )
 }
 
+async fn open_proposal_fixture(
+    suffix: &str,
+) -> (AppService, AppService, SpatialContextV1, String, String) {
+    let docs_sync = Arc::new(MemoryDocsSync::default());
+    let blob_service = Arc::new(MemoryBlobService::default());
+    let proposer_keys = generate_keys();
+    let receiver_keys = generate_keys();
+    let proposer_pubkey = proposer_keys.public_key_hex();
+    let receiver_pubkey = receiver_keys.public_key_hex();
+    let proposer =
+        app_with_shared_dome_services(docs_sync.clone(), blob_service.clone(), proposer_keys);
+    let receiver = app_with_shared_dome_services(docs_sync, blob_service, receiver_keys);
+    let topic = format!("kukuri:topic:dome-open-proposal-{suffix}");
+    let context = SpatialContextV1::Topic {
+        topic_id: TopicId::new(topic.clone()),
+    };
+    let proposer_instance = proposer
+        .create_metaverse_room(
+            &topic,
+            CreateMetaverseRoomInput {
+                title: "Proposer Dome".into(),
+                description: String::new(),
+                max_peers: Some(8),
+            },
+        )
+        .await
+        .expect("create proposer Dome");
+    let receiver_instance = receiver
+        .create_metaverse_room(
+            &topic,
+            CreateMetaverseRoomInput {
+                title: "Receiver Dome".into(),
+                description: String::new(),
+                max_peers: Some(8),
+            },
+        )
+        .await
+        .expect("create receiver Dome");
+    proposer
+        .create_dome_connection_proposal(CreateDomeConnectionProposalInput {
+            proposal_id: format!("proposal-{suffix}"),
+            spatial_context: context.clone(),
+            proposer_instance_id: proposer_instance,
+            receiver_instance_id: receiver_instance,
+            proposer_direction: DomeDirection::East,
+        })
+        .await
+        .expect("create proposal");
+    (
+        proposer,
+        receiver,
+        context,
+        proposer_pubkey,
+        receiver_pubkey,
+    )
+}
+
 #[tokio::test]
 async fn dome_connection_proposal_accept_and_revoke_round_trip() {
     let docs_sync = Arc::new(MemoryDocsSync::default());
@@ -237,6 +294,129 @@ async fn owner_block_revokes_connection_and_unblock_does_not_restore_it() {
     assert_eq!(
         unblocked.connections[0].record.status,
         kukuri_core::DomeConnectionStatusV1::Revoked
+    );
+}
+
+#[tokio::test]
+async fn proposer_block_discards_open_proposal_and_unblock_does_not_restore_it() {
+    let (proposer, receiver, context, _, receiver_pubkey) =
+        open_proposal_fixture("proposer-block").await;
+
+    proposer
+        .block_author(&receiver_pubkey)
+        .await
+        .expect("block receiver owner");
+    let blocked = proposer
+        .list_dome_connection_topology(context.clone())
+        .await
+        .expect("blocked topology");
+    assert_eq!(
+        blocked.proposals[0].status,
+        DomeProposalDerivedStatusV1::Discarded
+    );
+    assert_eq!(
+        blocked.proposals[0].terminal_reason,
+        Some(kukuri_core::DomeConnectionTerminalReasonV1::OwnersBlocked)
+    );
+    assert!(blocked.connections.is_empty());
+    assert!(
+        receiver
+            .accept_dome_connection_proposal(AcceptDomeConnectionProposalInput {
+                spatial_context: context.clone(),
+                proposal_id: "proposal-proposer-block".into(),
+            })
+            .await
+            .is_err()
+    );
+
+    proposer
+        .unblock_author(&receiver_pubkey)
+        .await
+        .expect("unblock receiver owner");
+    let unblocked = proposer
+        .list_dome_connection_topology(context)
+        .await
+        .expect("topology after unblock");
+    assert_eq!(
+        unblocked.proposals[0].status,
+        DomeProposalDerivedStatusV1::Discarded
+    );
+}
+
+#[tokio::test]
+async fn receiver_block_discards_open_proposal_and_prevents_accept() {
+    let (proposer, receiver, context, proposer_pubkey, _) =
+        open_proposal_fixture("receiver-block").await;
+
+    receiver
+        .block_author(&proposer_pubkey)
+        .await
+        .expect("block proposer owner");
+    let blocked = receiver
+        .list_dome_connection_topology(context.clone())
+        .await
+        .expect("blocked topology");
+    assert_eq!(
+        blocked.proposals[0].status,
+        DomeProposalDerivedStatusV1::Discarded
+    );
+    assert_eq!(
+        blocked.proposals[0].terminal_reason,
+        Some(kukuri_core::DomeConnectionTerminalReasonV1::OwnersBlocked)
+    );
+    assert!(blocked.connections.is_empty());
+    assert!(
+        receiver
+            .accept_dome_connection_proposal(AcceptDomeConnectionProposalInput {
+                spatial_context: context.clone(),
+                proposal_id: "proposal-receiver-block".into(),
+            })
+            .await
+            .is_err()
+    );
+    assert!(
+        proposer
+            .list_dome_connection_topology(context)
+            .await
+            .expect("proposer topology")
+            .connections
+            .is_empty()
+    );
+}
+
+#[tokio::test]
+async fn accept_rechecks_owner_block_before_persisting_connection_records() {
+    let (_, receiver, context, proposer_pubkey, _) =
+        open_proposal_fixture("accept-block-recheck").await;
+    let block = build_block_edge_envelope(
+        receiver.services.keys.as_ref(),
+        &Pubkey::from(proposer_pubkey),
+        BlockEdgeStatus::Active,
+    )
+    .expect("build block edge");
+    receiver
+        .services
+        .store
+        .put_envelope(block)
+        .await
+        .expect("store block edge without reconciliation");
+
+    let error = receiver
+        .accept_dome_connection_proposal(AcceptDomeConnectionProposalInput {
+            spatial_context: context.clone(),
+            proposal_id: "proposal-accept-block-recheck".into(),
+        })
+        .await
+        .expect_err("block must be rechecked before accept persistence");
+    assert!(error.to_string().contains("DOME_CONNECTION_OWNERS_BLOCKED"));
+    let topology = receiver
+        .list_dome_connection_topology(context)
+        .await
+        .expect("topology after rejected accept");
+    assert!(topology.connections.is_empty());
+    assert_eq!(
+        topology.proposals[0].terminal_reason,
+        Some(kukuri_core::DomeConnectionTerminalReasonV1::OwnersBlocked)
     );
 }
 

--- a/docs/adr/0037-dome-connection-topology.md
+++ b/docs/adr/0037-dome-connection-topology.md
@@ -41,7 +41,7 @@ ConnectionはDome Preset / Instance manifestへ埋め込まない。引っ越し
 - `waiting_for_slot`: 未選択、またはreceiver slotだけが別のactive Connectionで占有されている導出状態。
 - `draining` / `revoked`: いずれかのendpoint ownerが署名できるterminal lifecycle。途中失敗は同じoperation id / generationで再開する。
 
-proposerの指定slotに別Connectionが成立、proposerが同じslotで別proposalからConnectionを成立、どちらかのInstanceがdetach / tombstone / delete、owner間block入力、proposer withdrawではproposalをterminal discardとする。receiver slotが別Connectionで占有されたことだけではdiscardせず、待機リストに残す。ADR-0043がsigned blockを検出してactive Connectionを`owners_blocked`で即時revokeする。
+proposerの指定slotに別Connectionが成立、proposerが同じslotで別proposalからConnectionを成立、どちらかのInstanceがdetach / tombstone / delete、owner間block入力、proposer withdrawではproposalをterminal discardとする。receiver slotが別Connectionで占有されたことだけではdiscardせず、待機リストに残す。owner間blockによる`owners_blocked` terminal eventはblockを入力したどちらのendpoint ownerも署名でき、block解除後もproposalを復元しない。receiverはaccept recordを保存する直前にも双方向blockを再検査し、block済みならproposalだけをterminal discardしてConnection recordを作らない。ADR-0043がsigned blockを検出してactive Connectionを`owners_blocked`で即時revokeする。
 
 ### Concurrencyと上限
 

--- a/docs/progress/2026-08-27-issue-792-dome-connection-topology.md
+++ b/docs/progress/2026-08-27-issue-792-dome-connection-topology.md
@@ -12,6 +12,8 @@
 - SQLite / memory storeへ削除・再構築可能な`dome_connection_projection_cache`を追加した。
 - desktop runtime / Tauri IPC / generated TypeScript contractと、4方向Connection管理panelを追加した。
 - 3 ownerのA–B / B–C接続、A–C cycle拒否、restart復元、revoke分割を`desktop_smoke_metaverse_dome_connections`で固定した。
+- endpoint owner間のblock入力で未accept proposalを`owners_blocked`として自動破棄し、block解除後も復元しないreconciliationを追加した。
+- accept直前にも双方向blockを再検査し、競合するblockを観測した場合はConnection recordを保存せずproposalをterminal discardするようにした。
 
 ## 境界
 
@@ -30,5 +32,16 @@
 - `cargo xtask desktop-ui-check`: pass（Storybook build、browser 44、visual 14を含む）
 - `cargo xtask tauri-check`: pass
 - `cargo xtask e2e-smoke`: pass
+- `cargo xtask oversized-files`: pass（既存baseline warningのみ）
+- `git diff --check`: pass
+
+### 2026-08-29 block proposal follow-up
+
+- `cargo test -p kukuri-app-api dome_connections`: pass（6 tests）
+- `cargo test -p kukuri-core dome_connections`: pass（9 tests）
+- `cargo xtask rust-test`: pass（Rust workspace 694、harness 22、doc tests）
+- `cargo xtask check`: pass
+- `cargo xtask test`: pass（Rust workspace 694、harness 22、desktop 915）
+- `cargo xtask ipc-types --check`: pass
 - `cargo xtask oversized-files`: pass（既存baseline warningのみ）
 - `git diff --check`: pass


### PR DESCRIPTION
## 概要
- owner間block時に未accept proposalを owners_blocked でterminal discard
- block解除後もproposalを復元しない
- accept直前に双方向blockを再検査し、Connection record作成を防止
- proposer/receiver双方署名のterminal eventを検証

## 検証
- cargo test -p kukuri-app-api dome_connections
- cargo test -p kukuri-core dome_connections
- cargo xtask rust-test
- cargo xtask check
- cargo xtask test
- cargo xtask ipc-types --check
- cargo xtask oversized-files
- git diff --check

Closes #792