### PR TITLE
fix(desktop): route起因のColumn scroll中のmobile settle誤activateを防止

### DIFF
--- a/apps/desktop/src/components/shell/ColumnCanvas.test.tsx
+++ b/apps/desktop/src/components/shell/ColumnCanvas.test.tsx
@@ -432,8 +432,7 @@ describe('ColumnCanvas', () => {
     ).toBe(0);
   });
 
-  it('syncs the nearest mobile snap page after settle and offers direct indicator jumps', async () => {
-    vi.useFakeTimers();
+  function stubMobileMatchMedia() {
     vi.stubGlobal('matchMedia', vi.fn((query: string) => ({
       matches: query === '(max-width: 759px)',
       media: query,
@@ -444,6 +443,24 @@ describe('ColumnCanvas', () => {
       removeEventListener: vi.fn(),
       dispatchEvent: vi.fn(),
     })));
+  }
+
+  function stubMobilePageGeometry(container: HTMLElement, scrollLeft: number) {
+    const canvas = container.querySelector('.shell-column-canvas') as HTMLElement;
+    Object.defineProperty(canvas, 'clientWidth', { value: 390 });
+    Object.defineProperty(canvas, 'scrollLeft', { value: scrollLeft, writable: true });
+    Array.from(container.querySelectorAll<HTMLElement>('[data-column-id]')).forEach(
+      (column, index) => {
+        Object.defineProperty(column, 'offsetLeft', { value: index * 390 });
+        Object.defineProperty(column, 'offsetWidth', { value: 390 });
+      }
+    );
+    return canvas;
+  }
+
+  it('syncs the nearest mobile snap page after settle and offers direct indicator jumps', async () => {
+    vi.useFakeTimers();
+    stubMobileMatchMedia();
     const onActivateColumn = vi.fn();
     const { container } = render(
       <ColumnCanvas
@@ -468,16 +485,11 @@ describe('ColumnCanvas', () => {
         ))}
       </ColumnCanvas>
     );
-    const canvas = container.querySelector('.shell-column-canvas') as HTMLElement;
-    Object.defineProperty(canvas, 'clientWidth', { value: 390 });
-    Object.defineProperty(canvas, 'scrollLeft', { value: 390, writable: true });
-    Array.from(container.querySelectorAll<HTMLElement>('[data-column-id]')).forEach(
-      (column, index) => {
-        Object.defineProperty(column, 'offsetLeft', { value: index * 390 });
-        Object.defineProperty(column, 'offsetWidth', { value: 390 });
-      }
-    );
+    const canvas = stubMobilePageGeometry(container, 390);
 
+    // 実機の user scroll は wheel / touch 入力から始まる。mount 直後の programmatic
+    // scroll ガードを user 入力で解除してから settle を検証する。
+    fireEvent.wheel(canvas);
     fireEvent.scroll(canvas);
     await act(async () => vi.advanceTimersByTime(120));
     expect(onActivateColumn).toHaveBeenCalledWith('thread', true);
@@ -496,6 +508,121 @@ describe('ColumnCanvas', () => {
     fireEvent.scroll(canvas);
     await act(async () => vi.advanceTimersByTime(120));
     expect(onActivateColumn).toHaveBeenCalledTimes(2);
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it('ignores a mobile settle that fires while a route-driven activation is still scrolling', async () => {
+    // hash-routing narrow flake の再現: goBack の route 投影が Timeline を activate し
+    // smooth scroll が始まった直後、CI 負荷で scroll が 120ms 以上停滞すると settle が
+    // 移動元 Column を user scroll と誤認して再 activate + route 同期していた。
+    vi.useFakeTimers();
+    stubMobileMatchMedia();
+    const onActivateColumn = vi.fn();
+    const surfaces = (activeColumnId: string) =>
+      ['timeline', 'thread', 'profile'].map((id, index) => (
+        <ColumnSurface
+          key={id}
+          columnId={id}
+          title={id}
+          scopeLabel='Public'
+          position={index + 1}
+          total={3}
+          span={1}
+          active={id === activeColumnId}
+          pinned
+        >
+          {id}
+        </ColumnSurface>
+      ));
+    const { container, rerender } = render(
+      <ColumnCanvas
+        activeColumnId='thread'
+        columnIds={['timeline', 'thread', 'profile']}
+        onActivateColumn={onActivateColumn}
+      >
+        {surfaces('thread')}
+      </ColumnCanvas>
+    );
+    const canvas = stubMobilePageGeometry(container, 390);
+
+    // goBack 相当: route 投影が timeline を activate し programmatic scroll が始まる。
+    rerender(
+      <ColumnCanvas
+        activeColumnId='timeline'
+        columnIds={['timeline', 'thread', 'profile']}
+        onActivateColumn={onActivateColumn}
+      >
+        {surfaces('timeline')}
+      </ColumnCanvas>
+    );
+
+    // scroll 位置がまだ thread ページのまま settle が発火しても activate しない。
+    fireEvent.scroll(canvas);
+    await act(async () => vi.advanceTimersByTime(120));
+    expect(onActivateColumn).not.toHaveBeenCalled();
+
+    // 目的地到達の settle でガードが解除される(activate は不要)。
+    canvas.scrollLeft = 0;
+    fireEvent.scroll(canvas);
+    await act(async () => vi.advanceTimersByTime(120));
+    expect(onActivateColumn).not.toHaveBeenCalled();
+
+    // 解除後の user scroll paging は従来どおり動く。
+    canvas.scrollLeft = 780;
+    fireEvent.scroll(canvas);
+    await act(async () => vi.advanceTimersByTime(120));
+    expect(onActivateColumn).toHaveBeenCalledWith('profile', true);
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it('lets wheel input take paging over from a route-driven programmatic scroll', async () => {
+    vi.useFakeTimers();
+    stubMobileMatchMedia();
+    const onActivateColumn = vi.fn();
+    const surfaces = (activeColumnId: string) =>
+      ['timeline', 'thread', 'profile'].map((id, index) => (
+        <ColumnSurface
+          key={id}
+          columnId={id}
+          title={id}
+          scopeLabel='Public'
+          position={index + 1}
+          total={3}
+          span={1}
+          active={id === activeColumnId}
+          pinned
+        >
+          {id}
+        </ColumnSurface>
+      ));
+    const { container, rerender } = render(
+      <ColumnCanvas
+        activeColumnId='thread'
+        columnIds={['timeline', 'thread', 'profile']}
+        onActivateColumn={onActivateColumn}
+      >
+        {surfaces('thread')}
+      </ColumnCanvas>
+    );
+    const canvas = stubMobilePageGeometry(container, 390);
+    rerender(
+      <ColumnCanvas
+        activeColumnId='timeline'
+        columnIds={['timeline', 'thread', 'profile']}
+        onActivateColumn={onActivateColumn}
+      >
+        {surfaces('timeline')}
+      </ColumnCanvas>
+    );
+
+    // wheel 入力はユーザーの引き継ぎ。programmatic scroll ガードを解除し settle を有効化する。
+    fireEvent.wheel(canvas);
+    canvas.scrollLeft = 780;
+    fireEvent.scroll(canvas);
+    await act(async () => vi.advanceTimersByTime(120));
+    expect(onActivateColumn).toHaveBeenCalledWith('profile', true);
     vi.unstubAllGlobals();
     vi.useRealTimers();
   });

--- a/apps/desktop/src/components/shell/ColumnCanvas.tsx
+++ b/apps/desktop/src/components/shell/ColumnCanvas.tsx
@@ -163,6 +163,10 @@ export function ColumnCanvas({
           window.clearTimeout(scrollSettleTimeoutRef.current);
           scrollSettleTimeoutRef.current = null;
         }
+        // route 起因の activate による smooth scroll が停滞しても、settle が途中位置の
+        // Column を user scroll と誤認して activate + route 同期しないよう対象を記録する
+        // (解除は目的地到達の settle か pointer / wheel のユーザー入力)。
+        programmaticScrollTargetRef.current = activeColumnId;
       }
       column.scrollIntoView({
         block: 'nearest',
@@ -294,6 +298,10 @@ export function ColumnCanvas({
       className='shell-column-canvas'
       aria-label={canvasLabel}
       onScroll={settleMobileScroll}
+      onWheelCapture={() => {
+        // wheel 入力はユーザーの scroll 引き継ぎ。programmatic scroll ガードを解除する。
+        programmaticScrollTargetRef.current = null;
+      }}
       onClickCapture={(event) => {
         if (!swipeConsumedRef.current) return;
         event.preventDefault();


### PR DESCRIPTION
## 概要

Fast CI `linux-desktop-browser` で断続的に失敗していた `hash-routing.spec.ts:82`「browser mock hash history keeps route state stable without narrow-width overflow」の根本対策です(main run 1199 などで発生)。

## 根本原因

失敗 run の error-context スナップショットで、timeout 時点の状態は「URL は goBack 済みなのに Thread Column が Active のまま(page 2/6)」でした。

メカニズム:

1. 700px viewport は `ColumnCanvas` の mobile 判定(`max-width: 759px`)に該当する
2. `page.goBack()` で route 投影が Timeline Column を activate し、`activeColumnId` 変更 effect が `scrollIntoView({ behavior: 'smooth' })` を開始する
3. CI 負荷で smooth scroll が 120ms 以上停滞すると `settleMobileScroll` が発火し、「viewport 中央に最も近い Column」= まだ移動元の Thread を user scroll と誤認して `onActivateColumn(thread, true)` で再 activate + route 同期する
4. Timeline が Active に戻らず、`/^Timeline Column,.*Active,/` の locator が 30 秒 timeout する

swipe / page indicator 経由の activate には既に `programmaticScrollTargetRef` ガードがありましたが、route 起因の activate(effect の scrollIntoView)にはガードがありませんでした。テスト側の待ち不足ではなく実装側の状態遷移レースです。

## 修正

- `activeColumnId` 変更 effect(mobile 時)でも `programmaticScrollTargetRef` に対象 Column を記録し、途中位置での settle 誤 activate を防止
- ガードは目的地到達の settle で解除(既存動作)。加えて wheel 入力でも解除し(pointerdown は既存)、ユーザーによる scroll 引き継ぎを維持

## テスト

failing-test-first: `ColumnCanvas.test.tsx` に再現テストを追加し、修正前に `onActivateColumn('thread', true)` が呼ばれて失敗することを確認してから修正しました。

- 追加: route 起因 activate 中の settle を無視し、目的地到達後は通常 paging が動くことを固定
- 追加: wheel 入力によるユーザー引き継ぎでガードが解除されることを固定
- 更新: 既存 settle テストは user scroll の起点として wheel イベントを先行させる形に変更(実機では touch / wheel が必ず先行するため)

## 検証

- `vitest run`(994 tests)成功
- `cargo xtask desktop-browser-test`(52 tests)成功
- `hash-routing.spec.ts` を `--repeat-each=10 --workers=2` でストレス実行し 40/40 成功
- `cargo xtask desktop-lint`(eslint + tsc)成功

なお別 run で 1 回観測された `column-immersive.spec.ts:155` の flake は 900px(デスクトップ幅)の render suspend 待ちで、本件のモバイル settle レースとは別メカニズムです(本 PR のスコープ外)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)