### PR TITLE
本文・メディア取得不能時の無限読み込みを解消する (#814)

### DIFF
--- a/apps/desktop/src/components/core/PostCard.stories.tsx
+++ b/apps/desktop/src/components/core/PostCard.stories.tsx
@@ -137,6 +137,56 @@ export const ImageReady: Story = {
   },
 };
 
+export const UnavailableContentAndMedia: Story = {
+  args: {
+    view: createView({
+      post: {
+        ...basePost,
+        content: '[blob pending]',
+        content_status: 'Missing',
+      },
+      media: {
+        objectId: 'image-post',
+        kind: 'image',
+        extraAttachmentCount: 0,
+        state: 'unavailable',
+        metaMime: 'image/png',
+        metaBytesLabel: '2.0 KB',
+        imagePreviewSrc: null,
+        videoPosterPreviewSrc: null,
+        videoPlaybackSrc: null,
+        videoUnsupportedOnClient: false,
+      },
+      showUnavailableDiagnostics: false,
+    }),
+  },
+};
+
+export const DeveloperUnavailableDiagnostics: Story = {
+  args: {
+    view: createView({
+      post: {
+        ...basePost,
+        content: '[blob pending]',
+        content_status: 'Missing',
+      },
+      media: {
+        objectId: 'image-post',
+        kind: 'image',
+        extraAttachmentCount: 0,
+        state: 'unavailable',
+        metaMime: 'image/png',
+        metaBytesLabel: '2.0 KB',
+        imagePreviewSrc: null,
+        videoPosterPreviewSrc: null,
+        videoPlaybackSrc: null,
+        videoUnsupportedOnClient: false,
+      },
+      showUnavailableDiagnostics: true,
+    }),
+  },
+};
+
 export const VideoPosterOnly: Story = {
   args: {
     view: createView({

--- a/apps/desktop/src/components/core/PostCard.test.tsx
+++ b/apps/desktop/src/components/core/PostCard.test.tsx
@@ -47,6 +47,75 @@ test('post card renders the author image when one is available', () => {
   );
 });
 
+test('post card omits unavailable body and media from normal UI', () => {
+  const base = createView();
+  render(
+    <PostCard
+      view={createView({
+        post: {
+          ...base.post,
+          content: '[blob pending]',
+          content_status: 'Missing',
+          attachments: [
+            {
+              hash: 'b'.repeat(64),
+              mime: 'image/png',
+              bytes: 2048,
+              role: 'image_original',
+              status: 'Missing',
+            },
+          ],
+        },
+        media: {
+          ...base.media,
+          kind: 'image',
+          state: 'unavailable',
+          metaMime: 'image/png',
+          metaBytesLabel: '2.0 KB',
+        },
+        showUnavailableDiagnostics: false,
+      })}
+      onOpenAuthor={() => undefined}
+      onOpenThread={() => undefined}
+      onReply={() => undefined}
+    />
+  );
+
+  expect(screen.queryByText('[blob pending]')).not.toBeInTheDocument();
+  expect(screen.queryByText('Content unavailable.')).not.toBeInTheDocument();
+  expect(screen.queryByText('Media unavailable.')).not.toBeInTheDocument();
+  expect(screen.queryByText('image/png')).not.toBeInTheDocument();
+  expect(screen.queryByText('2.0 KB')).not.toBeInTheDocument();
+});
+
+test('post card exposes concise unavailable diagnostics in developer mode', () => {
+  const base = createView();
+  render(
+    <PostCard
+      view={createView({
+        post: {
+          ...base.post,
+          content: '[blob pending]',
+          content_status: 'Missing',
+        },
+        media: {
+          ...base.media,
+          kind: 'image',
+          state: 'unavailable',
+        },
+        showUnavailableDiagnostics: true,
+      })}
+      onOpenAuthor={() => undefined}
+      onOpenThread={() => undefined}
+      onReply={() => undefined}
+    />
+  );
+
+  expect(screen.getByText('Content unavailable.')).toHaveAttribute('role', 'status');
+  expect(screen.getByText('Media unavailable.')).toHaveAttribute('role', 'status');
+  expect(screen.queryByText('[blob pending]')).not.toBeInTheDocument();
+});
+
 test('clicking the author avatar triggers the same author action as the name', async () => {
   const user = userEvent.setup();
   const onOpenAuthor = vi.fn();

--- a/apps/desktop/src/components/core/PostCard.tsx
+++ b/apps/desktop/src/components/core/PostCard.tsx
@@ -149,7 +149,7 @@ export function PostCard({
     null
   );
   const [reactionMenuAsset, setReactionMenuAsset] = useState<CustomReactionAssetView | null>(null);
-  const isPendingText = post.content_status === 'Missing' && post.content === '[blob pending]';
+  const isUnavailableText = post.content_status === 'Missing' && post.content === '[blob pending]';
   const localState = post.local_state ?? null;
   const isWithdrawn = post.withdrawal != null;
   const interactionDisabled = localState !== null || isWithdrawn;
@@ -182,7 +182,7 @@ export function PostCard({
           ? t('feed.localFailed')
           : null;
   const primaryContent = showRepostAsPrimary && repostSource ? repostSource.content : post.content;
-  const hasPrimaryContent = isPendingText || primaryContent.trim().length > 0;
+  const hasPrimaryContent = !isUnavailableText && primaryContent.trim().length > 0;
   const reactionSummary = post.reaction_summary ?? [];
   const myReactionKeys = useMemo(
     () => new Set((post.my_reactions ?? []).map((reaction) => reaction.normalized_reaction_key)),
@@ -383,15 +383,12 @@ export function PostCard({
           <p className='topic-diagnostic topic-diagnostic-secondary' role='status'>
             {t('feed.withdrawnPost')}
           </p>
-        ) : isPendingText ? (
-          <div
-            className='text-skeleton-group'
-            data-testid={`text-skeleton-${post.object_id}`}
-            aria-hidden='true'
-          >
-            <span className='text-skeleton text-skeleton-line' />
-            <span className='text-skeleton text-skeleton-line text-skeleton-line-short' />
-          </div>
+        ) : isUnavailableText ? (
+          view.showUnavailableDiagnostics ? (
+            <p className='topic-diagnostic topic-diagnostic-secondary' role='status'>
+              {t('feed.contentUnavailable')}
+            </p>
+          ) : null
         ) : hasPrimaryContent ? (
           <strong className='post-title post-copy-wrap'>
             <SmartReferenceText
@@ -490,6 +487,7 @@ export function PostCard({
       {!isWithdrawn && view.media.kind ? (
         <PostMedia
           media={view.media}
+          showUnavailableDiagnostic={view.showUnavailableDiagnostics}
           onOpenImage={(index) => {
             setMediaViewerIndex(index);
             setMediaViewerOpen(true);

--- a/apps/desktop/src/components/core/PostMedia.tsx
+++ b/apps/desktop/src/components/core/PostMedia.tsx
@@ -8,17 +8,30 @@ import { type PostMediaView } from './types';
 
 type PostMediaProps = {
   media: PostMediaView;
+  showUnavailableDiagnostic?: boolean;
   onOpenImage?: (index: number) => void;
   /// 動画添付そのものを media として通報する(#697)。未指定なら操作を出さない。
   onReportVideo?: (hash: string) => void;
 };
 
-export function PostMedia({ media, onOpenImage, onReportVideo }: PostMediaProps) {
+export function PostMedia({
+  media,
+  showUnavailableDiagnostic = false,
+  onOpenImage,
+  onReportVideo,
+}: PostMediaProps) {
   const { t } = useTranslation(['common', 'shell']);
   const videoReportHash = media.kind === 'video' ? media.videoReportHash : null;
 
   if (!media.kind) {
     return null;
+  }
+  if (media.state === 'unavailable') {
+    return showUnavailableDiagnostic ? (
+      <p className='topic-diagnostic topic-diagnostic-secondary' role='status'>
+        {t('media.unavailable')}
+      </p>
+    ) : null;
   }
 
   return (

--- a/apps/desktop/src/components/core/types.ts
+++ b/apps/desktop/src/components/core/types.ts
@@ -48,7 +48,7 @@ export type PostMediaView = {
   kind: 'image' | 'video' | null;
   statusLabel?: string | null;
   extraAttachmentCount: number;
-  state: 'loading' | 'ready';
+  state: 'loading' | 'ready' | 'unavailable';
   metaMime?: string | null;
   metaBytesLabel?: string | null;
   imagePreviewSrc?: string | null;
@@ -113,6 +113,7 @@ export type PostCardView = {
   repostSourceAuthor?: ReferencedAuthorMeta | null;
   replyParentAuthor?: ReferencedAuthorMeta | null;
   suppressReplyPreview?: boolean;
+  showUnavailableDiagnostics?: boolean;
   mentionAuthors?: Record<string, MentionAuthorView>;
   // 正本（通常は author_docs）と、index / moderation / cache 等の観測経路を分離して保持する。
   // 通報ルーティング（#310）・content details・default node boundary 説明に使う。

--- a/apps/desktop/src/i18n/locales/en/common.json
+++ b/apps/desktop/src/i18n/locales/en/common.json
@@ -97,6 +97,7 @@
     "unsupportedAttachmentType": "unsupported attachment type: {{name}}"
   },
   "feed": {
+    "contentUnavailable": "Content unavailable.",
     "localFailed": "Publish failed",
     "localPosting": "Posting…",
     "localSyncing": "Syncing…",
@@ -155,6 +156,7 @@
     "viewers": "viewers"
   },
   "media": {
+    "unavailable": "Media unavailable.",
     "closeDialog": "Close image viewer",
     "imageAlt": "image attachment",
     "reportVideo": "Report video attachment",

--- a/apps/desktop/src/i18n/locales/ja/common.json
+++ b/apps/desktop/src/i18n/locales/ja/common.json
@@ -97,6 +97,7 @@
     "unsupportedAttachmentType": "未対応の添付タイプです: {{name}}"
   },
   "feed": {
+    "contentUnavailable": "本文を取得できません。",
     "localFailed": "投稿に失敗しました",
     "localPosting": "投稿中…",
     "localSyncing": "同期中…",
@@ -155,6 +156,7 @@
     "viewers": "視聴者"
   },
   "media": {
+    "unavailable": "メディアを取得できません。",
     "closeDialog": "画像ビューアーを閉じる",
     "imageAlt": "画像添付",
     "reportVideo": "動画添付を通報",

--- a/apps/desktop/src/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/i18n/locales/zh-CN/common.json
@@ -97,6 +97,7 @@
     "unsupportedAttachmentType": "不支持的附件类型: {{name}}"
   },
   "feed": {
+    "contentUnavailable": "无法获取正文。",
     "localFailed": "发布失败",
     "localPosting": "发布中…",
     "localSyncing": "同步中…",
@@ -155,6 +156,7 @@
     "viewers": "观看者"
   },
   "media": {
+    "unavailable": "无法获取媒体。",
     "closeDialog": "关闭图片查看器",
     "imageAlt": "图片附件",
     "reportVideo": "举报视频附件",

--- a/apps/desktop/src/shell/DesktopShellPage.mediaRendering.test.tsx
+++ b/apps/desktop/src/shell/DesktopShellPage.mediaRendering.test.tsx
@@ -1,10 +1,11 @@
-import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 
 import { createDesktopMockApi } from '@/mocks/desktopApiMock';
 import { App } from '@/App';
 import {
+  createDeferred,
   getDetailPane,
   buildImagePost,
   buildVideoPost,
@@ -12,6 +13,7 @@ import {
   setViewportWidth,
 } from './DesktopShellPage.testHelpers';
 import type { BlobViewStatus } from '@/lib/api';
+import { DEVELOPER_MODE_STORAGE_KEY } from '@/lib/developerMode';
 
 beforeEach(() => {
   setViewportWidth(1024);
@@ -22,7 +24,73 @@ afterEach(() => {
   vi.useRealTimers();
 });
 
-test('timeline image post shows media skeleton when attachment is missing', async () => {
+test('timeline image stops loading and hides unavailable media after a null response in normal mode', async () => {
+  window.localStorage.setItem(DEVELOPER_MODE_STORAGE_KEY, 'false');
+  const payload = createDeferred<null>();
+  const api = createDesktopMockApi({
+    seedPosts: {
+      'kukuri:topic:general': [
+        buildImagePost({ content: 'available caption', content_status: 'Available' }),
+      ],
+    },
+  });
+  api.getBlobMediaPayload = async () => payload.promise;
+
+  render(<App api={api} />);
+
+  expect(await screen.findByTestId('media-skeleton-image-post')).toBeInTheDocument();
+  act(() => payload.resolve(null));
+
+  await waitFor(() => {
+    expect(screen.queryByTestId('media-skeleton-image-post')).not.toBeInTheDocument();
+  });
+  expect(screen.queryByText('image/png')).not.toBeInTheDocument();
+  expect(screen.queryByText('Media unavailable.')).not.toBeInTheDocument();
+});
+
+test('timeline image stops loading and hides unavailable media after a rejected response in normal mode', async () => {
+  window.localStorage.setItem(DEVELOPER_MODE_STORAGE_KEY, 'false');
+  const payload = createDeferred<null>();
+  const api = createDesktopMockApi({
+    seedPosts: {
+      'kukuri:topic:general': [
+        buildImagePost({ content: 'available caption', content_status: 'Available' }),
+      ],
+    },
+  });
+  api.getBlobMediaPayload = async () => payload.promise;
+
+  render(<App api={api} />);
+
+  expect(await screen.findByTestId('media-skeleton-image-post')).toBeInTheDocument();
+  act(() => payload.reject(new Error('blob unavailable')));
+
+  await waitFor(() => {
+    expect(screen.queryByTestId('media-skeleton-image-post')).not.toBeInTheDocument();
+  });
+  expect(screen.queryByText('image/png')).not.toBeInTheDocument();
+  expect(screen.queryByText('blob unavailable')).not.toBeInTheDocument();
+});
+
+test('missing text body does not occupy normal UI', async () => {
+  window.localStorage.setItem(DEVELOPER_MODE_STORAGE_KEY, 'false');
+  render(
+    <App
+      api={createDesktopMockApi({
+        seedPosts: {
+          'kukuri:topic:general': [buildImagePost({ attachments: [] })],
+        },
+      })}
+    />
+  );
+
+  expect(await screen.findByText('envelope-image-post')).toBeInTheDocument();
+  expect(screen.queryByTestId('text-skeleton-image-post')).not.toBeInTheDocument();
+  expect(screen.queryByText('[blob pending]')).not.toBeInTheDocument();
+  expect(screen.queryByText('Content unavailable.')).not.toBeInTheDocument();
+});
+
+test('developer mode shows concise diagnostics after body and media become unavailable', async () => {
   const api = createDesktopMockApi({
     seedPosts: {
       'kukuri:topic:general': [buildImagePost()],
@@ -32,11 +100,26 @@ test('timeline image post shows media skeleton when attachment is missing', asyn
 
   render(<App api={api} />);
 
-  await waitFor(() => {
-    expect(screen.getByTestId('media-skeleton-image-post')).toBeInTheDocument();
+  expect(await screen.findByText('Content unavailable.')).toBeInTheDocument();
+  expect(await screen.findByText('Media unavailable.')).toBeInTheDocument();
+  expect(screen.queryByTestId('text-skeleton-image-post')).not.toBeInTheDocument();
+  expect(screen.queryByTestId('media-skeleton-image-post')).not.toBeInTheDocument();
+  expect(screen.queryByText('[blob pending]')).not.toBeInTheDocument();
+});
+
+test('developer mode replaces a missing image skeleton with a diagnostic', async () => {
+  const api = createDesktopMockApi({
+    seedPosts: {
+      'kukuri:topic:general': [buildImagePost()],
+    },
   });
-  expect(screen.getByTestId('media-skeleton-image-post')).toBeInTheDocument();
-  expect(screen.getByText('image/png')).toBeInTheDocument();
+  api.getBlobMediaPayload = async () => null;
+
+  render(<App api={api} />);
+
+  expect(await screen.findByText('Media unavailable.')).toBeInTheDocument();
+  expect(screen.queryByTestId('media-skeleton-image-post')).not.toBeInTheDocument();
+  expect(screen.queryByText('image/png')).not.toBeInTheDocument();
 });
 
 test('timeline image post switches to ready state when attachment becomes available', async () => {
@@ -82,8 +165,45 @@ test('timeline image post switches to ready state when attachment becomes availa
   expect(screen.queryByTestId('media-skeleton-image-post')).not.toBeInTheDocument();
 });
 
-test('timeline image post renders actual preview when object-url payload is available', async () => {
+test('timeline image recovers when an existing refresh retries a previously unavailable hash', async () => {
+  window.localStorage.setItem(DEVELOPER_MODE_STORAGE_KEY, 'false');
   installObjectUrlMocks();
+  const missingPost = buildImagePost({ content: 'caption', content_status: 'Available' });
+  const unavailableApi = createDesktopMockApi({
+    seedPosts: { 'kukuri:topic:general': [missingPost] },
+  });
+  unavailableApi.getBlobMediaPayload = async () => null;
+  const recoveredApi = createDesktopMockApi({
+    seedPosts: {
+      'kukuri:topic:general': [
+        buildImagePost({
+          content: 'caption',
+          content_status: 'Available',
+          attachments: [{ ...missingPost.attachments[0], status: 'Available' }],
+        }),
+      ],
+    },
+  });
+  recoveredApi.getBlobMediaPayload = async (_hash, mime) => ({
+    bytes_base64: 'ZmFrZS1pbWFnZQ==',
+    mime,
+  });
+
+  const { rerender } = render(<App api={unavailableApi} />);
+  await waitFor(() => {
+    expect(screen.queryByTestId('media-skeleton-image-post')).not.toBeInTheDocument();
+  });
+
+  rerender(<App api={recoveredApi} />);
+
+  expect(await screen.findByTestId('media-preview-image-post')).toHaveAttribute(
+    'src',
+    expect.stringContaining('blob:mock-')
+  );
+});
+
+test('timeline image post renders actual preview when object-url payload is available', async () => {
+  const { revokeObjectUrl } = installObjectUrlMocks();
   const api = createDesktopMockApi({
     seedPosts: {
       'kukuri:topic:general': [
@@ -108,14 +228,19 @@ test('timeline image post renders actual preview when object-url payload is avai
     mime: 'image/png',
   });
 
-  render(<App api={api} />);
+  const { unmount } = render(<App api={api} />);
 
   const preview = await screen.findByTestId('media-preview-image-post');
   expect(preview).toBeInTheDocument();
   expect(preview.getAttribute('src')).toContain('blob:mock-');
+  expect(revokeObjectUrl).not.toHaveBeenCalled();
+
+  unmount();
+  expect(revokeObjectUrl).toHaveBeenCalledOnce();
+  expect(revokeObjectUrl).toHaveBeenCalledWith(preview.getAttribute('src'));
 });
 
-test('thread pane reuses the same image placeholder renderer', async () => {
+test('thread pane reuses the same unavailable media renderer', async () => {
   const user = userEvent.setup();
   const api = createDesktopMockApi({
     seedPosts: {
@@ -149,31 +274,27 @@ test('thread pane reuses the same image placeholder renderer', async () => {
   await waitFor(() => expect(getDetailPane('Thread')).toBeInTheDocument());
   const threadPanel = getDetailPane('Thread');
 
-  await waitFor(() => {
-    expect(within(threadPanel).getByTestId('media-skeleton-image-post')).toBeInTheDocument();
-  });
-  expect(within(threadPanel).getByTestId('media-skeleton-image-post')).toBeInTheDocument();
+  expect(await within(threadPanel).findByText('Media unavailable.')).toBeInTheDocument();
+  expect(within(threadPanel).queryByTestId('media-skeleton-image-post')).not.toBeInTheDocument();
 });
 
-test('text body pending uses text skeleton without hiding image metadata', async () => {
+test('developer mode reports an unavailable text body without rendering its placeholder', async () => {
   render(
     <App
       api={createDesktopMockApi({
         seedPosts: {
-          'kukuri:topic:general': [buildImagePost()],
+          'kukuri:topic:general': [buildImagePost({ attachments: [] })],
         },
       })}
     />
   );
 
-  await waitFor(() => {
-    expect(screen.getByTestId('text-skeleton-image-post')).toBeInTheDocument();
-  });
-  expect(screen.getByText('image/png')).toBeInTheDocument();
-  expect(screen.getByText('2.0 KB')).toBeInTheDocument();
+  expect(await screen.findByText('Content unavailable.')).toBeInTheDocument();
+  expect(screen.queryByTestId('text-skeleton-image-post')).not.toBeInTheDocument();
+  expect(screen.queryByText('[blob pending]')).not.toBeInTheDocument();
 });
 
-test('timeline video post shows poster skeleton when poster is missing', async () => {
+test('developer mode replaces an unavailable video skeleton with a diagnostic', async () => {
   const api = createDesktopMockApi({
     seedPosts: {
       'kukuri:topic:general': [buildVideoPost()],
@@ -183,11 +304,9 @@ test('timeline video post shows poster skeleton when poster is missing', async (
 
   render(<App api={api} />);
 
-  await waitFor(() => {
-    expect(screen.getByTestId('media-skeleton-video-post')).toBeInTheDocument();
-  });
-  expect(screen.getByTestId('media-skeleton-video-post')).toBeInTheDocument();
-  expect(screen.getByText('video/mp4')).toBeInTheDocument();
+  expect(await screen.findByText('Media unavailable.')).toBeInTheDocument();
+  expect(screen.queryByTestId('media-skeleton-video-post')).not.toBeInTheDocument();
+  expect(screen.queryByText('video/mp4')).not.toBeInTheDocument();
 });
 
 test('poster-only video card renders poster preview without video element', async () => {

--- a/apps/desktop/src/shell/data/useDesktopShellDataEffects.ts
+++ b/apps/desktop/src/shell/data/useDesktopShellDataEffects.ts
@@ -2,6 +2,7 @@ import {
   startTransition,
   useCallback,
   useEffect,
+  useRef,
   type MutableRefObject,
 } from 'react';
 
@@ -138,6 +139,7 @@ export function useDesktopShellDataEffects({
   setTimelineScopeByTopic,
   setMediaObjectUrls,
 }: UseDesktopShellDataEffectsArgs) {
+  const mediaFetchInputRef = useRef(new Map<string, AttachmentView>());
   // 非 active な Timeline Column が Bookmarks を表示しているか(bookmarks ロード gate 用、Issue #765)。
   const hasBookmarksTimelineColumn = useDesktopShellStore((state) =>
     state.workspaceState.columns.some((column) => column.timelineView === 'bookmarks')
@@ -507,11 +509,21 @@ export function useDesktopShellDataEffects({
 
   useEffect(() => {
     let disposed = false;
+    const currentHashes = new Set(previewableMediaAttachments.map((attachment) => attachment.hash));
+    for (const hash of mediaFetchInputRef.current.keys()) {
+      if (!currentHashes.has(hash)) {
+        mediaFetchInputRef.current.delete(hash);
+      }
+    }
 
     for (const attachment of previewableMediaAttachments) {
       if (typeof mediaObjectUrls[attachment.hash] === 'string') {
         continue;
       }
+      if (mediaFetchInputRef.current.get(attachment.hash) === attachment) {
+        continue;
+      }
+      mediaFetchInputRef.current.set(attachment.hash, attachment);
 
       const nextAttempt = (mediaFetchAttemptRef.current.get(attachment.hash) ?? 0) + 1;
       mediaFetchAttemptRef.current.set(attachment.hash, nextAttempt);
@@ -541,6 +553,11 @@ export function useDesktopShellDataEffects({
               role: attachment.role,
               status: attachment.status,
             });
+            setMediaObjectUrls((current) =>
+              typeof current[attachment.hash] === 'string' || current[attachment.hash] === null
+                ? current
+                : { ...current, [attachment.hash]: null }
+            );
             return;
           }
 
@@ -555,7 +572,7 @@ export function useDesktopShellDataEffects({
           });
 
           setMediaObjectUrls((current) => {
-            if (current[attachment.hash] !== undefined) {
+            if (typeof current[attachment.hash] === 'string') {
               URL.revokeObjectURL(nextUrl);
               return current;
             }
@@ -578,6 +595,11 @@ export function useDesktopShellDataEffects({
             role: attachment.role,
             status: attachment.status,
           });
+          setMediaObjectUrls((current) =>
+            typeof current[attachment.hash] === 'string' || current[attachment.hash] === null
+              ? current
+              : { ...current, [attachment.hash]: null }
+          );
         });
     }
 
@@ -587,6 +609,7 @@ export function useDesktopShellDataEffects({
   }, [
     api,
     mediaFetchAttemptRef,
+    mediaFetchInputRef,
     mediaObjectUrls,
     previewableMediaAttachments,
     remoteObjectUrlRef,

--- a/apps/desktop/src/shell/useDesktopShellViewModels.test.tsx
+++ b/apps/desktop/src/shell/useDesktopShellViewModels.test.tsx
@@ -268,6 +268,13 @@ describe('useDesktopShellViewModels', () => {
     expect(card.media.currentImageIndex).toBe(0);
 
     actPatchState(view.store, {
+      mediaObjectUrls: { [imageHash]: null },
+    });
+
+    const unavailableCard = view.result.current.activeTimelinePostViews[0];
+    expect(unavailableCard.media.state).toBe('unavailable');
+
+    actPatchState(view.store, {
       mediaObjectUrls: { [imageHash]: 'blob:image-preview-1' },
     });
 

--- a/apps/desktop/src/shell/useDesktopShellViewModels.ts
+++ b/apps/desktop/src/shell/useDesktopShellViewModels.ts
@@ -153,6 +153,7 @@ export function useDesktopShellViewModels({
     activeJoinedChannels,
     activeTimeline,
     bookmarkedPosts,
+    developerModeEnabled: state.developerModeEnabled,
     knownAuthorsByPubkey,
     localAuthorPubkey: syncStatus.local_author_pubkey,
     locale,

--- a/apps/desktop/src/shell/viewModels/useTimelineViewModels.ts
+++ b/apps/desktop/src/shell/viewModels/useTimelineViewModels.ts
@@ -5,7 +5,7 @@ import type {
   PostCardView,
   ReferencedAuthorMeta,
 } from '@/components/core/types';
-import type { PostView, ProfileAssetView } from '@/lib/api';
+import type { AttachmentView, PostView, ProfileAssetView } from '@/lib/api';
 import { contentProvenanceFromView } from '@/lib/api/provenance';
 import type { SupportedLocale } from '@/i18n';
 import { extractMentions } from '@/lib/internalLinks';
@@ -36,6 +36,7 @@ type UseTimelineViewModelsArgs = {
   activeJoinedChannels: DesktopShellState['joinedChannelsByTopic'][string];
   activeTimeline: PostView[];
   bookmarkedPosts: DesktopShellState['bookmarkedPosts'];
+  developerModeEnabled: boolean;
   knownAuthorsByPubkey: DesktopShellState['knownAuthorsByPubkey'];
   localAuthorPubkey: string;
   locale: SupportedLocale;
@@ -51,6 +52,7 @@ export function useTimelineViewModels({
   activeJoinedChannels,
   activeTimeline,
   bookmarkedPosts,
+  developerModeEnabled,
   knownAuthorsByPubkey,
   localAuthorPubkey,
   locale,
@@ -109,6 +111,17 @@ export function useTimelineViewModels({
         videoManifest && typeof mediaObjectUrls[videoManifest.hash] === 'string'
           ? mediaObjectUrls[videoManifest.hash]
           : null;
+      const hasSettledUnavailable = (hash: string) =>
+        Object.prototype.hasOwnProperty.call(mediaObjectUrls, hash) &&
+        mediaObjectUrls[hash] === null;
+      const mediaUnavailable =
+        mediaKind === 'image'
+          ? Boolean(primaryImage && hasSettledUnavailable(primaryImage.hash))
+          : mediaKind === 'video'
+            ? [videoManifest, videoPoster]
+                .filter((attachment): attachment is AttachmentView => attachment !== null)
+                .every((attachment) => hasSettledUnavailable(attachment.hash))
+            : false;
       const videoUnsupportedOnClient = Boolean(
         videoManifest && unsupportedVideoManifests[videoManifest.hash]
       );
@@ -244,6 +257,7 @@ export function useTimelineViewModels({
         replyParentAuthor,
         mentionAuthors,
         suppressReplyPreview: context === 'thread',
+        showUnavailableDiagnostics: developerModeEnabled,
         media: {
           objectId: post.object_id,
           kind: mediaKind,
@@ -252,12 +266,16 @@ export function useTimelineViewModels({
             mediaKind === 'video'
               ? videoPlaybackSrc || videoPosterPreviewSrc
                 ? 'ready'
-                : 'loading'
+                : mediaUnavailable
+                  ? 'unavailable'
+                  : 'loading'
               : mediaKind === 'image'
                 ? imagePreviewSrc
                   ? 'ready'
-                  : 'loading'
-                : 'loading',
+                  : mediaUnavailable
+                    ? 'unavailable'
+                    : 'loading'
+                : 'ready',
           metaMime: mediaMetaAttachment?.mime ?? null,
           metaBytesLabel: mediaMetaAttachment
             ? formatBytes(mediaMetaAttachment.bytes, locale)
@@ -293,6 +311,7 @@ export function useTimelineViewModels({
     },
     [
       activeJoinedChannels,
+      developerModeEnabled,
       knownAuthorsByPubkey,
       localAuthorPubkey,
       localProfile,

--- a/apps/desktop/src/styles/shell-phase1-part2.css
+++ b/apps/desktop/src/styles/shell-phase1-part2.css
@@ -184,27 +184,6 @@
   font-size: var(--text-caption);
 }
 
-.text-skeleton-group {
-  display: grid;
-  gap: var(--space-xs);
-}
-
-.text-skeleton {
-  display: block;
-  height: 0.95rem;
-  border-radius: var(--radius-pill);
-  background: var(--surface-skeleton);
-  animation: skeleton-pulse 1.8s ease-in-out infinite;
-}
-
-.text-skeleton-line {
-  width: 92%;
-}
-
-.text-skeleton-line-short {
-  width: 58%;
-}
-
 .post-actions {
   display: flex;
   justify-content: flex-end;

--- a/apps/desktop/tests/playwright/media-unavailable.spec.ts
+++ b/apps/desktop/tests/playwright/media-unavailable.spec.ts
@@ -1,0 +1,120 @@
+import { expect, test, type Page } from '@playwright/test';
+
+import { DEVELOPER_MODE_STORAGE_KEY } from '../../src/lib/developerMode';
+
+const MEDIA_HASH = 'a'.repeat(64);
+
+async function installUnavailableMediaScenario(
+  page: Page,
+  options: { developerMode: boolean; rejectInitialFetch: boolean }
+) {
+  await page.addInitScript(
+    ({ developerModeKey, developerMode, mediaHash, rejectInitialFetch }) => {
+      window.localStorage.setItem(developerModeKey, developerMode ? 'true' : 'false');
+      let desktopApi: typeof window.__KUKURI_DESKTOP__;
+      Object.defineProperty(window, '__KUKURI_DESKTOP__', {
+        configurable: true,
+        get: () => desktopApi,
+        set: (value: NonNullable<typeof window.__KUKURI_DESKTOP__>) => {
+          const originalListTimeline = value.listTimeline.bind(value);
+          value.listTimeline = async (topic, cursor, limit, channelId) => {
+            if (topic !== 'kukuri:topic:general') {
+              return originalListTimeline(topic, cursor, limit, channelId);
+            }
+            const recovered = window.sessionStorage.getItem('issue-814-recovered') === 'true';
+            return {
+              items: [
+                {
+                  object_id: 'browser-unavailable',
+                  envelope_id: 'browser-unavailable-envelope',
+                  author_pubkey: 'f'.repeat(64),
+                  author_name: 'fixture-author',
+                  author_display_name: 'Fixture Author',
+                  following: false,
+                  followed_by: false,
+                  mutual: false,
+                  friend_of_friend: false,
+                  object_kind: 'post',
+                  is_threadable: true,
+                  content: recovered ? 'Recovered body' : '[blob pending]',
+                  content_status: recovered ? 'Available' : 'Missing',
+                  attachments: [
+                    {
+                      hash: mediaHash,
+                      mime: 'image/png',
+                      bytes: 2048,
+                      role: 'image_original',
+                      status: recovered ? 'Available' : 'Missing',
+                    },
+                  ],
+                  created_at: 1,
+                  reply_to: null,
+                  root_id: 'browser-unavailable',
+                  channel_id: null,
+                  audience_label: 'Public',
+                },
+              ],
+              next_cursor: null,
+            };
+          };
+          value.getBlobMediaPayload = async (_hash, mime) => {
+            if (window.sessionStorage.getItem('issue-814-recovered') === 'true') {
+              return { bytes_base64: 'ZmFrZS1pbWFnZQ==', mime };
+            }
+            if (rejectInitialFetch) {
+              throw new Error('fixture blob unavailable');
+            }
+            return null;
+          };
+          desktopApi = value;
+        },
+      });
+    },
+    {
+      developerModeKey: DEVELOPER_MODE_STORAGE_KEY,
+      developerMode: options.developerMode,
+      mediaHash: MEDIA_HASH,
+      rejectInitialFetch: options.rejectInitialFetch,
+    }
+  );
+}
+
+test('normal mode removes unavailable content and media after a null response', async ({ page }) => {
+  await installUnavailableMediaScenario(page, {
+    developerMode: false,
+    rejectInitialFetch: false,
+  });
+  await page.goto('/#/timeline?topic=kukuri%3Atopic%3Ageneral');
+
+  await expect(page.getByText('browser-unavailable-envelope')).toBeVisible();
+  await expect(page.getByText('image/png')).toHaveCount(0);
+  await expect(page.getByTestId('text-skeleton-browser-unavailable')).toHaveCount(0);
+  await expect(page.getByTestId('media-skeleton-browser-unavailable')).toHaveCount(0);
+  await expect(page.getByText('Content unavailable.')).toHaveCount(0);
+  await expect(page.getByText('Media unavailable.')).toHaveCount(0);
+});
+
+test('developer mode reports a rejected fetch and an existing refresh can recover it', async ({
+  page,
+}) => {
+  await installUnavailableMediaScenario(page, {
+    developerMode: true,
+    rejectInitialFetch: true,
+  });
+  await page.goto('/#/timeline?topic=kukuri%3Atopic%3Ageneral');
+
+  await expect(page.getByText('Content unavailable.')).toBeVisible();
+  await expect(page.getByText('Media unavailable.')).toBeVisible();
+  await expect(page.getByText('fixture blob unavailable')).toHaveCount(0);
+
+  await page.evaluate(() => {
+    window.sessionStorage.setItem('issue-814-recovered', 'true');
+  });
+  await page.goto('/#/timeline?topic=kukuri%3Atopic%3Adev');
+  await page.goto('/#/timeline?topic=kukuri%3Atopic%3Ageneral');
+
+  await expect(page.getByText('Recovered body')).toBeVisible();
+  await expect(page.getByTestId('media-preview-browser-unavailable')).toBeVisible();
+  await expect(page.getByText('Content unavailable.')).toHaveCount(0);
+  await expect(page.getByText('Media unavailable.')).toHaveCount(0);
+});


### PR DESCRIPTION
## Summary
- treat null/rejected blob media fetches as a settled unavailable state instead of leaving the skeleton active
- hide unavailable body/media portions in normal UI and show concise localized diagnostics in Developer mode
- keep the existing refresh path able to recover the same hash, while revoking accepted or late object URLs safely

## UI review
- Normal mode: unavailable body/media occupy no space; MIME/byte metadata and internal errors are not exposed.
- Developer mode: `本文を取得できません。` / `メディアを取得できません。` are shown as compact status text.
- Recovery: leaving and reopening the topic retries refreshed attachment metadata and restores body/media.
- Storybook states added for both normal and Developer unavailable presentations.

## Validation
- `cargo xtask doctor`
- `cargo xtask check`
- Rust workspace: 694 passed, 3 skipped
- Harness: 22 passed
- Frontend full suite at reduced local concurrency: 121 files / 925 tests passed
- `src/shell/routes.test.tsx`: 15 passed in isolation
- Storybook production build
- Browser Playwright: 46 passed, including 2 Issue #814 scenarios
- Visual Playwright: 14 passed
- `git diff --check`

The default-concurrency local frontend gate repeatedly hit the existing 5-second timeout in the unchanged `topic and private channel selection sync into the hash route` test (all other 924 tests passed). The same test passed in isolation, and the complete 925-test suite passed with two workers. CI remains the merge gate.

## Windows real-device check
- Started the native Tauri debug application on Windows and operated it through Computer Use.
- Verified stable Timeline rendering across the persisted `general`, `dev`, and `test` topics with no infinite text/media skeleton or raw internal error.
- Verified Developer mode can be enabled and disabled through Settings; restored it to disabled afterward.
- No post, deletion, upload, or other representational action was performed.

Closes #814