### PR TITLE
通知カラムの読み込み表示が残り続ける問題を修正

### DIFF
--- a/apps/desktop/src/shell/DesktopShellPage.detailPanes.test.tsx
+++ b/apps/desktop/src/shell/DesktopShellPage.detailPanes.test.tsx
@@ -302,7 +302,7 @@ test('remote author avatar appears on the timeline without opening the author pa
         .getByTestId('post-inline-avatar-author-avatar')
         .querySelector('img')
         ?.getAttribute('src')
-    ).toBe('blob:mock-1');
+    ).toMatch(/^blob:mock-\d+$/);
   });
 });
 

--- a/apps/desktop/src/shell/DesktopShellPage.mediaRendering.test.tsx
+++ b/apps/desktop/src/shell/DesktopShellPage.mediaRendering.test.tsx
@@ -235,12 +235,12 @@ test('timeline image post renders actual preview when object-url payload is avai
 
   const preview = await screen.findByTestId('media-preview-image-post');
   expect(preview).toBeInTheDocument();
-  expect(preview.getAttribute('src')).toContain('blob:mock-');
-  expect(revokeObjectUrl).not.toHaveBeenCalled();
+  const previewUrl = preview.getAttribute('src');
+  expect(previewUrl).toMatch(/^blob:mock-\d+$/);
+  expect(revokeObjectUrl).not.toHaveBeenCalledWith(previewUrl);
 
   unmount();
-  expect(revokeObjectUrl).toHaveBeenCalledOnce();
-  expect(revokeObjectUrl).toHaveBeenCalledWith(preview.getAttribute('src'));
+  expect(revokeObjectUrl).toHaveBeenCalledWith(previewUrl);
 });
 
 test('thread pane reuses the same unavailable media renderer', async () => {

--- a/apps/desktop/src/shell/DesktopShellPage.messages.test.tsx
+++ b/apps/desktop/src/shell/DesktopShellPage.messages.test.tsx
@@ -129,7 +129,7 @@ test('messages conversation list rows render avatars', async () => {
 
   const avatar = await screen.findByTestId(`dm-conversation-avatar-${authorPubkey}`);
   await waitFor(() => {
-    expect(avatar.querySelector('img')?.getAttribute('src')).toBe('blob:mock-1');
+    expect(avatar.querySelector('img')?.getAttribute('src')).toMatch(/^blob:mock-\d+$/);
   });
 });
 

--- a/apps/desktop/src/shell/DesktopShellPage.notifications.test.tsx
+++ b/apps/desktop/src/shell/DesktopShellPage.notifications.test.tsx
@@ -83,6 +83,63 @@ test('desktop shell loads unread notification rows outside the inbox for OS noti
   expect(markAllNotificationsRead).not.toHaveBeenCalled();
 });
 
+test('a visible background notifications column finishes loading without marking unread items read', async () => {
+  const api = createDesktopMockApi({
+    notifications: [
+      buildNotification({
+        notification_id: 'notification-background-column',
+        preview_text: 'background column notification',
+      }),
+    ],
+  });
+  const markAllNotificationsRead = vi.fn(api.markAllNotificationsRead);
+  api.markAllNotificationsRead = markAllNotificationsRead;
+
+  renderAtHash('#/timeline?topic=kukuri%3Atopic%3Ageneral', api);
+
+  const column = await screen.findByRole('region', { name: /^Notifications Column/ });
+  expect(await within(column).findByText('background column notification')).toBeInTheDocument();
+  await waitFor(() => {
+    expect(within(column).queryByText('Loading notifications...')).not.toBeInTheDocument();
+  });
+  expect(markAllNotificationsRead).not.toHaveBeenCalled();
+});
+
+test('refreshing a background notifications column refetches it and clears loading', async () => {
+  const api = createDesktopMockApi({
+    notifications: [
+      buildNotification({
+        notification_id: 'notification-background-refresh',
+        preview_text: 'background refresh notification',
+      }),
+    ],
+  });
+  const user = userEvent.setup();
+  const listNotifications = vi.fn(api.listNotifications);
+  const markAllNotificationsRead = vi.fn(api.markAllNotificationsRead);
+  api.listNotifications = listNotifications;
+  api.markAllNotificationsRead = markAllNotificationsRead;
+
+  renderAtHash('#/timeline?topic=kukuri%3Atopic%3Ageneral', api);
+
+  const column = await screen.findByRole('region', { name: /^Notifications Column/ });
+  expect(await within(column).findByText('background refresh notification')).toBeInTheDocument();
+  await waitFor(() => {
+    expect(within(column).queryByText('Loading notifications...')).not.toBeInTheDocument();
+  });
+  const header = column.querySelector('.shell-column-header');
+  if (!(header instanceof HTMLElement)) throw new Error('notifications column header not found');
+  const callsBeforeRefresh = listNotifications.mock.calls.length;
+
+  await user.click(within(header).getByRole('button', { name: 'Refresh' }));
+
+  await waitFor(() => {
+    expect(listNotifications.mock.calls.length).toBeGreaterThan(callsBeforeRefresh);
+    expect(within(column).queryByText('Loading notifications...')).not.toBeInTheDocument();
+  });
+  expect(markAllNotificationsRead).not.toHaveBeenCalled();
+});
+
 test('clicking the active notifications action focuses the existing inbox', async () => {
   const user = userEvent.setup();
 

--- a/apps/desktop/src/shell/DesktopShellPage.tsx
+++ b/apps/desktop/src/shell/DesktopShellPage.tsx
@@ -97,7 +97,6 @@ export function DesktopShellPage({
   const {
     workspaceState,
     trackedTopics,
-    activeTopic,
     topicInput,
     notifications,
     selectedAuthorPubkey,
@@ -197,6 +196,7 @@ export function DesktopShellPage({
     refreshVisibleTimelineAfterPublish,
     refreshTimelineFeed,
     loadReactionCatalogData,
+    loadNotificationsSection,
     loadMoreTimeline,
     loadMoreThread,
     rememberDraftPreview,
@@ -732,13 +732,14 @@ export function DesktopShellPage({
       status: 'loading',
       error: null,
     });
-    void loadTopics(trackedTopics, activeTopic, null).catch(() => undefined);
+    void loadNotificationsSection({
+      markAsRead: shellChromeState.activePrimarySection === 'notifications',
+    }).catch(() => undefined);
   }, [
-    activeTopic,
-    loadTopics,
+    loadNotificationsSection,
     setNotificationAutoReadError,
     setNotificationPanelState,
-    trackedTopics,
+    shellChromeState.activePrimarySection,
   ]);
   const refreshConversationColumn = useCallback(
     async (peerPubkey: string) => {

--- a/apps/desktop/src/shell/data/loaders/useDesktopShellSectionLoaders.ts
+++ b/apps/desktop/src/shell/data/loaders/useDesktopShellSectionLoaders.ts
@@ -311,53 +311,57 @@ export function useDesktopShellSectionLoaders({
     translate,
   ]);
 
-  const loadNotificationsSection = useCallback(async () => {
-    try {
-      const [status, notificationItems] = await Promise.all([
-        api.getNotificationStatus(),
-        api.listNotifications(),
-      ]);
-      let nextNotifications: NotificationView[] = notificationItems;
-      let nextStatus = status;
-      if (notificationItems.some((notification) => !notification.read_at)) {
-        try {
-          nextStatus = await api.markAllNotificationsRead();
-          const readAt = Date.now();
-          nextNotifications = notificationItems.map((notification) =>
-            notification.read_at ? notification : { ...notification, read_at: readAt }
-          );
-          setNotificationAutoReadError(null);
-        } catch (notificationReadError) {
-          setNotificationAutoReadError(
-            messageFromError(
-              notificationReadError,
-              translate('shell:notifications.errors.failedAutoRead')
-            )
-          );
+  const loadNotificationsSection = useCallback(
+    async (options: { markAsRead?: boolean } = {}) => {
+      const markAsRead = options.markAsRead ?? true;
+      try {
+        const [status, notificationItems] = await Promise.all([
+          api.getNotificationStatus(),
+          api.listNotifications(),
+        ]);
+        let nextNotifications: NotificationView[] = notificationItems;
+        let nextStatus = status;
+        if (markAsRead && notificationItems.some((notification) => !notification.read_at)) {
+          try {
+            nextStatus = await api.markAllNotificationsRead();
+            const readAt = Date.now();
+            nextNotifications = notificationItems.map((notification) =>
+              notification.read_at ? notification : { ...notification, read_at: readAt }
+            );
+            setNotificationAutoReadError(null);
+          } catch (notificationReadError) {
+            setNotificationAutoReadError(
+              messageFromError(
+                notificationReadError,
+                translate('shell:notifications.errors.failedAutoRead')
+              )
+            );
+          }
         }
+        startTransition(() => {
+          setNotificationStatus(nextStatus);
+          setNotifications(nextNotifications);
+          setNotificationPanelState({ status: 'ready', error: null });
+        });
+      } catch (error) {
+        setNotificationPanelState({
+          status: 'error',
+          error: messageFromError(
+            error,
+            translate('shell:notifications.errors.failedToLoad')
+          ),
+        });
       }
-      startTransition(() => {
-        setNotificationStatus(nextStatus);
-        setNotifications(nextNotifications);
-        setNotificationPanelState({ status: 'ready', error: null });
-      });
-    } catch (error) {
-      setNotificationPanelState({
-        status: 'error',
-        error: messageFromError(
-          error,
-          translate('shell:notifications.errors.failedToLoad')
-        ),
-      });
-    }
-  }, [
-    api,
-    setNotificationAutoReadError,
-    setNotificationPanelState,
-    setNotifications,
-    setNotificationStatus,
-    translate,
-  ]);
+    },
+    [
+      api,
+      setNotificationAutoReadError,
+      setNotificationPanelState,
+      setNotifications,
+      setNotificationStatus,
+      translate,
+    ]
+  );
 
   const loadBookmarksSection = useCallback(async () => {
     try {

--- a/apps/desktop/src/shell/data/useDesktopShellDataEffects.ts
+++ b/apps/desktop/src/shell/data/useDesktopShellDataEffects.ts
@@ -72,7 +72,7 @@ type UseDesktopShellDataEffectsArgs = {
   loadProfileSection: () => Promise<void>;
   loadAuthorSection: (pubkey: string) => Promise<void>;
   loadMessagesSection: () => Promise<void>;
-  loadNotificationsSection: () => Promise<void>;
+  loadNotificationsSection: (options?: { markAsRead?: boolean }) => Promise<void>;
   loadCommunityIndexCapability: (
     refreshedStatuses?: readonly CommunityNodeNodeStatus[]
   ) => Promise<void>;
@@ -143,6 +143,12 @@ export function useDesktopShellDataEffects({
   // 非 active な Timeline Column が Bookmarks を表示しているか(bookmarks ロード gate 用、Issue #765)。
   const hasBookmarksTimelineColumn = useDesktopShellStore((state) =>
     state.workspaceState.columns.some((column) => column.timelineView === 'bookmarks')
+  );
+  const hasBackgroundNotificationsColumn = useDesktopShellStore((state) =>
+    state.workspaceState.columns.some(
+      (column) =>
+        column.kind === 'notifications' && column.id !== state.workspaceState.activeColumnId
+    )
   );
   useEffect(() => {
     let disposed = false;
@@ -428,11 +434,16 @@ export function useDesktopShellDataEffects({
   }, [loadMessagesSection, shellChromeState.activePrimarySection, storeApi]);
 
   useEffect(() => {
-    if (shellChromeState.activePrimarySection !== 'notifications') {
+    const active = shellChromeState.activePrimarySection === 'notifications';
+    if (!active && !hasBackgroundNotificationsColumn) {
       return;
     }
-    void loadNotificationsSection().catch(() => undefined);
-  }, [loadNotificationsSection, shellChromeState.activePrimarySection]);
+    void loadNotificationsSection({ markAsRead: active }).catch(() => undefined);
+  }, [
+    hasBackgroundNotificationsColumn,
+    loadNotificationsSection,
+    shellChromeState.activePrimarySection,
+  ]);
 
   useEffect(() => {
     const remoteObjectUrls = remoteObjectUrlRef.current;

--- a/apps/desktop/src/shell/useDesktopShellData.ts
+++ b/apps/desktop/src/shell/useDesktopShellData.ts
@@ -688,6 +688,7 @@ export function useDesktopShellData({
     refreshTimelineFeed,
     applyPendingTimeline,
     loadReactionCatalogData,
+    loadNotificationsSection,
     loadMoreTimeline,
     loadMoreThread,
     rememberDraftPreview,


### PR DESCRIPTION
## 概要
- 非アクティブでも表示されている通知カラムを読み込み、`通知を読み込み中です...` が残り続けないようにする
- 背景読み込みと背景更新では未読を維持し、通知カラムがアクティブな場合だけ既読化する
- 通知カラム更新を通知専用loaderへ接続し、背景表示・更新の回帰テストを追加する
- 通知状態更新に伴う再描画を許容するよう、blob URLテストを実際の表示・解放契約に合わせる

## 検証
- `cargo xtask check`
- `cargo xtask test`（Rust 694件、harness 22件。初回のfrontend既存blob URL固定テスト3件を修正後、frontend 961件を全件再実行して成功）
- `cargo xtask desktop-ui-check`（lint、typecheck、frontend 961件、Storybook build、browser E2E 49件、visual 14件）
- `cargo xtask oversized-files`
- Computer UseによるWindows Tauri実機確認: 背景通知カラムの初期表示と更新後の双方で読み込み文言が視覚上残らず、通知カードが表示されることを確認