### PR TITLE
[codex][fix] relay接続でデスクトップ起動を止めない

### DIFF
--- a/apps/desktop/src-tauri/src/commands/app_consent.rs
+++ b/apps/desktop/src-tauri/src/commands/app_consent.rs
@@ -1,10 +1,11 @@
 use serde::Serialize;
 use tauri::Manager;
 
+use crate::spawn_desktop_initialization;
 use crate::state::{
     AppConsentRecord, CommandError, DesktopStartupState, DesktopStartupStatus, DesktopState,
-    LEGAL_BUNDLE_VERSION, build_desktop_state, consent_satisfied, current_unix_seconds,
-    failed_status, load_app_consent, resolve_db_path, save_app_consent,
+    LEGAL_BUNDLE_VERSION, consent_satisfied, current_unix_seconds, load_app_consent,
+    resolve_db_path, save_app_consent,
 };
 
 #[derive(Clone, Debug, Serialize)]
@@ -32,7 +33,7 @@ pub fn get_app_consent_status(
 }
 
 #[tauri::command]
-pub fn accept_app_consents(
+pub async fn accept_app_consents(
     app_handle: tauri::AppHandle,
     bundle_version: i32,
 ) -> Result<DesktopStartupStatus, CommandError> {
@@ -59,17 +60,8 @@ pub fn accept_app_consents(
         return Ok(DesktopStartupStatus::Ready);
     }
 
-    match build_desktop_state(&app_handle) {
-        Ok(state) => {
-            app_handle.manage(state);
-            startup_state.set_status(DesktopStartupStatus::Ready);
-            Ok(DesktopStartupStatus::Ready)
-        }
-        Err(error) => {
-            let db_path = resolve_db_path(&app_handle).ok();
-            let status = failed_status(error, db_path);
-            startup_state.set_status(status.clone());
-            Ok(status)
-        }
-    }
+    startup_state.set_status(DesktopStartupStatus::Initializing);
+    spawn_desktop_initialization(app_handle)
+        .await
+        .map_err(|error| error.to_string().into())
 }

--- a/apps/desktop/src-tauri/src/commands/background_notifications.rs
+++ b/apps/desktop/src-tauri/src/commands/background_notifications.rs
@@ -18,7 +18,10 @@ use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Manager};
 use tracing::{debug, warn};
 
-use crate::{commands::os_notification::show_platform_notification, state::DesktopState};
+use crate::{
+    commands::os_notification::show_platform_notification,
+    state::{DesktopStartupState, DesktopStartupStatus, DesktopState},
+};
 
 const FALLBACK_POLL_INTERVAL: Duration = Duration::from_secs(60);
 
