### PR TITLE
見つけるカラムの投稿操作をタイムラインと統一

### DIFF
--- a/apps/desktop/src/components/core/CommunityIndexWorkspace.test.tsx
+++ b/apps/desktop/src/components/core/CommunityIndexWorkspace.test.tsx
@@ -95,6 +95,20 @@ function workspaceProps(
     selectedNodeBaseUrl: NODE_A,
     onOpenCommunityNodeSettings: vi.fn(),
     onOpenAuthor: vi.fn(),
+    onOpenThread: vi.fn(),
+    onOpenThreadInTopic: vi.fn(),
+    onReply: vi.fn(),
+    onRepost: vi.fn(),
+    onQuoteRepost: vi.fn(),
+    onToggleReaction: vi.fn(),
+    onBookmarkCustomReaction: vi.fn(),
+    onReactionPickerOpen: vi.fn(),
+    showBookmarkAction: true,
+    bookmarkedPostIds: new Set<string>(),
+    onToggleBookmark: vi.fn(),
+    onWithdraw: vi.fn(),
+    onActivateReference: vi.fn(),
+    onCopyPostLink: vi.fn(),
     ...overrides,
   };
 }
@@ -157,10 +171,71 @@ test('topic search sends the active public scope and renders results with the sh
   expect(screen.queryByText(/Search preview; may include derived tags/)).not.toBeInTheDocument();
   expect(screen.queryByText('rust')).not.toBeInTheDocument();
   expect(screen.queryByText('public_topic')).not.toBeInTheDocument();
-  expect(screen.queryByRole('button', { name: 'Reply' })).not.toBeInTheDocument();
-  expect(screen.queryByRole('button', { name: 'Repost' })).not.toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Reply' })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Repost' })).toBeInTheDocument();
   await user.click(screen.getByRole('button', { name: 'Alice' }));
   expect(onOpenAuthor).toHaveBeenCalledWith('author-1');
