### PR TITLE
fix(desktop): 追い越されたpending route pushを破棄して現在URLを再投影

### DIFF
--- a/apps/desktop/src/shell/routing/useRouteSynchronization.test.tsx
+++ b/apps/desktop/src/shell/routing/useRouteSynchronization.test.tsx
@@ -23,9 +23,14 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 import type { JoinedPrivateChannelView, PostView } from '@/lib/api';
 import { useRouteSynchronization } from '@/shell/routing/useRouteSynchronization';
 import { createDesktopShellStore, type DesktopShellStoreApi } from '@/shell/store';
-import { resetWindowHash } from '@/shell/testSupport/renderShellHook';
+import { resetWindowHash, setWindowHash } from '@/shell/testSupport/renderShellHook';
 import { selectShellRoutingSlice } from '@/shell/storeSelectors';
-import { activeWorkspaceScope } from '@/shell/slices/workspace';
+import {
+  activeWorkspaceColumn,
+  activeWorkspaceScope,
+  columnIdentityId,
+  openTransientColumn,
+} from '@/shell/slices/workspace';
 
 const DM_PEER_PUBKEY = 'd'.repeat(64);
 
@@ -443,6 +448,9 @@ describe('useRouteSynchronization', () => {
   describe('route observation gate', () => {
     test('skips processing while a pending route url has not been observed and the route did not change', () => {
       const storeApi = createDesktopShellStore();
+      // pending 未観測 = 自分の navigate で実 URL(hash)は pending へ更新済みだが
+      // router のレンダーがまだ追いついていない状態。
+      setWindowHash('#/timeline?topic=kukuri%3Atopic%3Ageneral');
       // 未追跡 topic(本来なら normalize される URL)でも、pending 未観測なら何もしない
       const args = createHookArgs(storeApi, {
         lastObservedRouteUrlRef: { current: '/timeline?topic=kukuri%3Atopic%3Aunknown' },
@@ -483,6 +491,46 @@ describe('useRouteSynchronization', () => {
       );
       // 未追跡 topic の normalize が通常どおり走る
       expect(args.syncRoute).toHaveBeenCalledTimes(1);
+      view.unmount();
+    });
+
+    test('discards a pending push superseded by history back and reprojects the observed url', () => {
+      // hash-routing narrow flake の再現(React Router v7 の transition レンダー):
+      // thread への push が router に commit される前に goBack が来ると、location 文字列は
+      // last observed と同一のまま二度と変化せず、pending ガードが route 消費を止めて
+      // thread Column が active のまま取り残されていた。実 URL(hash)が pending と一致
+      // しない場合は追い越し済みと判定し、pending を破棄して現在 URL を再投影する。
+      setWindowHash('#/timeline?topic=kukuri%3Atopic%3Ageneral');
+      const storeApi = createDesktopShellStore();
+      const args = createHookArgs(storeApi);
+      const view = renderHook((props: RouteSynchronizationArgs) => useRouteSynchronization(props), {
+        initialProps: args,
+      });
+      expect(activeWorkspaceColumn(storeApi.getState().workspaceState).kind).toBe('timeline');
+
+      // thread push 直後の状態を模す: store は thread Column が active、
+      // pending は push した URL のまま router には未観測。実 URL は goBack で timeline に settle 済み。
+      const scope = { topicId: 'kukuri:topic:general', channelId: null };
+      act(() => {
+        storeApi.getState().patchState({
+          selectedThread: 'post-1',
+          threadsById: { 'post-1': [buildPost()] },
+          workspaceState: openTransientColumn(storeApi.getState().workspaceState, {
+            id: columnIdentityId('thread', scope, 'post-1'),
+            kind: 'thread',
+            scope,
+            entityId: 'post-1',
+            pinned: false,
+          }),
+        });
+      });
+      args.pendingRouteUrlRef.current =
+        '/timeline?topic=kukuri%3Atopic%3Ageneral&context=thread&threadId=post-1';
+      view.rerender({ ...args, state: selectShellRoutingSlice(storeApi.getState()) });
+
+      expect(args.pendingRouteUrlRef.current).toBeNull();
+      expect(activeWorkspaceColumn(storeApi.getState().workspaceState).kind).toBe('timeline');
+      expect(storeApi.getState().selectedThread).toBeNull();
       view.unmount();
     });
   });

--- a/apps/desktop/src/shell/routing/useRouteSynchronization.ts
+++ b/apps/desktop/src/shell/routing/useRouteSynchronization.ts
@@ -7,6 +7,7 @@ import {
   PRIMARY_SECTION_PATHS,
   isProfileConnectionsView,
   isSettingsSection,
+  parseHashRouteLocation,
   parseLegacyRequestedChannel,
   parseShellRouteState,
   parsePrimarySectionPath,
@@ -173,8 +174,25 @@ export function useRouteSynchronization({
 
     const currentUrl = `${resolvedRouteLocation.pathname}${resolvedRouteLocation.search}`;
     const routeChanged = lastObservedRouteUrlRef.current !== currentUrl;
+    // 自分の navigate(pending)が router に commit される前に goBack 等の外部遷移へ
+    // 追い越されると、location 文字列は last observed と同一のまま routeChanged が
+    // 二度と立たず route 消費が止まる(React Router v7 は遷移レンダーを transition で
+    // 行うため、push のレンダーは後続遷移に破棄されうる)。hash は navigate / popstate と
+    // 同期して即時更新されるため、実 hash を pending と突き合わせて生死を判定する。
+    let pendingRouteSuperseded = false;
     if (pendingRouteUrlRef.current && pendingRouteUrlRef.current !== currentUrl) {
-      if (!routeChanged) {
+      const liveLocation =
+        typeof window === 'undefined' ? null : parseHashRouteLocation(window.location.hash);
+      const liveUrl = liveLocation ? `${liveLocation.pathname}${liveLocation.search}` : null;
+      if (liveUrl !== null && liveUrl !== pendingRouteUrlRef.current) {
+        // pending の push は追い越し済み。settle 先が現在の location なら投影をやり直し、
+        // 第三の URL なら破棄だけしてそのレンダーの到着に委ねる。
+        pendingRouteSuperseded = liveUrl === currentUrl;
+        if (!pendingRouteSuperseded && !routeChanged) {
+          pendingRouteUrlRef.current = null;
+          return;
+        }
+      } else if (!routeChanged) {
         return;
       }
       pendingRouteUrlRef.current = null;
@@ -863,6 +881,9 @@ export function useRouteSynchronization({
     if (
       !routeProjectionInitializedRef.current ||
       routeChanged ||
+      // 追い越された push の間に store は先行遷移している(thread Column が active 等)ため、
+      // location 文字列が不変でも現在 URL の投影をやり直して store を URL に揃える。
+      pendingRouteSuperseded ||
       resolvingCurrentGameColumn
     ) {
       routeProjectionInitializedRef.current = true;
@@ -927,8 +948,9 @@ export function useRouteSynchronization({
     openDirectMessagePane,
     openThread,
     pendingRouteUrlRef,
-    resolvedRouteLocation.pathname,
-    resolvedRouteLocation.search,
+    // オブジェクト依存が意図: 同一 URL 文字列でも history 遷移ごとに再評価し、
+    // 追い越された pending push の検出(上記)を働かせる。
+    resolvedRouteLocation,
     routeSection,
     scheduleAnimationFrame,
     selectedAuthor,

--- a/apps/desktop/src/shell/useDesktopShellRouting.ts
+++ b/apps/desktop/src/shell/useDesktopShellRouting.ts
@@ -147,7 +147,10 @@ export function useDesktopShellRouting({
         location.search,
         typeof window === 'undefined' ? '' : window.location.hash
       ),
-    [location.pathname, location.search]
+    // 文字列 (pathname, search) ではなく location オブジェクトで再計算する。
+    // 同一 URL 文字列の history entry へ戻る遷移(push が transition で未 commit のまま
+    // goBack された場合)でも新しい location として route 消費 effect を再評価させるため。
+    [location]
   );
 
   const routeSection = useMemo(() => {


### PR DESCRIPTION
## 概要

`hash-routing.spec.ts:82`(narrow goBack フロー)CI flake の**第二の根本原因**への対策です。[PR #846](https://github.com/KingYoSun/kukuri/pull/846) の mobile settle ガードだけでは、マージ直後の main run(33366315320)で同一symptomが再発しました。

## 根本原因

再発時の error-context も「URL は `#/timeline?...` のまま Thread Column が Active」で、URL の書き戻しを伴わない経路でした。CPU throttle(CDP `Emulation.setCPUThrottlingRate` rate=10)でローカル **15/15 再現**し、以下を特定:

1. 投稿クリック → `openThread` が thread URL を `syncRoute('push')`(`pendingRouteUrlRef` = thread URL)
2. React Router **v7 は遷移レンダーを `startTransition` で行う**ため、負荷下では push のレンダーが commit される前に `goBack` が到着し、push レンダーは破棄される
3. `useLocation` は thread URL を一度も公開せず、goBack 後の location 文字列は last observed と同一 → `routeChanged` が二度と立たない
4. `useRouteSynchronization` の pending ガード(`pending あり && routeChanged なし → 早期 return`)が route 消費を**恒久的に**停止。thread Column が active のまま `/^Timeline Column,.*Active,/` の locator が 30 秒 timeout

さらに location 文字列が不変のため、route 消費 effect(依存が pathname/search 文字列)は goBack レンダーでは再実行すらされませんでした。

## 対策

- **pending の生死判定**: pending が現在 URL と異なる場合、実 URL(`window.location.hash` — navigate / popstate と同期して即時更新される)と突き合わせる。hash が pending と一致しなければ「追い越し済み」と判定して pending を破棄し、settle 先が現在 location なら workspace 投影をやり直して store を URL に揃える([useRouteSynchronization.ts](apps/desktop/src/shell/routing/useRouteSynchronization.ts))
- **effect の再評価**: `resolvedRouteLocation` の useMemo 依存を文字列から location オブジェクトへ変更し、同一 URL 文字列の history entry へ戻る遷移でも route 消費 effect が再評価されるようにする([useDesktopShellRouting.ts](apps/desktop/src/shell/useDesktopShellRouting.ts))。他の利用箇所(routeSection / syncRoute 等)は文字列依存のままで identity churn の影響なし

## テスト(failing-test-first)

- 追加: `useRouteSynchronization.test.tsx` に追い越しシナリオの再現テスト。修正前は pending が残留し thread Column が active のままで失敗することを確認してから修正
- 更新: 既存の pending スキップテストに「実 hash = pending(push 反映待ち)」の前提を `setWindowHash` で明示(in-flight と追い越しの区別が仕様になったため)

## 検証

- `vitest run`(995 tests)成功
- `cargo xtask desktop-browser-test`(52 tests)成功
- CPU throttle rate=10 の一時 stress spec(narrow goBack フロー)で修正前 **15/15 失敗** → 修正後 **15/15 + 8/8 成功**(spec はコミットに含めず。再現手順: 該当テストの beforeEach で `client.send('Emulation.setCPUThrottlingRate', { rate: 10 })`)
- `cargo xtask desktop-lint`(eslint + tsc)成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)