### PR TITLE
feat(desktop): Ctrl+Enterでコンポーザーを送信する

### DIFF
--- a/apps/desktop/src/components/core/ComposerPanel.test.tsx
+++ b/apps/desktop/src/components/core/ComposerPanel.test.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react';
-import { render, screen } from '@testing-library/react';
+import { useState, type FormEventHandler } from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { expect, test, vi } from 'vitest';
 
@@ -13,7 +13,15 @@ const MENTION_CANDIDATES: MentionCandidate[] = [
   { pubkey: BOB, label: 'Bob', displayName: 'Bob', name: 'bob', about: null, picture: null },
 ];
 
-function MentionHarness({ candidates = MENTION_CANDIDATES }: { candidates?: MentionCandidate[] }) {
+function MentionHarness({
+  candidates = MENTION_CANDIDATES,
+  onSubmit = (event) => event.preventDefault(),
+  submitDisabled = false,
+}: {
+  candidates?: MentionCandidate[];
+  onSubmit?: FormEventHandler<HTMLFormElement>;
+  submitDisabled?: boolean;
+}) {
   const [value, setValue] = useState('');
   return (
     <ComposerPanel
@@ -21,7 +29,8 @@ function MentionHarness({ candidates = MENTION_CANDIDATES }: { candidates?: Ment
       onChange={(event) => setValue(event.target.value)}
       onValueChange={setValue}
       mentionCandidates={candidates}
-      onSubmit={(event) => event.preventDefault()}
+      onSubmit={onSubmit}
+      submitDisabled={submitDisabled}
       attachmentInputKey={0}
       onAttachmentSelection={() => undefined}
       draftMediaItems={[]}
@@ -31,6 +40,51 @@ function MentionHarness({ candidates = MENTION_CANDIDATES }: { candidates?: Ment
     />
   );
 }
+
+test('Ctrl+Enter submits the composer form exactly once', async () => {
+  const user = userEvent.setup();
+  const onSubmit = vi.fn<FormEventHandler<HTMLFormElement>>((event) => event.preventDefault());
+  render(<MentionHarness onSubmit={onSubmit} />);
+
+  const textarea = screen.getByRole('textbox');
+  await user.click(textarea);
+  await user.type(textarea, 'keyboard post');
+  await user.keyboard('{Control>}{Enter}{/Control}');
+
+  expect(onSubmit).toHaveBeenCalledTimes(1);
+});
+
+test('Enter and Shift+Enter keep inserting line breaks while Alt+Enter keeps its default behavior', async () => {
+  const user = userEvent.setup();
+  const onSubmit = vi.fn<FormEventHandler<HTMLFormElement>>((event) => event.preventDefault());
+  render(<MentionHarness onSubmit={onSubmit} />);
+
+  const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+  await user.click(textarea);
+  await user.type(textarea, 'first');
+  await user.keyboard('{Enter}');
+  await user.type(textarea, 'second');
+  await user.keyboard('{Shift>}{Enter}{/Shift}');
+  await user.type(textarea, 'third');
+
+  expect(textarea.value).toBe('first\nsecond\nthird');
+  expect(fireEvent.keyDown(textarea, { key: 'Enter', altKey: true })).toBe(true);
+  expect(onSubmit).not.toHaveBeenCalled();
+});
+
+test('disabled submit blocks both Ctrl+Enter and the submit button', async () => {
+  const user = userEvent.setup();
+  const onSubmit = vi.fn<FormEventHandler<HTMLFormElement>>((event) => event.preventDefault());
+  render(<MentionHarness onSubmit={onSubmit} submitDisabled />);
+
+  const textarea = screen.getByRole('textbox');
+  await user.click(textarea);
+  await user.type(textarea, 'pending post');
+  await user.keyboard('{Control>}{Enter}{/Control}');
+
+  expect(screen.getByRole('button', { name: 'Publish' })).toBeDisabled();
+  expect(onSubmit).not.toHaveBeenCalled();
+});
 
 test('typing @ with a query shows matching mention candidates', async () => {
   const user = userEvent.setup();
@@ -56,6 +110,34 @@ test('selecting a candidate with the keyboard inserts the mention token', async 
 
   expect(textarea.value).toBe(`hi @[Alice](${ALICE}) `);
   expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+});
+
+test('mention selection keeps priority over Ctrl+Enter form submission', async () => {
+  const user = userEvent.setup();
+  const onSubmit = vi.fn<FormEventHandler<HTMLFormElement>>((event) => event.preventDefault());
+  render(<MentionHarness onSubmit={onSubmit} />);
+
+  const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+  await user.click(textarea);
+  await user.keyboard('hi @al');
+  await user.keyboard('{Control>}{Enter}{/Control}');
+
+  expect(textarea.value).toBe(`hi @[Alice](${ALICE}) `);
+  expect(onSubmit).not.toHaveBeenCalled();
+});
+
+test('Tab keeps selecting a mention candidate without submitting', async () => {
+  const user = userEvent.setup();
+  const onSubmit = vi.fn<FormEventHandler<HTMLFormElement>>((event) => event.preventDefault());
+  render(<MentionHarness onSubmit={onSubmit} />);
+
+  const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+  await user.click(textarea);
+  await user.keyboard('hi @al');
+  await user.keyboard('{Tab}');
+
+  expect(textarea.value).toBe(`hi @[Alice](${ALICE}) `);
+  expect(onSubmit).not.toHaveBeenCalled();
 });
 
 test('Escape closes the suggestion list', async () => {

--- a/apps/desktop/src/components/core/ComposerPanel.tsx
+++ b/apps/desktop/src/components/core/ComposerPanel.tsx
@@ -1,4 +1,4 @@
-import type { ChangeEventHandler, FormEventHandler } from 'react';
+import type { ChangeEventHandler, FormEventHandler, KeyboardEventHandler } from 'react';
 
 import { X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
@@ -59,6 +59,7 @@ type ComposerPanelProps = {
   onClearReply: () => void;
   onClearRepost?: () => void;
   attachmentsDisabled?: boolean;
+  submitDisabled?: boolean;
   mentionCandidates?: MentionCandidate[];
   onValueChange?: (next: string) => void;
 };
@@ -82,6 +83,7 @@ export function ComposerPanel({
   onClearReply,
   onClearRepost,
   attachmentsDisabled = false,
+  submitDisabled = false,
   mentionCandidates = EMPTY_MENTION_CANDIDATES,
   onValueChange,
 }: ComposerPanelProps) {
@@ -102,6 +104,14 @@ export function ComposerPanel({
     candidates: mentionCandidates,
     onValueChange,
   });
+  const onComposerKeyDown: KeyboardEventHandler<HTMLTextAreaElement> = (event) => {
+    onMentionKeyDown(event);
+    if (event.defaultPrevented || submitDisabled || event.key !== 'Enter' || !event.ctrlKey) {
+      return;
+    }
+    event.preventDefault();
+    event.currentTarget.form?.requestSubmit();
+  };
 
   return (
     <form className='composer' onSubmit={onSubmit}>
@@ -153,7 +163,7 @@ export function ComposerPanel({
             onChange(event);
             onMentionSelectionChange();
           }}
-          onKeyDown={onMentionKeyDown}
+          onKeyDown={onComposerKeyDown}
           onKeyUp={onMentionSelectionChange}
           onClick={onMentionSelectionChange}
           onSelect={onMentionSelectionChange}
@@ -231,7 +241,7 @@ export function ComposerPanel({
         <span>{t('labels.audience')}: {audienceLabel}</span>
       </div>
 
-      <Button type='submit'>
+      <Button type='submit' disabled={submitDisabled}>
         {replyTarget || mode === 'reply'
           ? t('actions.reply')
           : repostTarget

--- a/apps/desktop/src/components/shell/ColumnComposerFooter.test.tsx
+++ b/apps/desktop/src/components/shell/ColumnComposerFooter.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -61,5 +61,26 @@ describe('ColumnComposerFooter', () => {
     const action = screen.getByRole('button', { name: /Publish to Friends/ });
     expect(action).toHaveClass('button-icon', 'size-10');
     expect(action.querySelector('span')).toBeNull();
+  });
+
+  it('disables button and Ctrl+Enter submission while its Draft is pending', async () => {
+    const user = userEvent.setup();
+    const view = renderFooter();
+
+    await user.click(screen.getByRole('button', { name: /Publish to Friends/ }));
+    await user.type(screen.getByPlaceholderText('Write a post'), 'pending draft');
+    act(() => {
+      const key = columnDraftKey(target);
+      view.store.getState().setField('columnDraftsByKey', {
+        [key]: {
+          ...view.store.getState().columnDraftsByKey[key],
+          pending: true,
+        },
+      });
+    });
+
+    expect(screen.getByRole('button', { name: 'Publish' })).toBeDisabled();
+    await user.keyboard('{Control>}{Enter}{/Control}');
+    expect(view.onSubmit).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/components/shell/ColumnComposerFooter.tsx
+++ b/apps/desktop/src/components/shell/ColumnComposerFooter.tsx
@@ -154,6 +154,7 @@ export function ColumnComposerFooter({
           updateDraft((current) => ({ ...current, repostTarget: null, error: null }))
         }
         attachmentsDisabled={draft.pending || Boolean(draft.repostTarget)}
+        submitDisabled={draft.pending}
         mentionCandidates={mentionCandidates}
       />
     </div>

--- a/apps/desktop/src/shell/useDesktopShellActions.test.tsx
+++ b/apps/desktop/src/shell/useDesktopShellActions.test.tsx
@@ -520,6 +520,38 @@ describe('useDesktopShellActions', () => {
     );
   });
 
+  test('pending Column Draft rejects a repeated form submission', async () => {
+    const createPost = vi.fn(async () => 'duplicate-post');
+    const target = {
+      columnId: 'timeline-pending',
+      action: 'post' as const,
+      scope: { topicId: 'topic-a', channelId: null },
+    };
+    const view = renderActionsHook({
+      api: { createPost },
+      preset: (current) => ({
+        columnDraftsByKey: setColumnDraft(current.columnDraftsByKey, target, (draft) => ({
+          ...draft,
+          content: 'already sending',
+          expanded: true,
+          pending: true,
+        })),
+      }),
+    });
+    const form = publishFormEvent();
+
+    await act(async () => {
+      await view.result.current.handleSubmitColumnDraft(target, form.event);
+    });
+
+    expect(form.preventDefault).toHaveBeenCalledTimes(1);
+    expect(createPost).not.toHaveBeenCalled();
+    expect(view.store.getState().columnDraftsByKey[columnDraftKey(target)]).toMatchObject({
+      content: 'already sending',
+      pending: true,
+    });
+  });
+
   test('quote repost expands the source topic public Column Draft and submits through createRepost', async () => {
     const createRepost = vi.fn(async () => 'repost-1');
     const source = buildPost({

--- a/apps/desktop/tests/playwright/column-scope.spec.ts
+++ b/apps/desktop/tests/playwright/column-scope.spec.ts
@@ -100,6 +100,60 @@ test('Public and private Timeline Columns coexist and keep posts within their ow
   await expect(privateColumn.getByText('public scoped post')).toHaveCount(0);
 });
 
+test('Timeline composer keeps line breaks and submits exactly once with Ctrl+Enter', async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1400, height: 980 });
+  await page.goto('/');
+
+  const timeline = activeColumn(page, 'Timeline');
+  await timeline.getByRole('button', { name: `Publish to ${GENERAL_PUBLIC_SCOPE}` }).click();
+  const textarea = timeline.getByPlaceholder('Write a post');
+  await textarea.fill('shortcut line one');
+  await textarea.press('Enter');
+  await textarea.type('shortcut line two');
+  await expect(textarea).toHaveValue('shortcut line one\nshortcut line two');
+
+  await textarea.press('Control+Enter');
+
+  await expect(textarea).toHaveCount(0);
+  await expect(
+    timeline
+      .getByRole('article')
+      .filter({ hasText: 'shortcut line one' })
+      .filter({ hasText: 'shortcut line two' })
+  ).toHaveCount(1);
+});
+
+test('mention selection keeps priority over Ctrl+Enter in the Timeline composer', async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1400, height: 980 });
+  await page.goto('/');
+
+  const timelineSurface = timelineColumnByScope(page, GENERAL_PUBLIC_SCOPE);
+  await timelineSurface.getByRole('button', { name: 'browser peer' }).first().click();
+  const profile = activeColumn(page, 'Profile');
+  await expect(profile.getByText('browser peer').first()).toBeVisible();
+  await timelineSurface.locator('.shell-column-header h2').dispatchEvent('pointerdown');
+  const timeline = activeColumn(page, 'Timeline');
+  await expect(timeline).toBeVisible();
+  await timeline.getByRole('button', { name: `Publish to ${GENERAL_PUBLIC_SCOPE}` }).click();
+  const textarea = timeline.getByPlaceholder('Write a post');
+  await textarea.pressSequentially('shortcut mention @bro', { delay: 25 });
+  await expect(timeline.getByRole('listbox', { name: 'Mention suggestions' })).toBeVisible();
+
+  await textarea.press('Control+Enter');
+
+  await expect(timeline.getByRole('listbox', { name: 'Mention suggestions' })).toHaveCount(0);
+  await expect(textarea).toBeVisible();
+  await expect(textarea).toHaveValue(/shortcut mention @\[browser peer\]\([a-f0-9]{64}\) /);
+
+  await textarea.press('Control+Enter');
+  await expect(textarea).toHaveCount(0);
+  await expect(timeline.getByRole('article').filter({ hasText: 'shortcut mention' })).toHaveCount(1);
+});
+
 test('Thread opened from the private Column keeps the private scope for header and footer reply', async ({
   page,
 }) => {


### PR DESCRIPTION
## 概要
- コンポーザーでCtrl+Enterを押すと、既存のform submit経路から送信するようにしました。
- 通常Enter／Shift+Enterの改行と、メンション候補操作の優先順位を維持しています。
- pending中は送信ボタンとCtrl+Enterの双方を無効化し、action境界でも重複送信を拒否します。

## テスト
- テストファースト: 実装前はCtrl+Enter契約が期待1回／実際0回で失敗することを確認
- targeted Vitest: 3 files / 26 tests passed
- targeted Playwright: 2 tests passed
- cargo xtask check
- cargo xtask test: Rust 694件、harness 22件、frontend 980件 passed
- cargo xtask desktop-ui-check: lint、typecheck、frontend 980件、Storybook build、browser E2E 52件、visual 14件 passed
- cargo xtask oversized-files: 成功（既存ベースライン警告のみ）

## Windows実機確認
隔離したmock app dataでTauri／WebViewアプリを起動し、Computer Useで実際のWindowsキー入力を自動操作しました。
- Enterで2行のdraftを維持
- Ctrl+Enterでコンポーザーが閉じ、投稿が1件だけ作成
- メンション候補表示中のCtrl+Enterは候補確定を優先し、投稿しない
- 候補確定後の次のCtrl+Enterで投稿が1件だけ作成
- 既存の投稿ボタンでも投稿が1件だけ作成

Closes #819