+});
+
+test('Explore results expose the same post actions as the timeline', async () => {
+  const user = userEvent.setup();
+  const onReply = vi.fn();
+  const onRepost = vi.fn();
+  const onToggleBookmark = vi.fn();
+  const searchCommunityNodeIndex = vi.fn().mockResolvedValue({
+    entries: [indexEntry('explore-actions', 'actionable result')],
+  });
+  const api = { searchCommunityNodeIndex } as unknown as DesktopApi;
+  const interactiveActions = {
+    onOpenThread: vi.fn(),
+    onOpenThreadInTopic: vi.fn(),
+    onReply,
+    onRepost,
+    onQuoteRepost: vi.fn(),
+    onToggleReaction: vi.fn(),
+    showBookmarkAction: true,
+    onToggleBookmark,
+    onCopyPostLink: vi.fn(),
+  };
+  render(
+    <CommunityIndexWorkspace
+      {...workspaceProps(api, { mode: 'explore' })}
+      {...interactiveActions}
+    />
+  );
+
+  runSearch();
+
+  const result = await screen.findByText('actionable result');
+  const card = result.closest('article');
+  if (!(card instanceof HTMLElement)) throw new Error('Explore result card not found');
+
+  expect(within(card).getByRole('button', { name: 'React' })).toBeEnabled();
+  expect(within(card).getByRole('button', { name: 'Repost' })).toBeInTheDocument();
+  expect(within(card).getByRole('button', { name: 'Reply' })).toBeInTheDocument();
+  expect(within(card).getByRole('button', { name: 'Copy link' })).toBeInTheDocument();
+  expect(within(card).getByRole('button', { name: 'Bookmark' })).toBeInTheDocument();
+  expect(within(card).getByRole('button', { name: 'Report' })).toBeInTheDocument();
+
+  await user.click(within(card).getByRole('button', { name: 'Reply' }));
+  expect(onReply).toHaveBeenCalledWith(
+    expect.objectContaining({
+      object_id: 'explore-actions',
+      published_topic_id: 'rust',
+      is_threadable: true,
+    })
+  );
+
+  await user.click(within(card).getByRole('button', { name: 'Bookmark' }));
+  expect(onToggleBookmark).toHaveBeenCalledWith(
+    expect.objectContaining({ object_id: 'explore-actions', published_topic_id: 'rust' })
+  );
+
+  await user.click(within(card).getByRole('button', { name: 'Repost' }));
+  await user.click(screen.getAllByRole('button', { name: 'Repost' })[1]);
+  expect(onRepost).toHaveBeenCalledWith(
+    expect.objectContaining({ object_id: 'explore-actions', published_topic_id: 'rust' })
+  );
 });
 
 test('index results hide identifiers and copy their complete values from context actions', async () => {

--- a/apps/desktop/src/components/core/CommunityIndexWorkspace.tsx
+++ b/apps/desktop/src/components/core/CommunityIndexWorkspace.tsx
@@ -5,12 +5,18 @@ import { useTranslation } from 'react-i18next';
 
 import type {
   AuthorSocialView,
+  BookmarkedCustomReactionView,
   CommunityNodeIndexQueryRequest,
+  CustomReactionAssetView,
   DesktopApi,
   IndexEntryView,
+  PostView,
+  ReactionKeyInput,
+  RecentReactionView,
   TimelineScope,
 } from '@/lib/api';
 import { InvokeError } from '@/lib/api/invoke/error';
+import type { InternalSmartReference } from '@/lib/internalLinks';
 import { copyTextToClipboard } from '@/lib/utils';
 
 import { Button } from '@/components/ui/button';
@@ -33,6 +39,24 @@ type CommunityIndexWorkspaceProps = {
   knownAuthorsByPubkey?: Record<string, AuthorSocialView>;
   mediaObjectUrls?: Record<string, string | null>;
   onOpenAuthor: (pubkey: string) => void;
+  onOpenThread?: (threadId: string) => void;
+  onOpenThreadInTopic?: (threadId: string, topicId: string) => void;
+  onReply?: (post: PostView) => void;
+  onRepost?: (post: PostView) => void;
+  onQuoteRepost?: (post: PostView) => void;
+  localAuthorPubkey?: string;
+  ownedReactionAssets?: CustomReactionAssetView[];
+  bookmarkedReactionAssets?: BookmarkedCustomReactionView[];
+  recentReactions?: RecentReactionView[];
+  onToggleReaction?: (post: PostView, reactionKey: ReactionKeyInput) => void;
+  onBookmarkCustomReaction?: (asset: CustomReactionAssetView) => void;
+  onReactionPickerOpen?: () => void;
+  showBookmarkAction?: boolean;
+  bookmarkedPostIds?: Set<string>;
+  onToggleBookmark?: (post: PostView) => void;
+  onWithdraw?: (post: PostView) => void;
+  onActivateReference?: (reference: InternalSmartReference) => void;
+  onCopyPostLink?: (link: string) => void;
 };
 
 type IndexRequestContext = {
@@ -130,6 +154,24 @@ export function CommunityIndexWorkspace({
   knownAuthorsByPubkey = {},
   mediaObjectUrls = {},
   onOpenAuthor,
+  onOpenThread,
+  onOpenThreadInTopic,
+  onReply,
+  onRepost,
+  onQuoteRepost,
+  localAuthorPubkey,
+  ownedReactionAssets = [],
+  bookmarkedReactionAssets = [],
+  recentReactions = [],
+  onToggleReaction,
+  onBookmarkCustomReaction,
+  onReactionPickerOpen,
+  showBookmarkAction = false,
+  bookmarkedPostIds,
+  onToggleBookmark,
+  onWithdraw,
+  onActivateReference,
+  onCopyPostLink,
 }: CommunityIndexWorkspaceProps) {
   const { t } = useTranslation(['shell', 'common']);
   const [operation, setOperation] = useState<IndexOperation>('search');
@@ -163,6 +205,7 @@ export function CommunityIndexWorkspace({
         view: communityIndexPostCardView(entry, {
           nodeBaseUrl: visibleResult.context.nodeBaseUrl,
           operation: visibleResult.context.operation,
+          topicId: visibleResult.context.topicId ?? null,
           knownAuthor: knownAuthorsByPubkey[entry.author_pubkey] ?? null,
           mediaObjectUrls,
         }),
@@ -315,11 +358,27 @@ export function CommunityIndexWorkspace({
             <li key={key}>
               <PostCard
                 view={view}
-                readOnly
+                readOnly={!view.threadTopicId}
                 mediaObjectUrls={mediaObjectUrls}
                 onOpenAuthor={onOpenAuthor}
-                onOpenThread={() => undefined}
-                onReply={() => undefined}
+                onOpenThread={onOpenThread ?? (() => undefined)}
+                onOpenThreadInTopic={onOpenThreadInTopic}
+                onReply={onReply ?? (() => undefined)}
+                onRepost={onRepost}
+                onQuoteRepost={onQuoteRepost}
+                localAuthorPubkey={localAuthorPubkey}
+                ownedReactionAssets={ownedReactionAssets}
+                bookmarkedReactionAssets={bookmarkedReactionAssets}
+                recentReactions={recentReactions}
+                onToggleReaction={onToggleReaction}
+                onBookmarkCustomReaction={onBookmarkCustomReaction}
+                onReactionPickerOpen={onReactionPickerOpen}
+                showBookmarkAction={showBookmarkAction}
+                isBookmarked={bookmarkedPostIds?.has(view.post.object_id) ?? false}
+                onToggleBookmark={onToggleBookmark}
+                onWithdraw={onWithdraw}
+                onActivateReference={onActivateReference}
+                onCopyLink={onCopyPostLink}
                 onSubmitReport={(request) => api.submitCommunityNodeReport(request)}
                 onCopyReportContact={(value) => void copyTextToClipboard(value)}
                 onFetchReportManifest={(baseUrl) => api.fetchCommunityNodeManifest(baseUrl)}

--- a/apps/desktop/src/components/core/communityIndexPostCardView.test.ts
+++ b/apps/desktop/src/components/core/communityIndexPostCardView.test.ts
@@ -42,6 +42,7 @@ describe('communityIndexPostCardView', () => {
     const view = communityIndexPostCardView(entry, {
       nodeBaseUrl: 'https://node.example',
       operation: 'search',
+      topicId: null,
       knownAuthor,
       mediaObjectUrls: {},
     });
@@ -57,14 +58,17 @@ describe('communityIndexPostCardView', () => {
       attachments: [],
       reaction_summary: [],
       my_reactions: [],
-      is_threadable: false,
+      is_threadable: true,
+      published_topic_id: entry.scope_id,
       reply_to: null,
       repost_of: null,
     });
     expect(view.authorLabel).toBe('Alice');
     expect(view.authorPicture).toBe('https://example.test/alice.png');
     expect(view.audienceChipLabel).toBe('Public');
-    expect(view.threadTopicId).toBeNull();
+    expect(view.threadTopicId).toBe(entry.scope_id);
+    expect(view.canReply).toBe(true);
+    expect(view.canRepost).toBe(true);
     expect(view.media).toMatchObject({ kind: null, state: 'ready', extraAttachmentCount: 0 });
     expect(view.identifierCopy).toEqual({
       postId: entry.object_id,
@@ -89,6 +93,7 @@ describe('communityIndexPostCardView', () => {
     const view = communityIndexPostCardView(entry, {
       nodeBaseUrl: 'https://node.example',
       operation,
+      topicId: null,
       knownAuthor: null,
       mediaObjectUrls: {},
     });
@@ -105,12 +110,37 @@ describe('communityIndexPostCardView', () => {
       {
         nodeBaseUrl: 'https://node.example',
         operation: 'search',
+        topicId: null,
         knownAuthor: null,
         mediaObjectUrls: {},
       }
     );
 
     expect(view.audienceChipLabel).toBe('Private channel');
+    expect(view.threadTopicId).toBeNull();
+    expect(view.post.channel_id).toBeNull();
     expect(JSON.stringify(view)).not.toContain('private-channel-secret-id');
+  });
+
+  test('restores a private channel interaction context only when its parent topic is known', () => {
+    const view = communityIndexPostCardView(
+      { ...entry, scope_kind: 'private_channel', scope_id: 'channel-1' },
+      {
+        nodeBaseUrl: 'https://node.example',
+        operation: 'search',
+        topicId: 'kukuri:topic:rust',
+        knownAuthor: null,
+        mediaObjectUrls: {},
+      }
+    );
+
+    expect(view.threadTopicId).toBe('kukuri:topic:rust');
+    expect(view.post).toMatchObject({
+      published_topic_id: 'kukuri:topic:rust',
+      channel_id: 'channel-1',
+      is_threadable: true,
+    });
+    expect(view.canReply).toBe(true);
+    expect(view.canRepost).toBe(false);
   });
 });

--- a/apps/desktop/src/components/core/communityIndexPostCardView.ts
+++ b/apps/desktop/src/components/core/communityIndexPostCardView.ts
@@ -9,6 +9,7 @@ export type CommunityIndexOperation = 'search' | 'discovery' | 'recommendations'
 type CommunityIndexPostCardViewOptions = {
   nodeBaseUrl: string;
   operation: CommunityIndexOperation;
+  topicId: string | null;
   knownAuthor: AuthorSocialView | null;
   mediaObjectUrls: Record<string, string | null>;
 };
@@ -26,6 +27,9 @@ export function communityIndexPostCardView(
   const recommendation = options.operation === 'recommendations';
   const capability = recommendation ? 'recommendation' : 'community_index';
   const knownAuthor = options.knownAuthor;
+  const topicId =
+    entry.scope_kind === 'public_topic' ? entry.scope_id : options.topicId?.trim() || null;
+  const channelId = topicId && entry.scope_kind === 'private_channel' ? entry.scope_id : null;
   const authorLabel = authorDisplayLabel(
     entry.author_pubkey,
     knownAuthor?.display_name,
@@ -57,12 +61,12 @@ export function communityIndexPostCardView(
       reply_preview: null,
       root_id: null,
       object_kind: 'post',
-      published_topic_id: null,
+      published_topic_id: topicId,
       origin_topic_id: null,
       repost_of: null,
       repost_commentary: null,
-      is_threadable: false,
-      channel_id: null,
+      is_threadable: topicId !== null,
+      channel_id: channelId,
       audience_label: audience,
       reaction_summary: [],
       my_reactions: [],
@@ -73,9 +77,9 @@ export function communityIndexPostCardView(
     relationshipLabel: null,
     audienceChipLabel: audience,
     threadTargetId: entry.object_id,
-    threadTopicId: null,
-    canReply: false,
-    canRepost: false,
+    threadTopicId: topicId,
+    canReply: topicId !== null,
+    canRepost: entry.scope_kind === 'public_topic',
     media: {
       objectId: entry.object_id,
       kind: null,

--- a/apps/desktop/src/shell/DesktopShellPage.communityIndex.test.tsx
+++ b/apps/desktop/src/shell/DesktopShellPage.communityIndex.test.tsx
@@ -86,7 +86,15 @@ test('Explore header selects named eligible nodes, clears stale results, and ret
   });
   await user.type(within(explore).getByLabelText('Search query'), 'hello');
   await user.click(within(explore).getByRole('button', { name: 'Run' }));
-  expect(await within(explore).findByText(`result from ${NODE_B}`)).toBeInTheDocument();
+  const result = await within(explore).findByText(`result from ${NODE_B}`);
+  const resultCard = result.closest('article');
+  if (!(resultCard instanceof HTMLElement)) throw new Error('Explore result card not found');
+  expect(within(resultCard).getByRole('button', { name: 'React' })).toBeEnabled();
+  expect(within(resultCard).getByRole('button', { name: 'Repost' })).toBeInTheDocument();
+  expect(within(resultCard).getByRole('button', { name: 'Reply' })).toBeInTheDocument();
+  expect(within(resultCard).getByRole('button', { name: 'Copy link' })).toBeInTheDocument();
+  expect(within(resultCard).getByRole('button', { name: 'Bookmark' })).toBeInTheDocument();
+  expect(within(resultCard).getByRole('button', { name: 'Report' })).toBeInTheDocument();
 
   await user.selectOptions(nodeSelect, NODE_A);
   await waitFor(() => {

--- a/apps/desktop/src/shell/page/DesktopShellPrimaryWorkspace.tsx
+++ b/apps/desktop/src/shell/page/DesktopShellPrimaryWorkspace.tsx
@@ -471,6 +471,24 @@ export function DesktopShellPrimarySurface({
             knownAuthorsByPubkey={knownAuthorsByPubkey}
             mediaObjectUrls={mediaObjectUrls}
             onOpenAuthor={(pubkey) => void openAuthorDetail(pubkey)}
+            onOpenThread={openThreadInSurfaceScope}
+            onOpenThreadInTopic={openThreadInTopicFromSurface}
+            onReply={beginColumnReply}
+            onRepost={(post) => void handleSimpleRepost(post)}
+            onQuoteRepost={beginColumnQuoteRepost}
+            localAuthorPubkey={syncStatus.local_author_pubkey}
+            ownedReactionAssets={ownedReactionAssets}
+            bookmarkedReactionAssets={bookmarkedReactionAssets}
+            recentReactions={recentReactions}
+            onToggleReaction={(post, reactionKey) => void handleToggleReaction(post, reactionKey)}
+            onBookmarkCustomReaction={(asset) => void handleBookmarkCustomReaction(asset)}
+            onReactionPickerOpen={() => void loadReactionCatalogData()}
+            showBookmarkAction={true}
+            bookmarkedPostIds={bookmarkedPostIds}
+            onToggleBookmark={(post) => void handleToggleBookmarkedPost(post)}
+            onWithdraw={(post) => void handleWithdrawPost(post)}
+            onActivateReference={(reference) => void handleActivateReference(reference)}
+            onCopyPostLink={handleCopyInternalLink}
           />
         ) : null}
 

--- a/apps/desktop/tests/playwright/community-index.spec.ts
+++ b/apps/desktop/tests/playwright/community-index.spec.ts
@@ -9,7 +9,7 @@ async function openControlCenter(page: import('@playwright/test').Page) {
   return controlCenter;
 }
 
-test('Timeline keeps Community Index out of the primary surface and Explore keeps reporting behavior visible', async ({ page }) => {
+test('Timeline keeps Community Index out of the primary surface and Explore exposes timeline post actions', async ({ page }) => {
   await page.setViewportSize({ width: 1400, height: 980 });
   await page.goto('/#/timeline?topic=kukuri%3Atopic%3Ageneral');
 
@@ -25,8 +25,12 @@ test('Timeline keeps Community Index out of the primary surface and Explore keep
   await expect(explore.getByText('dev topic seed for builder preview')).toBeVisible();
   const searchCard = explore.locator('article.post-card').first();
   await expect(searchCard).toBeVisible();
+  await expect(searchCard.getByRole('button', { name: 'React' })).toBeVisible();
+  await expect(searchCard.getByRole('button', { name: 'Repost' })).toBeVisible();
+  await expect(searchCard.getByRole('button', { name: 'Reply' })).toBeVisible();
+  await expect(searchCard.getByRole('button', { name: 'Copy link' })).toBeVisible();
+  await expect(searchCard.getByRole('button', { name: 'Bookmark' })).toBeVisible();
   await expect(searchCard.getByRole('button', { name: 'Report' })).toBeVisible();
-  await expect(searchCard.getByRole('button', { name: 'Reply' })).toHaveCount(0);
   await expect(explore.getByText(/Search preview; may include derived tags/)).toHaveCount(0);
   await expect(explore.getByText('public_topic', { exact: true })).toHaveCount(0);
 


### PR DESCRIPTION
## 概要

「見つける」カラムの投稿カードに、通常のタイムラインと同じ操作群を表示します。

## 変更内容

- リアクション、リポスト、返信、リンクコピー、ブックマーク、報告を表示
- 自分の投稿では取り下げ操作も共有コンポーネント経由で利用可能
- 公開結果にはトピックコンテキストを復元し、返信・リポストを有効化
- 非公開結果は親トピックを解決できる場合のみ返信を有効化し、リポストは無効のまま維持
- 親トピックを解決できない非公開結果は読み取り専用のまま維持し、生のチャンネルIDを露出しない

## 対象と非目標

- 対象: 既存の「見つける」画面における投稿操作の改善
- 非目標: インデックスプロトコルやドメインモデルの拡張、投稿カードの再設計

## 検証

- `cargo xtask check`
- `cargo xtask test`（Rust 694件、harness 22件、frontend 963件）
- `cargo xtask desktop-ui-check`（browser E2E 49件、visual 14件を含む）
- `cargo xtask oversized-files`
- `git diff --check`

既存の共通IconButton/PostCardを利用しているため、アクセシブルネーム、ツールチップ、キーボード操作を維持しています。ブラウザで表現可能な変更であり、Tauriネイティブ固有の挙動は含みません。


## マージ後の仕様決定（2026-08-31）

本PRをIssue #820の操作仕様に対する正式な上書きとする。従来の「read-only PostCard」前提は廃止する。

「提供部分のみ有効化」は「Community Indexの結果から実処理を完了できる投稿アクションのボタンのみを表示し、有効化する」と定義する。必要な識別子とtopic / channel文脈、権限・capability、対象objectの取得・解決、backend処理、成功後の画面反映まで成立することを動作可能の条件とし、ボタン表示、callback、API呼び出しだけでは完了とみなさない。

返信、リポスト、リアクション、リンクコピー、ブックマーク、通報、取り下げなど、共通PostCardが提示し得るすべての投稿アクションを対象とする。条件を満たせないアクションは表示しない。本PRのマージ時検証で処理完了まで確認されていない操作は、Issue #820の再定義後の完了条件を満たしたものとは扱わない。
