### PR TITLE
chore: bump preview version to 0.1.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3112,7 +3112,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-app-api"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3143,7 +3143,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-blob-service"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3161,7 +3161,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-cli"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3183,7 +3183,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-core"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3217,7 +3217,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-e2e"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3250,7 +3250,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-indexer"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3280,7 +3280,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-iroh-relay"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "iroh-relay",
@@ -3294,7 +3294,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-operator"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "clap",
@@ -3309,7 +3309,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-protocol"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "kukuri-cn-safety",
@@ -3322,14 +3322,14 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-runtime-support"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "tracing-subscriber",
 ]
 
 [[package]]
 name = "kukuri-cn-safety"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "async-trait",
  "kukuri-cn-safety",
@@ -3342,7 +3342,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-safety-arachnid"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "async-trait",
  "kukuri-cn-safety",
@@ -3357,7 +3357,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-safety-runtime"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3376,7 +3376,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-safety-vlm"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -3392,7 +3392,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-trust"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3406,7 +3406,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-user-api"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "axum",
@@ -3442,7 +3442,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-core"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3461,7 +3461,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-desktop-runtime"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3498,7 +3498,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-docs-sync"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3523,7 +3523,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-harness"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "axum",
@@ -3549,7 +3549,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-iroh-node"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -3568,7 +3568,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-metaverse-host"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "kukuri-core",
@@ -3579,7 +3579,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-store"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3596,7 +3596,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-test-support"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "async-trait",
  "thiserror 2.0.20",
@@ -3605,7 +3605,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-transport"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8038,7 +8038,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 license = "MIT"
-version = "0.1.7"
+version = "0.1.8"
 
 [workspace.dependencies]
 anyhow = "1.0.104"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kukuri-desktop",
   "private": true,
-  "version": "0.1.7",
+  "version": "0.1.8",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -3796,7 +3796,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-app-api"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3820,7 +3820,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-blob-service"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3837,7 +3837,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-protocol"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "kukuri-cn-safety",
@@ -3849,7 +3849,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-safety"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "async-trait",
  "serde",
@@ -3859,7 +3859,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-core"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3877,7 +3877,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-desktop-runtime"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3904,7 +3904,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-desktop-tauri"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "base64 0.23.1",
@@ -3928,7 +3928,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-docs-sync"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3951,7 +3951,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-iroh-node"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -3969,7 +3969,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-metaverse-host"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "kukuri-core",
@@ -3980,7 +3980,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-store"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3994,7 +3994,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-transport"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kukuri-desktop-tauri"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2024"
 default-run = "kukuri-desktop-tauri"
 

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "kukuri",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "identifier": "app.kukuri.desktop",
   "build": {
     "beforeDevCommand": "npx pnpm@10.16.1 vite --host 127.0.0.1 --port 5173 --strictPort",

--- a/docs/runbooks/release.md
+++ b/docs/runbooks/release.md
@@ -28,7 +28,7 @@ Windows code signing certificates are optional for the first preview. If code si
 ## Local Gates
 
 ```bash
-cargo xtask release-check v0.1.7-preview.1
+cargo xtask release-check v0.1.8-preview.1
 cargo xtask check
 cargo xtask test
 cargo xtask e2e-smoke
@@ -108,7 +108,7 @@ The repository keeps a [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)-
 To preview the generated section locally before tagging (no commit, branch, or PR is created):
 
 ```powershell
-./scripts/release/update-changelog.ps1 -Tag v0.1.7-preview.1 -Repository KingYoSun/kukuri -PreviousTag v0.1.6-preview.1
+./scripts/release/update-changelog.ps1 -Tag v0.1.8-preview.1 -Repository KingYoSun/kukuri -PreviousTag v0.1.7-preview.1
 ```
 
 The `changelog` job needs `contents: write` and `pull-requests: write` permissions (already set in the workflow) to push the branch and open the PR.
@@ -192,7 +192,7 @@ if (-not $manifest.platforms.'windows-x86_64'.signature) {
 network access が必要。
 
 ```powershell
-./scripts/release/test-published-updater-signature.ps1 -Tag v0.1.7-preview.1
+./scripts/release/test-published-updater-signature.ps1 -Tag v0.1.8-preview.1
 ```
 
 assetを差し替えた場合は `SHA256SUMS.txt` も必ず更新する。GitHub/CDNの切替後に上記の短いURLを


### PR DESCRIPTION
## 概要
- workspace / desktop / Tauri のバージョンを 0.1.8 に更新
- preview release runbook の例を v0.1.8-preview.1 に更新
- root / Tauri の lockfile を更新

## 検証
- cargo xtask release-check v0.1.8-preview.1
- cargo xtask check
- cargo xtask test
- cargo xtask e2e-smoke