@@ -126,22 +129,36 @@ pub fn set_os_notification_settings(
 /// Start the background notification dispatcher. Subscribes to runtime events
 /// for instant dispatch and falls back to a 60-second poll for resilience.
 pub fn spawn(app: AppHandle) {
-    if let Some(state) = app.try_state::<DesktopState>() {
+    let mut startup_status = app.state::<DesktopStartupState>().subscribe();
+    let event_app = app.clone();
+    tauri::async_runtime::spawn(async move {
+        loop {
+            match startup_status.borrow().clone() {
+                DesktopStartupStatus::Ready => break,
+                DesktopStartupStatus::Failed { .. } => return,
+                DesktopStartupStatus::Initializing
+                | DesktopStartupStatus::ConsentRequired { .. } => {}
+            }
+            if startup_status.changed().await.is_err() {
+                return;
+            }
+        }
+        let Some(state) = event_app.try_state::<DesktopState>() else {
+            return;
+        };
         let mut rx = state.runtime.subscribe_events();
-        let event_app = app.clone();
-        tauri::async_runtime::spawn(async move {
-            while let Ok(event) = rx.recv().await {
-                if matches!(
-                    event,
-                    kukuri_desktop_runtime::RuntimeEvent::NotificationStatusChanged
-                ) {
-                    if let Err(error) = poll_once(&event_app).await {
-                        debug!(%error, "event-driven notification poll skipped");
-                    }
+        drop(state);
+        while let Ok(event) = rx.recv().await {
+            if matches!(
+                event,
+                kukuri_desktop_runtime::RuntimeEvent::NotificationStatusChanged
+            ) {
+                if let Err(error) = poll_once(&event_app).await {
+                    debug!(%error, "event-driven notification poll skipped");
                 }
             }
-        });
-    }
+        }
+    });
 
     tauri::async_runtime::spawn(async move {
         loop {

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -13,11 +13,38 @@ use tauri_plugin_deep_link::DeepLinkExt;
 use crate::{
     commands::background_notifications::OsNotificationBackground,
     state::{
-        DesktopStartupState, build_desktop_state, consent_satisfied, load_app_consent,
-        resolve_db_path,
+        DesktopStartupState, DesktopStartupStatus, build_desktop_state, consent_satisfied,
+        failed_status, load_app_consent, resolve_db_path,
     },
     tracing::init_tracing,
 };
+
+pub(crate) async fn initialize_desktop_state(app_handle: AppHandle) -> DesktopStartupStatus {
+    let status = match build_desktop_state(&app_handle).await {
+        Ok(state) => {
+            info!("initialized kukuri desktop runtime");
+            app_handle.manage(state);
+            DesktopStartupStatus::Ready
+        }
+        Err(error) => {
+            error!(%error, "failed to initialize desktop runtime");
+            let db_path = resolve_db_path(&app_handle).ok();
+            failed_status(error, db_path)
+        }
+    };
+    app_handle
+        .state::<DesktopStartupState>()
+        .set_status(status.clone());
+    status
+}
+
+pub(crate) fn spawn_desktop_initialization(
+    app_handle: AppHandle,
+) -> tauri::async_runtime::JoinHandle<DesktopStartupStatus> {
+    tauri::async_runtime::spawn_blocking(move || {
+        tauri::async_runtime::block_on(initialize_desktop_state(app_handle))
+    })
+}
 
 /// Bring the main window back from the tray.
 fn show_main_window(app: &AppHandle) {
@@ -96,19 +123,9 @@ pub fn run() {
                 .and_then(|db_path| load_app_consent(&db_path))
                 .map(|record| record.accepted_bundle_version);
 
-            let startup_state = if consent_satisfied(accepted_bundle_version) {
-                match build_desktop_state(app.handle()) {
-                    Ok(state) => {
-                        info!("initialized kukuri desktop runtime");
-                        app.manage(state);
-                        DesktopStartupState::ready()
-                    }
-                    Err(error) => {
-                        error!(%error, "failed to initialize desktop runtime");
-                        let db_path = resolve_db_path(app.handle()).ok();
-                        DesktopStartupState::failed(error, db_path)
-                    }
-                }
+            let initialize_runtime = consent_satisfied(accepted_bundle_version);
+            let startup_state = if initialize_runtime {
+                DesktopStartupState::initializing()
             } else {
                 info!("app-level legal consent required; deferring runtime startup");
                 DesktopStartupState::consent_required(
@@ -124,6 +141,10 @@ pub fn run() {
             commands::background_notifications::spawn(app.handle().clone());
             #[cfg(any(windows, target_os = "linux"))]
             app.deep_link().register_all()?;
+            if initialize_runtime {
+                let app_handle = app.handle().clone();
+                spawn_desktop_initialization(app_handle);
+            }
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![

--- a/apps/desktop/src-tauri/src/state.rs
+++ b/apps/desktop/src-tauri/src/state.rs
@@ -1,12 +1,13 @@
 use std::{
     path::{Path, PathBuf},
-    sync::{Arc, Mutex},
+    sync::Arc,
     time::{SystemTime, UNIX_EPOCH},
 };
 
 use kukuri_desktop_runtime::{DesktopRuntime, StoreStartupError, resolve_db_path_from_env};
 use serde::{Deserialize, Serialize};
 use tauri::{Emitter, Manager};
+use tokio::sync::watch;
 
 pub(crate) struct DesktopState {
     pub(crate) runtime: Arc<DesktopRuntime>,
@@ -25,6 +26,7 @@ pub(crate) struct AppConsentRecord {
 #[derive(Clone, Debug, Serialize)]
 #[serde(tag = "status", rename_all = "snake_case")]
 pub(crate) enum DesktopStartupStatus {
+    Initializing,
     Ready,
     ConsentRequired {
         current_bundle_version: i32,
@@ -85,43 +87,39 @@ impl std::fmt::Display for StartupError {
 }
 
 pub(crate) struct DesktopStartupState {
-    status: Mutex<DesktopStartupStatus>,
+    status: watch::Sender<DesktopStartupStatus>,
 }
 
 impl DesktopStartupState {
-    pub(crate) fn ready() -> Self {
-        Self {
-            status: Mutex::new(DesktopStartupStatus::Ready),
-        }
+    pub(crate) fn initializing() -> Self {
+        Self::new(DesktopStartupStatus::Initializing)
     }
 
     pub(crate) fn consent_required(
         current_bundle_version: i32,
         accepted_bundle_version: Option<i32>,
     ) -> Self {
-        Self {
-            status: Mutex::new(DesktopStartupStatus::ConsentRequired {
-                current_bundle_version,
-                accepted_bundle_version,
-            }),
-        }
+        Self::new(DesktopStartupStatus::ConsentRequired {
+            current_bundle_version,
+            accepted_bundle_version,
+        })
     }
 
-    pub(crate) fn failed(error: StartupError, db_path: Option<PathBuf>) -> Self {
-        Self {
-            status: Mutex::new(failed_status(error, db_path)),
-        }
+    fn new(status: DesktopStartupStatus) -> Self {
+        let (status, _) = watch::channel(status);
+        Self { status }
     }
 
     pub(crate) fn status(&self) -> DesktopStartupStatus {
-        self.status
-            .lock()
-            .expect("startup status lock poisoned")
-            .clone()
+        self.status.borrow().clone()
     }
 
     pub(crate) fn set_status(&self, next: DesktopStartupStatus) {
-        *self.status.lock().expect("startup status lock poisoned") = next;
+        self.status.send_replace(next);
+    }
+
+    pub(crate) fn subscribe(&self) -> watch::Receiver<DesktopStartupStatus> {
+        self.status.subscribe()
     }
 }
 
@@ -233,13 +231,13 @@ pub(crate) fn map_error(error: anyhow::Error) -> CommandError {
         return CommandError {
             code: rejection.code(),
             message: rejection.to_string(),
-            status: Some(if rejection.reason
-                == kukuri_core::MetaverseResourceRejectionReason::RateExceeded
-            {
-                429
-            } else {
-                422
-            }),
+            status: Some(
+                if rejection.reason == kukuri_core::MetaverseResourceRejectionReason::RateExceeded {
+                    429
+                } else {
+                    422
+                },
+            ),
             retry_after_seconds: None,
         };
     }
@@ -268,19 +266,20 @@ pub(crate) fn resolve_db_path(app_handle: &tauri::AppHandle) -> Result<PathBuf, 
     resolve_db_path_from_env(&app_data_dir).map_err(error_message)
 }
 
-pub(crate) fn build_desktop_state(
+pub(crate) async fn build_desktop_state(
     app_handle: &tauri::AppHandle,
 ) -> Result<DesktopState, StartupError> {
     let db_path = resolve_db_path(app_handle).map_err(StartupError::unknown)?;
-    let runtime = tauri::async_runtime::block_on(DesktopRuntime::from_env(db_path))
+    let runtime = DesktopRuntime::from_env(db_path)
+        .await
         .map_err(StartupError::from_runtime_error)?;
     let runtime = Arc::new(runtime);
     // トレイ常駐中はフロントのポーリング(hidden で停止)が CN セッションを維持できないため、
     // runtime 常駐のセッション維持スケジューラをここで起動する(停止は shutdown / プロセス終了)。
-    tauri::async_runtime::block_on(runtime.start_community_node_session_scheduler());
+    runtime.start_community_node_session_scheduler().await;
 
     spawn_runtime_event_bridge(app_handle, &runtime);
-    tauri::async_runtime::block_on(runtime.start_sync_status_observer());
+    runtime.start_sync_status_observer().await;
 
     Ok(DesktopState { runtime })
 }
@@ -385,14 +384,12 @@ mod tests {
 
     #[test]
     fn community_indexing_request_error_preserves_stable_conflict_code() {
-        let error = CommandError::from(
-            kukuri_desktop_runtime::CommunityNodeIndexingRequestError {
-                code: "CHANNEL_SECRET_CONFLICT".to_string(),
-                message: "channel capability conflicts with the existing registration".to_string(),
-                status: Some(409),
-                retry_after_seconds: None,
-            },
-        );
+        let error = CommandError::from(kukuri_desktop_runtime::CommunityNodeIndexingRequestError {
+            code: "CHANNEL_SECRET_CONFLICT".to_string(),
+            message: "channel capability conflicts with the existing registration".to_string(),
+            status: Some(409),
+            retry_after_seconds: None,
+        });
         let json = serde_json::to_string(&error).expect("serialize indexing request error");
         assert_eq!(
             json,
@@ -402,13 +399,11 @@ mod tests {
 
     #[test]
     fn trust_relation_error_preserves_stable_unavailable_code() {
-        let error = CommandError::from(
-            kukuri_desktop_runtime::CommunityNodeTrustRelationError {
-                code: "RELATION_NOT_FOUND".to_string(),
-                message: "no relation observed for this pair".to_string(),
-                status: Some(404),
-            },
-        );
+        let error = CommandError::from(kukuri_desktop_runtime::CommunityNodeTrustRelationError {
+            code: "RELATION_NOT_FOUND".to_string(),
+            message: "no relation observed for this pair".to_string(),
+            status: Some(404),
+        });
         let json = serde_json::to_string(&error).expect("serialize trust relation error");
         assert_eq!(
             json,
@@ -472,7 +467,12 @@ mod tests {
 
     #[test]
     fn startup_state_status_can_be_updated() {
-        let state = DesktopStartupState::consent_required(LEGAL_BUNDLE_VERSION, None);
+        let state = DesktopStartupState::initializing();
+        assert!(matches!(state.status(), DesktopStartupStatus::Initializing));
+        state.set_status(DesktopStartupStatus::ConsentRequired {
+            current_bundle_version: LEGAL_BUNDLE_VERSION,
+            accepted_bundle_version: None,
+        });
         assert!(matches!(
             state.status(),
             DesktopStartupStatus::ConsentRequired { .. }

--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -183,3 +183,24 @@ test('desktop app renders a startup error when the local database cannot be open
   expect(screen.getByDisplayValue(/migration checksum mismatch/)).toBeInTheDocument();
   expect(screen.queryByRole('button', { name: 'Post' })).not.toBeInTheDocument();
 });
+
+test('desktop app keeps the startup screen visible while the native runtime initializes', async () => {
+  invokeMock.mockResolvedValueOnce({ status: 'initializing' });
+  invokeMock.mockResolvedValueOnce({
+    status: 'failed',
+    error: {
+      kind: 'unknown',
+      message: 'kukuri could not finish desktop startup.',
+      detail: 'background initialization completed with an error',
+      db_path: null,
+    },
+  });
+
+  render(<App />);
+
+  expect(await screen.findByText('Checking startup status…')).toBeInTheDocument();
+  expect(await screen.findByText('kukuri could not open the local database.')).toBeInTheDocument();
+  expect(invokeMock).toHaveBeenCalledTimes(2);
+  expect(invokeMock).toHaveBeenNthCalledWith(1, 'get_desktop_startup_status', undefined);
+  expect(invokeMock).toHaveBeenNthCalledWith(2, 'get_desktop_startup_status', undefined);
+});

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -95,39 +95,49 @@ export function App(props: AppProps) {
     }
 
     let active = true;
-    getDesktopStartupStatus()
-      .then((status: DesktopStartupStatus) => {
-        if (!active) {
-          return;
-        }
-        setStartupGate(status);
-      })
-      .catch((error: unknown) => {
-        if (!active) {
-          return;
-        }
-        if (isBridgeUnavailableError(error)) {
-          // Tauri ブリッジ不在(ブラウザ/mock モード)— 文言非依存の code 判定(WP-C3)。
-          setStartupGate({ status: 'ready' });
-          return;
-        }
-        setStartupGate({
-          status: 'failed',
-          error: {
-            kind: 'unknown',
-            message: 'kukuri could not finish desktop startup.',
-            detail: error instanceof Error ? error.message : String(error),
-            db_path: null,
-          },
+    let retryTimer: ReturnType<typeof setTimeout> | null = null;
+    const loadStartupStatus = () => {
+      getDesktopStartupStatus()
+        .then((status: DesktopStartupStatus) => {
+          if (!active) {
+            return;
+          }
+          setStartupGate(status);
+          if (status.status === 'initializing') {
+            retryTimer = setTimeout(loadStartupStatus, 100);
+          }
+        })
+        .catch((error: unknown) => {
+          if (!active) {
+            return;
+          }
+          if (isBridgeUnavailableError(error)) {
+            // Tauri ブリッジ不在(ブラウザ/mock モード)— 文言非依存の code 判定(WP-C3)。
+            setStartupGate({ status: 'ready' });
+            return;
+          }
+          setStartupGate({
+            status: 'failed',
+            error: {
+              kind: 'unknown',
+              message: 'kukuri could not finish desktop startup.',
+              detail: error instanceof Error ? error.message : String(error),
+              db_path: null,
+            },
+          });
         });
-      });
+    };
+    loadStartupStatus();
 
     return () => {
       active = false;
+      if (retryTimer !== null) {
+        clearTimeout(retryTimer);
+      }
     };
   }, [props.api]);
 
-  if (startupGate.status === 'checking') {
+  if (startupGate.status === 'checking' || startupGate.status === 'initializing') {
     return <StartupStatusScreen status='checking' />;
   }
 

--- a/apps/desktop/src/lib/api/types.ts
+++ b/apps/desktop/src/lib/api/types.ts
@@ -106,6 +106,7 @@ export type DesktopStartupErrorView = {
 };
 
 export type DesktopStartupStatus =
+  | { status: 'initializing' }
   | { status: 'ready' }
   | {
       status: 'consent_required';

--- a/crates/transport/src/discovery.rs
+++ b/crates/transport/src/discovery.rs
@@ -1,17 +1,12 @@
 use std::sync::Arc;
 #[cfg(test)]
 use std::sync::RwLock as StdRwLock;
-use std::time::Duration;
 
 use anyhow::Result;
 use iroh::Endpoint;
 use iroh::address_lookup::MemoryLookup;
-use tokio::time::timeout;
-use tracing::debug;
 
 use crate::config::{ConnectMode, TransportRelayConfig};
-
-const RELAY_ONLINE_STARTUP_TIMEOUT: Duration = Duration::from_secs(15);
 
 pub async fn prepare_endpoint_for_discovery(
     endpoint: &Endpoint,
@@ -22,23 +17,10 @@ pub async fn prepare_endpoint_for_discovery(
     if relay_backed {
         let endpoint = endpoint.clone();
         let discovery = Arc::clone(discovery);
-        let online_task = tokio::spawn(async move {
+        tokio::spawn(async move {
             endpoint.online().await;
             discovery.add_endpoint_info(endpoint.addr());
         });
-        match timeout(RELAY_ONLINE_STARTUP_TIMEOUT, async {
-            let _ = online_task.await;
-        })
-        .await
-        {
-            Ok(()) => {}
-            Err(error) => {
-                debug!(
-                    error = %error,
-                    "timed out waiting for relay-backed endpoint to come online; continuing startup in background"
-                );
-            }
-        }
     }
     discovery.add_endpoint_info(endpoint.addr());
 
@@ -54,9 +36,41 @@ mod tests {
     use iroh::address_lookup::{AddrFilter, AddressLookup};
     use iroh_mainline_address_lookup::DhtAddressLookup;
     use n0_mainline::{DhtBuilder, Testnet};
+    use std::time::Duration;
+    use tokio::time::timeout;
 
     use crate::config::DhtDiscoveryOptions;
     use crate::iroh::bind_endpoint_with_options;
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn transport_unreachable_relay_does_not_block_endpoint_bind() {
+        let relay_config = TransportRelayConfig {
+            iroh_relay_urls: vec!["https://127.0.0.1:9".to_string()],
+        }
+        .normalized();
+        let relay_urls = Arc::new(StdRwLock::new(
+            relay_config.parsed_relay_urls().expect("relay urls"),
+        ));
+
+        let (endpoint, _discovery) = timeout(
+            Duration::from_secs(3),
+            bind_endpoint_with_options(
+                std::net::SocketAddr::V4(std::net::SocketAddrV4::new(
+                    std::net::Ipv4Addr::LOCALHOST,
+                    0,
+                )),
+                &DhtDiscoveryOptions::disabled(),
+                &relay_config,
+                relay_urls,
+                None,
+            ),
+        )
+        .await
+        .expect("endpoint bind must not wait for relay connectivity")
+        .expect("bind endpoint");
+
+        endpoint.close().await;
+    }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn transport_relay_backed_dht_lookup_publishes_relay_info() {


### PR DESCRIPTION
## 概要
- 同意済みの2回目以降の起動で、Tauri `setup` からデスクトップランタイム初期化を分離
- ランタイム初期化Futureを専用の blocking worker で駆動し、WebView資源処理との競合を回避
- relay-backed endpoint の `online()` 待機を起動クリティカルパスから外し、バックグラウンド更新へ変更
- `initializing` 状態と既存の起動ステータス画面を追加し、初期化中もUIを表示
- ランタイム準備後にバックグラウンド通知のイベント購読を開始

## 原因
保存済みコミュニティノード設定にrelay URLがあると、endpoint bind中の `endpoint.online()` を最大15秒待っていました。さらに通常の非同期ワーカで重い初期化を開始すると、TauriのWebView資源処理と競合し、`setup` 自体が短時間で返っても初期HTMLの描画が遅延していました。

## 振る舞い変更
- relay未到達でもendpoint bindとTauri setupは待機しません
- 初期化中は `StartupStatusScreen` を表示し、完了後に通常画面へ遷移します
- 初回の規約同意前は従来どおりネットワーク初期化を開始しません

## 検証
- 修正前の回帰テスト: 3秒でtimeout（再現確認）
- 修正後の同テスト: 0.06秒で成功
- 未到達コミュニティノードのruntimeテスト: 18.76秒 → 4.10秒
- `cargo test -p kukuri-transport`: 52 passed
- `cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml`: 18 passed / 1 ignored（既定）
- `cargo xtask check`: passed
- `cargo xtask test`: 701 nextest + 22 serial harness + 1055 frontend tests passed
- `cargo xtask e2e-smoke`: passed
- `cargo xtask desktop-ui-check`: lint/typecheck/Storybook/Playwright/visual smoke passed
- Windows 11 + WebView2で、実際の同意済み設定・コミュニティノード設定を使った再起動を確認。変更前は約10秒以上白画面、変更後は再起動直後にUI描画

## リスク
- 通信プロトコル、永続化形式、規約同意条件は変更していません
- relay online情報は接続完了後に従来どおりdiscoveryへ反映されます