### PR TITLE
fix(desktop): prevent Column transition flicker

### DIFF
--- a/apps/desktop/src/shell/DesktopShellPage.notifications.test.tsx
+++ b/apps/desktop/src/shell/DesktopShellPage.notifications.test.tsx
@@ -317,5 +317,15 @@ test('follow notification click-through opens the author pane from timeline', as
   });
   expect(getDetailPane('Author')).toBeInTheDocument();
   expect(screen.getByText('opened from follow notification')).toBeInTheDocument();
+  const columns = Array.from(document.querySelectorAll<HTMLElement>('.shell-column-surface'));
+  const notificationsIndex = columns.findIndex((column) =>
+    column.getAttribute('aria-label')?.startsWith('Notifications Column,')
+  );
+  const openedProfileIndex = columns.findIndex(
+    (column) =>
+      column.getAttribute('aria-label')?.startsWith('Profile Column,') &&
+      column.getAttribute('aria-current') === 'true'
+  );
+  expect(openedProfileIndex).toBe(notificationsIndex + 1);
 });
 

--- a/apps/desktop/src/shell/DesktopShellPage.tsx
+++ b/apps/desktop/src/shell/DesktopShellPage.tsx
@@ -491,15 +491,30 @@ export function DesktopShellPage({
   }, [checkForUpdate]);
   const renderMessagesSurface = (
     surfaceKind: 'messages' | 'conversation',
-    peerPubkey?: string
+    peerPubkey: string | undefined,
+    sourceColumnId: string
   ) => (
     <DesktopShellMessagesSurface
       t={t}
       locale={locale}
       viewModels={viewModels}
       openDirectMessageList={openDirectMessageList}
-      openDirectMessagePane={openDirectMessagePane}
-      openAuthorDetail={openAuthorDetail}
+      openDirectMessagePane={(nextPeerPubkey, options) =>
+        openDirectMessagePane(nextPeerPubkey, {
+          ...options,
+          parentColumnId: options?.parentColumnId ?? sourceColumnId,
+        })
+      }
+      openAuthorDetail={(authorPubkey, options) =>
+        openAuthorDetail(authorPubkey, {
+          ...options,
+          // A selected DM can also be projected inside the Messages Column. Preserve
+          // its logical Conversation parent so opening the author does not replace it.
+          parentColumnId:
+            options?.parentColumnId ??
+            (options?.preserveDirectMessageContext ? undefined : sourceColumnId),
+        })
+      }
       handleClearDirectMessage={shellActions.handleClearDirectMessage}
       handleDeleteDirectMessageMessage={shellActions.handleDeleteDirectMessageMessage}
       handleDirectMessageAttachmentSelection={shellActions.handleDirectMessageAttachmentSelection}
@@ -510,7 +525,7 @@ export function DesktopShellPage({
       showComposer={false}
     />
   );
-  const notificationsSurface = (
+  const renderNotificationsSurface = (column: ColumnState) => (
     <DesktopShellNotificationsSurface
       t={t}
       locale={locale}
@@ -522,13 +537,17 @@ export function DesktopShellPage({
         });
         void loadTopics(trackedTopics, activeTopic, null).catch(() => undefined);
       }}
-      handleOpenNotification={shellActions.handleOpenNotification}
+      handleOpenNotification={(notification) =>
+        shellActions.handleOpenNotification(notification, column.id)
+      }
     />
   );
   const renderDetailSurface = (
     surfaceKind: 'thread' | 'profile',
     entityId?: string,
-    topicId?: string
+    topicId?: string,
+    sourceColumnId?: string,
+    channelId?: string | null
   ) => (
     <DesktopShellDetailSurfaceStack
       api={api}
@@ -536,9 +555,26 @@ export function DesktopShellPage({
       viewModels={viewModels}
       loadMoreThread={loadMoreThread}
       loadReactionCatalogData={loadReactionCatalogData}
-      openAuthorDetail={openAuthorDetail}
-      openDirectMessagePane={openDirectMessagePane}
-      openThread={openThread}
+      openAuthorDetail={(authorPubkey, options) =>
+        openAuthorDetail(authorPubkey, {
+          ...options,
+          parentColumnId: options?.parentColumnId ?? sourceColumnId,
+        })
+      }
+      openDirectMessagePane={(peerPubkey, options) =>
+        openDirectMessagePane(peerPubkey, {
+          ...options,
+          parentColumnId: options?.parentColumnId ?? sourceColumnId,
+        })
+      }
+      openThread={(threadId, options) =>
+        openThread(threadId, {
+          ...options,
+          channelId: options?.channelId ?? channelId,
+          parentColumnId: options?.parentColumnId ?? sourceColumnId,
+          topic: options?.topic ?? topicId,
+        })
+      }
       beginColumnReply={shellActions.beginColumnReply}
       handleSimpleRepost={shellActions.handleSimpleRepost}
       beginColumnQuoteRepost={shellActions.beginColumnQuoteRepost}
@@ -574,8 +610,20 @@ export function DesktopShellPage({
       loadReactionCatalogData={loadReactionCatalogData}
       refreshTimelineFeed={refreshTimelineFeed}
       loadMoreTimeline={loadMoreTimeline}
-      openAuthorDetail={openAuthorDetail}
-      openThread={openThread}
+      openAuthorDetail={(authorPubkey, options) =>
+        openAuthorDetail(authorPubkey, {
+          ...options,
+          parentColumnId: options?.parentColumnId ?? column.id,
+        })
+      }
+      openThread={(threadId, options) =>
+        openThread(threadId, {
+          ...options,
+          channelId: options?.channelId ?? column.scope?.channelId,
+          parentColumnId: options?.parentColumnId ?? column.id,
+          topic: options?.topic ?? column.scope?.topicId,
+        })
+      }
       beginColumnReply={shellActions.beginColumnReply}
       handleSimpleRepost={shellActions.handleSimpleRepost}
       beginColumnQuoteRepost={shellActions.beginColumnQuoteRepost}
@@ -701,16 +749,30 @@ export function DesktopShellPage({
         void activateWorkspaceColumn(column, preserveAuthorPane)
       }
       renderPrimarySurface={renderPrimarySurface}
-      messagesSurface={renderMessagesSurface('messages')}
-      renderConversationSurface={(column) =>
-        renderMessagesSurface('conversation', column.entityId)
+      renderMessagesSurface={(column) =>
+        renderMessagesSurface('messages', undefined, column.id)
       }
-      notificationsSurface={notificationsSurface}
+      renderConversationSurface={(column) =>
+        renderMessagesSurface('conversation', column.entityId, column.id)
+      }
+      renderNotificationsSurface={renderNotificationsSurface}
       renderThreadSurface={(column) =>
-        renderDetailSurface('thread', column.entityId, column.scope?.topicId)
+        renderDetailSurface(
+          'thread',
+          column.entityId,
+          column.scope?.topicId,
+          column.id,
+          column.scope?.channelId
+        )
       }
       renderProfileSurface={(column) =>
-        renderDetailSurface('profile', column.entityId, column.scope?.topicId)
+        renderDetailSurface(
+          'profile',
+          column.entityId,
+          column.scope?.topicId,
+          column.id,
+          column.scope?.channelId
+        )
       }
       titles={columnTitles}
     />

--- a/apps/desktop/src/shell/DesktopShellPage.workspaceResilience.test.tsx
+++ b/apps/desktop/src/shell/DesktopShellPage.workspaceResilience.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, within } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 
@@ -6,6 +6,7 @@ import { createDesktopMockApi } from '@/mocks/desktopApiMock';
 import { App } from '@/App';
 import {
   closestSection,
+  createDeferred,
   openSettingsSection,
   setViewportWidth,
 } from './DesktopShellPage.testHelpers';
@@ -153,6 +154,60 @@ test('Explore owns the affected-column notice and hides the healthy primary node
   const notice = await screen.findByTestId('community-node-unavailable-notice');
   const exploreColumn = notice.closest('[data-column-id]');
   expect(exploreColumn).toHaveAccessibleName(/^Explore Column/);
+});
+
+test('Explore does not flash a false no-node warning while another Column triggers manifest refresh', async () => {
+  const baseApi = createDesktopMockApi();
+  const manifestResponse = await baseApi.fetchCommunityNodeManifest('https://api.kukuri.app');
+  const pendingManifest = createDeferred<typeof manifestResponse>();
+  let holdManifestRefresh = false;
+  const fetchCommunityNodeManifest = vi.fn((baseUrl: string) =>
+    holdManifestRefresh
+      ? pendingManifest.promise
+      : baseApi.fetchCommunityNodeManifest(baseUrl)
+  );
+  const api: DesktopApi = {
+    ...baseApi,
+    fetchCommunityNodeManifest,
+  };
+  const user = userEvent.setup();
+
+  render(<App api={api} />);
+  await user.click(await screen.findByTestId('control-center-trigger'));
+  const controlCenter = screen.getByRole('complementary', { name: 'Control Center' });
+  await user.click(within(controlCenter).getByRole('button', { name: 'Add Explore Column' }));
+
+  const explore = await screen.findByTestId('community-index-explore');
+  const noEligibleNode =
+    'No authenticated and consented Community Node currently advertises an available Community Index.';
+  await waitFor(() => {
+    expect(fetchCommunityNodeManifest).toHaveBeenCalled();
+    expect(within(explore).queryByText(noEligibleNode)).not.toBeInTheDocument();
+  });
+  const initialManifestCalls = fetchCommunityNodeManifest.mock.calls.length;
+  const transientWarnings: string[] = [];
+  const observer = new MutationObserver(() => {
+    if (explore.textContent?.includes(noEligibleNode)) transientWarnings.push(noEligibleNode);
+  });
+  observer.observe(explore, { childList: true, subtree: true, characterData: true });
+
+  holdManifestRefresh = true;
+  const timeline = screen.getByRole('region', { name: /^Timeline Column,/ });
+  fireEvent.pointerDown(within(timeline).getByRole('heading', { level: 2, name: 'Timeline' }));
+
+  await waitFor(() => {
+    expect(fetchCommunityNodeManifest.mock.calls.length).toBeGreaterThan(initialManifestCalls);
+  });
+  expect(within(explore).queryByText(noEligibleNode)).not.toBeInTheDocument();
+  expect(transientWarnings).toEqual([]);
+
+  await act(async () => {
+    pendingManifest.resolve(manifestResponse);
+    await pendingManifest.promise;
+  });
+  observer.disconnect();
+  expect(within(explore).queryByText(noEligibleNode)).not.toBeInTheDocument();
+  expect(transientWarnings).toEqual([]);
 });
 
 test('timeline keeps the last successful workspace state when joined channels refresh fails', async () => {

--- a/apps/desktop/src/shell/actions/messageReactionSocial.ts
+++ b/apps/desktop/src/shell/actions/messageReactionSocial.ts
@@ -113,10 +113,14 @@ export function createMessageReactionSocialActions({
     }
   }
 
-  async function handleOpenNotification(notification: NotificationView) {
+  async function handleOpenNotification(
+    notification: NotificationView,
+    parentColumnId?: string
+  ) {
     if (notification.kind === 'direct_message') {
       await openDirectMessagePane(notification.actor_pubkey, {
         historyMode: 'push',
+        parentColumnId,
       });
       return;
     }
@@ -135,6 +139,7 @@ export function createMessageReactionSocialActions({
       });
       await openAuthorDetail(notification.actor_pubkey, {
         historyMode: 'replace',
+        parentColumnId,
       });
       return;
     }
@@ -160,7 +165,9 @@ export function createMessageReactionSocialActions({
 
     if (threadTargetId) {
       await openThread(threadTargetId, {
+        channelId: nextChannelId,
         historyMode: 'replace',
+        parentColumnId,
         topic: targetTopic,
       });
       return;

--- a/apps/desktop/src/shell/actions/shared.ts
+++ b/apps/desktop/src/shell/actions/shared.ts
@@ -1,7 +1,7 @@
 import type { Dispatch, SetStateAction } from 'react';
 
 import type { DesktopApi } from '@/lib/api';
-import type { OpenThreadOptions } from '@/shell/routes';
+import type { OpenAuthorOptions, OpenThreadOptions } from '@/shell/routes';
 import type { DesktopShellState, DesktopShellStateValue } from '@/shell/store';
 
 export type Setter<K extends keyof DesktopShellState> = (
@@ -20,6 +20,7 @@ export type OpenDirectMessagePane = (
   options?: {
     historyMode?: 'push' | 'replace';
     normalizeOnError?: boolean;
+    parentColumnId?: string;
     preserveAuthorPane?: boolean;
     preservedAuthorPubkey?: string | null;
   }
@@ -27,14 +28,7 @@ export type OpenDirectMessagePane = (
 
 export type OpenAuthorDetail = (
   authorPubkey: string,
-  options?: {
-    fromThread?: boolean;
-    historyMode?: 'push' | 'replace';
-    normalizeOnError?: boolean;
-    threadId?: string | null;
-    preserveDirectMessageContext?: boolean;
-    directMessagePeerPubkey?: string | null;
-  }
+  options?: OpenAuthorOptions
 ) => Promise<void>;
 
 export type OpenThread = (

--- a/apps/desktop/src/shell/data/loaders/useDesktopShellSectionLoaders.ts
+++ b/apps/desktop/src/shell/data/loaders/useDesktopShellSectionLoaders.ts
@@ -393,7 +393,12 @@ export function useDesktopShellSectionLoaders({
       setCommunityNodeManifests((current) => {
         const next = { ...current };
         for (const baseUrl of baseUrls) {
-          next[baseUrl] = { status: 'loading' };
+          // A refresh is background work when a usable manifest is already on screen.
+          // Keep that successful value until the replacement settles so consumers do not
+          // briefly project an empty/no-node state while another Column is activated.
+          if (next[baseUrl]?.status !== 'ok') {
+            next[baseUrl] = { status: 'loading' };
+          }
         }
         return next;
       });

--- a/apps/desktop/src/shell/page/DesktopShellColumnWorkspace.tsx
+++ b/apps/desktop/src/shell/page/DesktopShellColumnWorkspace.tsx
@@ -57,8 +57,8 @@ type DesktopShellColumnWorkspaceProps = {
   onOpenGameCreate: () => void;
   onOpenLiveCreate: () => void;
   renderConversationSurface: (column: ColumnState) => ReactNode;
-  messagesSurface: ReactNode;
-  notificationsSurface: ReactNode;
+  renderMessagesSurface: (column: ColumnState) => ReactNode;
+  renderNotificationsSurface: (column: ColumnState) => ReactNode;
   onActivateColumn: (column: ColumnState, preserveAuthorPane?: boolean) => void;
   onSelectTimelineView: (column: ColumnState, view: TimelineViewId) => void;
   renderProfileSurface: (column: ColumnState) => ReactNode;
@@ -82,8 +82,8 @@ export function DesktopShellColumnWorkspace({
   onOpenGameCreate,
   onOpenLiveCreate,
   renderConversationSurface,
-  messagesSurface,
-  notificationsSurface,
+  renderMessagesSurface,
+  renderNotificationsSurface,
   onActivateColumn,
   onSelectTimelineView,
   renderProfileSurface,
@@ -140,8 +140,8 @@ export function DesktopShellColumnWorkspace({
     if (column.kind === 'thread') return renderThreadSurface(column);
     if (column.kind === 'profile' && column.entityId) return renderProfileSurface(column);
     if (column.kind === 'conversation') return renderConversationSurface(column);
-    if (column.kind === 'messages') return messagesSurface;
-    if (column.kind === 'notifications') return notificationsSurface;
+    if (column.kind === 'messages') return renderMessagesSurface(column);
+    if (column.kind === 'notifications') return renderNotificationsSurface(column);
     return renderPrimarySurface(column);
   };
   const scopeDestinationLabel = (column: ColumnState) => {

--- a/apps/desktop/src/shell/routes.ts
+++ b/apps/desktop/src/shell/routes.ts
@@ -37,6 +37,7 @@ export type OpenThreadOptions = {
   focusObjectId?: string | null;
   historyMode?: 'push' | 'replace';
   normalizeOnEmpty?: boolean;
+  parentColumnId?: string;
   topic?: string;
 };
 
@@ -44,6 +45,7 @@ export type OpenAuthorOptions = {
   fromThread?: boolean;
   historyMode?: 'push' | 'replace';
   normalizeOnError?: boolean;
+  parentColumnId?: string;
   threadId?: string | null;
   preserveDirectMessageContext?: boolean;
   directMessagePeerPubkey?: string | null;

--- a/apps/desktop/src/shell/useDesktopShellRouting.ts
+++ b/apps/desktop/src/shell/useDesktopShellRouting.ts
@@ -237,6 +237,7 @@ export function useDesktopShellRouting({
       options?: {
         historyMode?: 'push' | 'replace';
         normalizeOnError?: boolean;
+        parentColumnId?: string;
         preserveAuthorPane?: boolean;
         preservedAuthorPubkey?: string | null;
       }
@@ -270,12 +271,16 @@ export function useDesktopShellRouting({
         setKnownAuthorsByPubkey((current) =>
           mergeKnownAuthors(current, [authorViewFromDirectMessageConversation(conversation)])
         );
-        const scope = activeWorkspaceScope(storeApi.getState().workspaceState);
+        const currentWorkspaceState = storeApi.getState().workspaceState;
+        const parentColumn = options?.parentColumnId
+          ? currentWorkspaceState.columns.find((column) => column.id === options.parentColumnId)
+          : undefined;
+        const scope = parentColumn?.scope ?? activeWorkspaceScope(currentWorkspaceState);
         openWorkspaceColumn(
           'conversation',
           scope,
           peerPubkey,
-          storeApi.getState().workspaceState.activeColumnId
+          options?.parentColumnId ?? currentWorkspaceState.activeColumnId
         );
         setDirectMessagePaneOpen(true);
         setSelectedLiveSessionId(null);
@@ -404,7 +409,7 @@ export function useDesktopShellRouting({
           'thread',
           scope,
           threadId,
-          storeApi.getState().workspaceState.activeColumnId
+          options?.parentColumnId ?? storeApi.getState().workspaceState.activeColumnId
         );
         syncRoute(options?.historyMode ?? 'push', {
           activeTopic: topic,
@@ -513,8 +518,13 @@ export function useDesktopShellRouting({
             : undefined,
         });
         const currentState = storeApi.getState();
-        const scope = activeWorkspaceScope(currentState.workspaceState);
-        const parentColumnId = options?.fromThread && nextThreadId
+        const explicitParentColumn = options?.parentColumnId
+          ? currentState.workspaceState.columns.find(
+              (column) => column.id === options.parentColumnId
+            )
+          : undefined;
+        const scope = explicitParentColumn?.scope ?? activeWorkspaceScope(currentState.workspaceState);
+        const parentColumnId = options?.parentColumnId ?? (options?.fromThread && nextThreadId
           ? columnIdentityId('thread', scope, nextThreadId)
           : options?.preserveDirectMessageContext && nextDirectMessagePeerPubkey
             ? columnIdentityId('conversation', scope, nextDirectMessagePeerPubkey)
@@ -523,7 +533,7 @@ export function useDesktopShellRouting({
                   column.kind === 'timeline' &&
                   column.scope?.topicId === scope.topicId &&
                   column.scope.channelId === scope.channelId
-              )?.id ?? currentState.workspaceState.activeColumnId;
+              )?.id ?? currentState.workspaceState.activeColumnId);
         openWorkspaceColumn('profile', scope, authorPubkey, parentColumnId);
       } catch (detailError) {
         const nextError =


### PR DESCRIPTION
## Summary
- keep the last successful Community Node manifest visible while a background refresh is pending, preventing a false no-node warning flash
- pass the originating Column through profile, thread, conversation, and notification navigation so transient derived Columns open immediately after their source
- preserve logical Conversation parenting for DM author details and retain the existing pinned-Column position rule

Closes #813

## UI review
- Classification: navigation / multi-component state flow; no CSS or design-language change
- Target: Windows Tauri WebView, 1283x871, dark theme, Japanese locale
- Before: the new regression tests reproduced a transient Explore no-node warning and a Profile Column opening away from Notifications
- After: a MutationObserver assertion saw no warning during a held manifest refresh, and the opened Profile was adjacent to the source Notifications Column
- Windows Computer Use: activated Timeline while Explore remained visible and sampled six consecutive frames; Explore content stayed stable with no false warning. Exercised pinned/transient Column controls and verified pinned Profile position retention. Restored the original workspace order and active Timeline; discarded the test draft without publishing
- Accessibility/input: pointer and accessibility-tree indexed controls were both exercised; existing keyboard, narrow-layout, and localization Playwright coverage remains green
- Performance: no additional API calls or polling; the change only preserves an already loaded manifest during refresh and carries an existing Column id through navigation

## Validation
- cargo xtask doctor
- cargo xtask check
- cargo xtask test (694 workspace tests + 22 serial harness tests + doc tests + 918 frontend tests)
- cargo xtask desktop-ui-check (lint, typecheck, 918 Vitest tests, Storybook build, 44 browser Playwright tests, 14 Windows visual smoke tests)
- targeted regression: DesktopShellPage.workspaceResilience.test.tsx, DesktopShellPage.notifications.test.tsx, DesktopShellPage.messages.test.tsx (24 tests)