### PR TITLE
[codex][refactor:delete] remove community node auto approve flag

### DIFF
--- a/.codex/plans/2026-09-02-community-node-auto-approve-removal.md
+++ b/.codex/plans/2026-09-02-community-node-auto-approve-removal.md
@@ -1,0 +1,46 @@
+# Implementation Plan
+
+## Goal
+実際の接続制御に使われていない `auto_approve` フラグを Community Node の設定、実行時状態、IPC、画面、配布設定、文書から削除し、明示同意済みの設定 Node は自動的にセッション維持するという単一契約へ整理する。
+
+## Non-goals
+- Issue #857 が定める Node 別・文書別の明示同意、同意前通信禁止、重要変更時の再同意は変更しない。
+- default Community Node の候補 URL、初回だけ配布設定を保存する挙動、削除・置換後に復活しない挙動は変更しない。
+- Community Node の認証、登録、接続維持、参加審査、HTTP endpoint の契約は変更しない。
+- 手動接続モードや代替フラグは追加しない。
+
+## Assumptions
+- 現行 runtime は `auto_approve` を接続可否の分岐に使っておらず、設定済み Node はローカル同意成立後に同じセッション維持経路へ入る。
+- `CommunityNodeConfig` は未知の JSON フィールドを拒否していないため、旧 `community-node.json` の `auto_approve` は専用 migration を追加せず読み捨てられる。
+- Community Node の Rust 型と TypeScript 型は同一 desktop binary 内の IPC 契約であり、両側を同一変更で更新できる。
+- 配布設定からフラグを除いても default Node の初回 preload 判定には影響しない。
+
+## Definition of Done
+- product source、配布設定、生成 IPC 型、画面文言、現行文書から `auto_approve` / `autoApprove` と「自動承認」の概念がなくなる。旧設定互換テストの入力 fixture に限り旧キーを残してよい。
+- 旧 `auto_approve` を含む保存済み設定を読み込め、再保存した JSON から旧フィールドが除去される。
+- Community Node 設定画面から自動承認の入力・診断表示がなくなり、Node の保存 request は base URL だけを送る。
+- 未同意 Node への通信が発生せず、明示同意後だけセッションが確立し、policy 更新時には黙って再同意しない既存契約が成功する。
+- 配布 Node の初回 preload、利用者による空設定・置換設定の優先、Community Node 関連の desktop/runtime 回帰が成功する。
+
+## Plan
+| ID | Task | Outcome | Files / Areas | Acceptance Criteria | Validation | Depends On |
+|---|---|---|---|---|---|---|
+| T1 | Rust の設定・状態・入力型から不要フラグを削除し、旧設定の読み捨て互換を固定する | runtime とローカル設定の Node モデルが `base_url` と接続解決状態だけを持ち、重複正規化から不要な真偽値統合が消える | `crates/desktop-runtime/src/community_node/{mod.rs,config_support.rs,session_runtime_support.rs}`、`crates/desktop-runtime/src/runtime/community_node_api.rs`、`crates/desktop-runtime/src/tests/**`、`crates/harness/src/scenarios/**` | `CommunityNodeNodeConfig`、`CommunityNodeNodeStatus`、設定入力からフラグが消える。旧キー入り JSON は同じ Node URL と解決済み接続情報を保持して読み込め、保存後は旧キーを出力しない。未同意、同意済み、policy 更新の各セッション契約は従来どおり成立する | 旧設定の load/save 互換テスト、対象 community-node runtime tests、`cargo xtask ipc-types`、`cargo xtask rust-test` | None |
+| T2 | 配布設定と Tauri / frontend の設定契約・画面からフラグを削除する | 利用者が意味のない自動承認設定を操作・診断できなくなり、default Node は URL だけで preload される | `apps/desktop/src-tauri/distribution/community-nodes.json`、`apps/desktop/src-tauri/src/state.rs`、`apps/desktop/src/lib/api/{types.ts,types.generated.ts}`、`apps/desktop/src/shell/**`、`apps/desktop/src/components/settings/**`、`apps/desktop/src/mocks/**`、関連 story/test/i18n | 配布 JSON と設定 request に旧フィールドがない。設定画面・診断・story・mock に自動承認の表示や入力がない。fresh install、空設定、置換設定の優先契約が維持され、Rust 生成型と TypeScript 利用側が一致する | `cargo xtask ipc-types`、Tauri 配布設定 test、関連 Vitest、`cargo xtask tauri-check`、`cargo xtask desktop-ui-check` | T1 |
+| T3 | 現行文書とテスト名称を明示同意後の自動接続契約へ合わせる | `auto_approve` が法的同意を自動化するように読める記述がなくなり、Issue #857 との責任境界が一貫する | `docs/progress/2026-04-16-mvp-builder-preview-plan.md`、`docs/adr/0024-community-node-admission-data-classification.md`、`docs/runbooks/mvp-troubleshooting.md`、関連コードコメント・テスト名 | 文書は「配布候補」「利用者の明示同意」「同意後の自動セッション確立」を区別する。認証前の公開 policy 照合、サーバ同意記録への同期、重要変更時の再同意を自動的な法的同意と表現しない | `rg` による旧用語残存確認、文書内の command/path 確認、更新したテストの実行 | T1、T2 |
+| T4 | path 別の必須検証と全体回帰を完走する | フラグ削除が desktop 起動、設定永続化、IPC、画面、Community Node セッションを壊していないことを判定できる | workspace 全体 | `auto_approve` / `autoApprove` は旧設定互換 fixture 以外に残らず、生成差分が確定し、必須検証がすべて成功する。意図した画面差分で視覚回帰が失敗した場合は Linux/Chromium の正規手順で baseline を更新する | `cargo xtask check`、`cargo xtask test`、`cargo xtask rust-test`、`cargo xtask tauri-check`、`cargo xtask desktop-ui-check`、`cargo xtask e2e-smoke` | T1、T2、T3 |
+
+## Decision Needed / Blockers
+None
+
+## Out of Scope
+- Community Node 同意モーダルのデザイン変更。
+- app-level 利用規約・プライバシーポリシー同意の変更。
+- Community Node server 側の consent データや API の移行。
+
+## Single Next Action
+PR を作成し、CI 成功後にマージする。
+
+## Progress
+- 2026-09-02: T1-T3 を実装。Rust / IPC / frontend / 配布設定 / 現行文書からフラグを削除し、旧設定の読み捨て・再保存互換テストを追加。
+- 2026-09-02: `cargo xtask check`、`cargo xtask test`、`cargo xtask rust-test`、`cargo xtask tauri-check`、`cargo xtask desktop-ui-check`、`cargo xtask e2e-smoke` が成功。

--- a/apps/desktop/src-tauri/distribution/community-nodes.json
+++ b/apps/desktop/src-tauri/distribution/community-nodes.json
@@ -1,8 +1,7 @@
 {
   "nodes": [
     {
-      "base_url": "https://api.kukuri.app",
-      "auto_approve": true
+      "base_url": "https://api.kukuri.app"
     }
   ]
 }

--- a/apps/desktop/src-tauri/src/state.rs
+++ b/apps/desktop/src-tauri/src/state.rs
@@ -538,10 +538,10 @@ mod tests {
     use super::*;
 
     #[test]
-    fn distribution_community_node_config_is_valid_and_auto_approved() {
+    fn distribution_community_node_config_is_valid() {
         let config = distribution_community_node_config().expect("distribution config");
         assert_eq!(config.nodes.len(), 1);
-        assert!(config.nodes[0].auto_approve);
+        assert!(config.nodes[0].base_url.starts_with("https://"));
     }
 
     // IPC エラー封筒の wire 形状(WP-C3)。TS 側 normalizeInvokeError と対になる

--- a/apps/desktop/src/components/settings/CommunityNodePanel.distanceOptout.test.tsx
+++ b/apps/desktop/src/components/settings/CommunityNodePanel.distanceOptout.test.tsx
@@ -33,7 +33,6 @@ test('loads, enables, and clears reversible node-local distance opt-out', async 
       clearDisabled={false}
       onAddNode={() => undefined}
       onNodeBaseUrlChange={() => undefined}
-      onNodeAutoApproveChange={() => undefined}
       onRemoveNode={() => undefined}
       onSaveNodes={() => undefined}
       onReset={() => undefined}
@@ -79,7 +78,6 @@ test('disables distance opt-out actions for a node that is not eligible', async 
       clearDisabled={false}
       onAddNode={() => undefined}
       onNodeBaseUrlChange={() => undefined}
-      onNodeAutoApproveChange={() => undefined}
       onRemoveNode={() => undefined}
       onSaveNodes={() => undefined}
       onReset={() => undefined}
@@ -124,7 +122,6 @@ test('explains distance opt-out failures with stable codes instead of raw server
       clearDisabled={false}
       onAddNode={() => undefined}
       onNodeBaseUrlChange={() => undefined}
-      onNodeAutoApproveChange={() => undefined}
       onRemoveNode={() => undefined}
       onSaveNodes={() => undefined}
       onReset={() => undefined}

--- a/apps/desktop/src/components/settings/CommunityNodePanel.indexPreference.test.tsx
+++ b/apps/desktop/src/components/settings/CommunityNodePanel.indexPreference.test.tsx
@@ -12,7 +12,6 @@ const baseProps = {
   clearDisabled: false,
   onAddNode: () => {},
   onNodeBaseUrlChange: () => {},
-  onNodeAutoApproveChange: () => {},
   onRemoveNode: () => {},
   onSaveNodes: () => {},
   onReset: () => {},

--- a/apps/desktop/src/components/settings/CommunityNodePanel.inviteAdmission.test.tsx
+++ b/apps/desktop/src/components/settings/CommunityNodePanel.inviteAdmission.test.tsx
@@ -40,7 +40,6 @@ test('submits a masked invite code only for the selected node', async () => {
       clearDisabled={false}
       onAddNode={() => {}}
       onNodeBaseUrlChange={() => {}}
-      onNodeAutoApproveChange={() => {}}
       onRemoveNode={() => {}}
       onSaveNodes={() => {}}
       onReset={() => {}}

--- a/apps/desktop/src/components/settings/CommunityNodePanel.stories.tsx
+++ b/apps/desktop/src/components/settings/CommunityNodePanel.stories.tsx
@@ -35,7 +35,6 @@ function CommunityNodePanelStory({
               {
                 id: `story-node-${current.length + 1}`,
                 baseUrl: '',
-                autoApprove: false,
                 saved: false,
                 diagnostics: [],
                 dependency: { diagnostics: [], boundaryNotes: [] },
@@ -59,11 +58,6 @@ function CommunityNodePanelStory({
           onNodeBaseUrlChange={(id, value) =>
             setNodes((current) =>
               current.map((node) => (node.id === id ? { ...node, baseUrl: value } : node))
-            )
-          }
-          onNodeAutoApproveChange={(id, value) =>
-            setNodes((current) =>
-              current.map((node) => (node.id === id ? { ...node, autoApprove: value } : node))
             )
           }
           onRemoveNode={(id) =>
@@ -96,7 +90,6 @@ const meta = {
     clearDisabled: false,
     onAddNode: () => {},
     onNodeBaseUrlChange: () => {},
-    onNodeAutoApproveChange: () => {},
     onRemoveNode: () => {},
     onSaveNodes: () => {},
     onReset: () => {},

--- a/apps/desktop/src/components/settings/CommunityNodePanel.tsx
+++ b/apps/desktop/src/components/settings/CommunityNodePanel.tsx
@@ -26,7 +26,6 @@ type CommunityNodePanelProps = {
   nodeActionsDisabled?: boolean;
   onAddNode: () => void;
   onNodeBaseUrlChange: (id: string, value: string) => void;
-  onNodeAutoApproveChange: (id: string, value: boolean) => void;
   onRemoveNode: (id: string) => void;
   onSaveNodes: () => void;
   onReset: () => void;
@@ -59,7 +58,6 @@ export function CommunityNodePanel({
   nodeActionsDisabled = false,
   onAddNode,
   onNodeBaseUrlChange,
-  onNodeAutoApproveChange,
   onRemoveNode,
   onSaveNodes,
   onReset,
@@ -319,16 +317,6 @@ export function CommunityNodePanel({
                     className='font-mono text-[0.8rem]'
                   />
                 </div>
-                <label className='flex items-center gap-3 text-sm text-foreground'>
-                  <input
-                    type='checkbox'
-                    checked={node.autoApprove}
-                    onChange={(event) =>
-                      onNodeAutoApproveChange(node.id, event.currentTarget.checked)
-                    }
-                  />
-                  <span>{t('settings:communityNode.autoApproveLabel')}</span>
-                </label>
                 <p className='text-sm text-[var(--muted-foreground)]'>
                   {node.saved
                     ? t('settings:communityNode.nodeSummary')

--- a/apps/desktop/src/components/settings/SettingsPanels.test.tsx
+++ b/apps/desktop/src/components/settings/SettingsPanels.test.tsx
@@ -163,7 +163,6 @@ test('community node panel renders ready and error states', async () => {
       clearDisabled={false}
       onAddNode={() => {}}
       onNodeBaseUrlChange={() => {}}
-      onNodeAutoApproveChange={() => {}}
       onRemoveNode={() => {}}
       onSaveNodes={() => {}}
       onReset={() => {}}
@@ -235,7 +234,6 @@ test('community node consent dialog shows policy body, version, and update notic
       clearDisabled={false}
       onAddNode={() => {}}
       onNodeBaseUrlChange={() => {}}
-      onNodeAutoApproveChange={() => {}}
       onRemoveNode={() => {}}
       onSaveNodes={() => {}}
       onReset={() => {}}
@@ -296,7 +294,6 @@ test('community node consent dialog disables accept when latest policy fetch fai
       clearDisabled={false}
       onAddNode={() => {}}
       onNodeBaseUrlChange={() => {}}
-      onNodeAutoApproveChange={() => {}}
       onRemoveNode={() => {}}
       onSaveNodes={() => {}}
       onReset={() => {}}
@@ -360,7 +357,6 @@ test('settings panels avoid the legacy grid classname collision', () => {
         clearDisabled={false}
         onAddNode={() => {}}
         onNodeBaseUrlChange={() => {}}
-        onNodeAutoApproveChange={() => {}}
         onRemoveNode={() => {}}
         onSaveNodes={() => {}}
         onReset={() => {}}
@@ -600,7 +596,6 @@ test('community node panel hides diagnostics but keeps node editing when showDia
       clearDisabled={false}
       onAddNode={() => {}}
       onNodeBaseUrlChange={() => {}}
-      onNodeAutoApproveChange={() => {}}
       onRemoveNode={() => {}}
       onSaveNodes={() => {}}
       onReset={() => {}}

--- a/apps/desktop/src/components/settings/fixtures.ts
+++ b/apps/desktop/src/components/settings/fixtures.ts
@@ -145,10 +145,8 @@ export function createCommunityNodePanelFixture(): CommunityNodePanelView {
       {
         id: 'node-api',
         baseUrl: 'https://api.kukuri.app',
-        autoApprove: true,
         saved: true,
         diagnostics: [
-          { label: i18n.t('settings:communityNode.diagnostics.autoApprove'), value: i18n.t('common:states.yes') },
           { label: i18n.t('settings:communityNode.diagnostics.auth'), value: `${i18n.t('common:states.yes')} (1711324800000)` },
           { label: i18n.t('settings:communityNode.diagnostics.consent'), value: i18n.t('common:states.accepted') },
           {
@@ -244,10 +242,8 @@ export function createCommunityNodePanelFixture(): CommunityNodePanelView {
       {
         id: 'node-example',
         baseUrl: 'https://community.example.com',
-        autoApprove: false,
         saved: true,
         diagnostics: [
-          { label: i18n.t('settings:communityNode.diagnostics.autoApprove'), value: i18n.t('common:states.no') },
           { label: i18n.t('settings:communityNode.diagnostics.auth'), value: i18n.t('common:states.no') },
           { label: i18n.t('settings:communityNode.diagnostics.consent'), value: i18n.t('common:states.unknown') },
           {

--- a/apps/desktop/src/components/settings/types.ts
+++ b/apps/desktop/src/components/settings/types.ts
@@ -99,7 +99,6 @@ export type CommunityNodeConsentView = {
 export type CommunityNodeEntryView = {
   id: string;
   baseUrl: string;
-  autoApprove: boolean;
   saved: boolean;
   diagnostics: SettingsDiagnosticItemView[];
   dependency: CommunityNodeDependencyView;

--- a/apps/desktop/src/components/shell/SettingsDrawer.stories.tsx
+++ b/apps/desktop/src/components/shell/SettingsDrawer.stories.tsx
@@ -87,7 +87,6 @@ function SettingsDrawerStory({ initialSection = 'connectivity' }: { initialSecti
               {
                 id: `drawer-node-${current.length + 1}`,
                 baseUrl: '',
-                autoApprove: false,
                 saved: false,
                 diagnostics: [],
                 dependency: { diagnostics: [], boundaryNotes: [] },
@@ -111,11 +110,6 @@ function SettingsDrawerStory({ initialSection = 'connectivity' }: { initialSecti
           onNodeBaseUrlChange={(id, value) =>
             setCommunityNodes((current) =>
               current.map((node) => (node.id === id ? { ...node, baseUrl: value } : node))
-            )
-          }
-          onNodeAutoApproveChange={(id, value) =>
-            setCommunityNodes((current) =>
-              current.map((node) => (node.id === id ? { ...node, autoApprove: value } : node))
             )
           }
           onRemoveNode={(id) =>

--- a/apps/desktop/src/i18n/locales/en/settings.json
+++ b/apps/desktop/src/i18n/locales/en/settings.json
@@ -121,7 +121,6 @@
       "enabled": "Enabled. The node-local minimum proximity is {{distance}}.",
       "disabled": "Disabled. The node-local minimum proximity would be {{distance}}."
     },
-    "autoApproveLabel": "Auto-approve consent for this node",
     "admission": {
       "inviteCodeLabel": "Invite code",
       "inviteCodePlaceholder": "Enter invite code",
@@ -172,7 +171,6 @@
     "baseUrlsLabel": "Base URLs",
     "baseUrlsPlaceholder": "https://community.example.com",
     "diagnostics": {
-      "autoApprove": "Auto-approve",
       "auth": "Auth",
       "connectivityUrls": "Connectivity URLs",
       "consent": "Consent",
@@ -188,7 +186,7 @@
     },
     "loading": "Loading community node diagnostics…",
     "noNodes": "No community nodes configured.",
-    "nodesHint": "Each community node keeps a base URL and an auto-approve policy.",
+    "nodesHint": "Each community node has a base URL and requires separate consent before use.",
     "nodesLabel": "Configured Nodes",
     "nodeSummary": "Auth, consent, and connectivity state for this node.",
     "sessionPhases": {

--- a/apps/desktop/src/i18n/locales/ja/settings.json
+++ b/apps/desktop/src/i18n/locales/ja/settings.json
@@ -121,7 +121,6 @@
       "enabled": "有効です。ノード内の最小関係距離は {{distance}} です。",
       "disabled": "無効です。有効時のノード内最小関係距離は {{distance}} です。"
     },
-    "autoApproveLabel": "このノードの同意を自動承認する",
     "admission": {
       "inviteCodeLabel": "招待コード",
       "inviteCodePlaceholder": "招待コードを入力",
@@ -172,7 +171,6 @@
     "baseUrlsLabel": "ベース URL",
     "baseUrlsPlaceholder": "https://community.example.com",
     "diagnostics": {
-      "autoApprove": "自動承認",
       "auth": "認証",
       "connectivityUrls": "接続 URL",
       "consent": "同意",
@@ -188,7 +186,7 @@
     },
     "loading": "コミュニティノード診断を読み込み中…",
     "noNodes": "設定済みのコミュニティノードはありません。",
-    "nodesHint": "各コミュニティノードはベースURLと自動承認ポリシーを持ちます。",
+    "nodesHint": "各コミュニティノードはベースURLを持ち、利用前に個別の同意が必要です。",
     "nodesLabel": "設定済みノード",
     "nodeSummary": "このノードの認証、同意、接続状態です。",
     "sessionPhases": {

--- a/apps/desktop/src/i18n/locales/zh-CN/settings.json
+++ b/apps/desktop/src/i18n/locales/zh-CN/settings.json
@@ -121,7 +121,6 @@
       "enabled": "已启用。节点本地最小接近度为 {{distance}}。",
       "disabled": "已停用。启用时的节点本地最小接近度为 {{distance}}。"
     },
-    "autoApproveLabel": "自动批准此节点的 consent",
     "admission": {
       "inviteCodeLabel": "邀请码",
       "inviteCodePlaceholder": "输入邀请码",
@@ -172,7 +171,6 @@
     "baseUrlsLabel": "基础 URL",
     "baseUrlsPlaceholder": "https://community.example.com",
     "diagnostics": {
-      "autoApprove": "自动批准",
       "auth": "认证",
       "connectivityUrls": "连接 URL",
       "consent": "同意",
@@ -188,7 +186,7 @@
     },
     "loading": "正在加载社区节点诊断…",
     "noNodes": "尚未配置社区节点。",
-    "nodesHint": "每个社区节点都保存基础 URL 和自动批准策略。",
+    "nodesHint": "每个社区节点都有基础 URL，并且在使用前需要单独同意。",
     "nodesLabel": "已配置的节点",
     "nodeSummary": "此节点的认证、同意和连接状态。",
     "sessionPhases": {

--- a/apps/desktop/src/lib/api/communityIndex.test.ts
+++ b/apps/desktop/src/lib/api/communityIndex.test.ts
@@ -38,7 +38,6 @@ const manifest = (available: string[]): CommunityNodeManifest => ({
 
 const status = (baseUrl: string, ready: boolean): CommunityNodeNodeStatus => ({
   base_url: baseUrl,
-  auto_approve: false,
   auth_state: { authenticated: ready, expires_at: null },
   consent_state: ready ? { all_required_accepted: true, items: [] } : null,
   resolved_urls: null,
@@ -53,7 +52,7 @@ const status = (baseUrl: string, ready: boolean): CommunityNodeNodeStatus => ({
 describe('community index node eligibility', () => {
   it('requires configured, authenticated, consented, available capability', () => {
     const config: CommunityNodeConfig = {
-      nodes: [{ base_url: 'https://a', auto_approve: false, resolved_urls: null }],
+      nodes: [{ base_url: 'https://a', resolved_urls: null }],
     };
     expect(
       eligibleCommunityIndexNodes(config, [status('https://a', true)], {
@@ -76,8 +75,8 @@ describe('community index node eligibility', () => {
   it('separates trust relation and distance opt-out eligibility by capability', () => {
     const config: CommunityNodeConfig = {
       nodes: [
-        { base_url: 'https://index-only', auto_approve: false, resolved_urls: null },
-        { base_url: 'https://trust', auto_approve: false, resolved_urls: null },
+        { base_url: 'https://index-only', resolved_urls: null },
+        { base_url: 'https://trust', resolved_urls: null },
       ],
     };
     const statuses = [status('https://index-only', true), status('https://trust', true)];

--- a/apps/desktop/src/lib/api/types.generated.ts
+++ b/apps/desktop/src/lib/api/types.generated.ts
@@ -306,7 +306,7 @@ export type CommunityNodeAdmissionRejection = { code: CommunityNodeAdmissionReje
 
 export type CommunityNodeSessionPhase = "idle" | "connecting" | "authenticating" | "accepting" | "refreshing" | "ready" | "retrying" | "awaiting_admission";
 
-export type CommunityNodeNodeStatus = { base_url: string, auth_state: CommunityNodeAuthState, consent_state?: CommunityNodeConsentStatus | null,
+export type CommunityNodeNodeStatus = { base_url: string, auth_state: CommunityNodeAuthState, consent_state?: CommunityNodeConsentStatus | null, 
 /**
  * #857: Node 別ローカル同意記録。空 = 未同意(この node へは通信しない)。
  */
@@ -676,3 +676,4 @@ export type AccountsSnapshot = { active_account_id: string, accounts: Array<Acco
 export type AccountKeyExport = { export: string, public_key: string, };
 
 export type AccountKeyImportPreview = { version: number, kdf: string, public_key: string, already_registered: boolean, };
+

--- a/apps/desktop/src/lib/api/types.generated.ts
+++ b/apps/desktop/src/lib/api/types.generated.ts
@@ -275,7 +275,7 @@ export type CommunityNodeSeedPeer = { endpoint_id: string, addr_hint?: string | 
 
 export type CommunityNodeResolvedUrls = { public_base_url: string, connectivity_urls: Array<string>, seed_peers?: Array<CommunityNodeSeedPeer> | null, };
 
-export type CommunityNodeNodeConfig = { base_url: string, auto_approve?: boolean | null, resolved_urls?: CommunityNodeResolvedUrls | null, };
+export type CommunityNodeNodeConfig = { base_url: string, resolved_urls?: CommunityNodeResolvedUrls | null, };
 
 export type CommunityNodeConfig = { nodes: Array<CommunityNodeNodeConfig>, };
 
@@ -306,7 +306,7 @@ export type CommunityNodeAdmissionRejection = { code: CommunityNodeAdmissionReje
 
 export type CommunityNodeSessionPhase = "idle" | "connecting" | "authenticating" | "accepting" | "refreshing" | "ready" | "retrying" | "awaiting_admission";
 
-export type CommunityNodeNodeStatus = { base_url: string, auto_approve?: boolean | null, auth_state: CommunityNodeAuthState, consent_state?: CommunityNodeConsentStatus | null, 
+export type CommunityNodeNodeStatus = { base_url: string, auth_state: CommunityNodeAuthState, consent_state?: CommunityNodeConsentStatus | null,
 /**
  * #857: Node 別ローカル同意記録。空 = 未同意(この node へは通信しない)。
  */
@@ -649,7 +649,7 @@ export type WithdrawDomeConnectionProposalRequest = { spatial_context: SpatialCo
 
 export type RevokeDomeConnectionRequest = { spatial_context: SpatialContextV1, connection_id: string, };
 
-export type SetCommunityNodeConfigNode = { base_url: string, auto_approve: boolean, };
+export type SetCommunityNodeConfigNode = { base_url: string, };
 
 export type SetCommunityNodeConfigRequest = { nodes: Array<SetCommunityNodeConfigNode>, };
 
@@ -676,4 +676,3 @@ export type AccountsSnapshot = { active_account_id: string, accounts: Array<Acco
 export type AccountKeyExport = { export: string, public_key: string, };
 
 export type AccountKeyImportPreview = { version: number, kdf: string, public_key: string, already_registered: boolean, };
-

--- a/apps/desktop/src/lib/api/types.ts
+++ b/apps/desktop/src/lib/api/types.ts
@@ -199,7 +199,6 @@ export type CreateRepostInput = {
 
 export type CommunityNodeConfigInput = {
   base_url: string;
-  auto_approve: boolean;
 };
 
 // community node manifest (#355/#356) の client 側表現。public manifest endpoint から取得し、

--- a/apps/desktop/src/mocks/api/connectivity.ts
+++ b/apps/desktop/src/mocks/api/connectivity.ts
@@ -105,20 +105,18 @@ export function createConnectivityMock(runtime: MockRuntime): ConnectivityMock {
       runtime.communityNodeConfig = {
         nodes: nodes.map((node) => ({
           base_url: node.base_url,
-          auto_approve: node.auto_approve,
           resolved_urls: null,
         })),
       };
       runtime.communityNodeStatuses = nodes.map((node) => ({
         base_url: node.base_url,
-        auto_approve: node.auto_approve,
         auth_state: { authenticated: false, expires_at: null },
         consent_state: null,
         resolved_urls: null,
         last_error: null,
         invite_code_saved: false,
         admission_rejection: null,
-        session_phase: node.auto_approve ? 'connecting' : 'idle',
+        session_phase: 'idle',
         retry_after: null,
         restart_required: false,
       }));
@@ -135,7 +133,7 @@ export function createConnectivityMock(runtime: MockRuntime): ConnectivityMock {
               ...status,
               auth_state: { authenticated: true, expires_at: Date.now() },
               consent_state: { all_required_accepted: false, items: mockConsentItems(false) },
-              session_phase: status.auto_approve ? 'accepting' : 'authenticating',
+              session_phase: 'authenticating',
             }
           : status
       );

--- a/apps/desktop/src/mocks/mockRuntime.ts
+++ b/apps/desktop/src/mocks/mockRuntime.ts
@@ -330,7 +330,6 @@ export function createMockRuntime(options?: DesktopMockApiOptions): MockRuntime 
       nodes: [
         {
           base_url: 'https://api.kukuri.app',
-          auto_approve: true,
           resolved_urls: {
             public_base_url: 'https://api.kukuri.app',
             connectivity_urls: ['https://api.kukuri.app'],
@@ -342,7 +341,6 @@ export function createMockRuntime(options?: DesktopMockApiOptions): MockRuntime 
     communityNodeStatuses: [
       {
         base_url: 'https://api.kukuri.app',
-        auto_approve: true,
         auth_state: { authenticated: true, expires_at: Date.now() + 60_000 },
         consent_state: { all_required_accepted: true, items: mockConsentItems(true) },
         // #857: mock の既定ノードはローカル同意済みとして扱う。

--- a/apps/desktop/src/shell/DesktopShellPage.communityIndex.test.tsx
+++ b/apps/desktop/src/shell/DesktopShellPage.communityIndex.test.tsx
@@ -50,8 +50,8 @@ test('Explore header selects named eligible nodes, clears stale results, and ret
     );
   }
   await api.setCommunityNodeConfig([
-    { base_url: NODE_A, auto_approve: false },
-    { base_url: NODE_B, auto_approve: false },
+    { base_url: NODE_A },
+    { base_url: NODE_B },
   ]);
   for (const baseUrl of [NODE_A, NODE_B]) {
     await api.authenticateCommunityNode(baseUrl);

--- a/apps/desktop/src/shell/DesktopShellPage.workspaceResilience.test.tsx
+++ b/apps/desktop/src/shell/DesktopShellPage.workspaceResilience.test.tsx
@@ -22,7 +22,7 @@ afterEach(() => {
   vi.useRealTimers();
 });
 
-test('community node panel keeps the auto-approve node active on the current session', async () => {
+test('community node panel keeps the configured node active on the current session', async () => {
   const api = createDesktopMockApi();
   const user = userEvent.setup();
 
@@ -31,11 +31,7 @@ test('community node panel keeps the auto-approve node active on the current ses
   const drawer = await openSettingsSection(user, 'community-node');
   const nodeHeading = await within(drawer).findByText('https://api.kukuri.app', { selector: 'h4' });
   const blockElement = closestSection(nodeHeading);
-  expect(
-    within(blockElement).getByRole('checkbox', {
-      name: 'Auto-approve consent for this node',
-    })
-  ).toBeChecked();
+  expect(within(blockElement).queryByRole('checkbox')).not.toBeInTheDocument();
 
   await waitFor(() => {
     expect(within(blockElement).getAllByText('https://api.kukuri.app').length).toBeGreaterThan(0);

--- a/apps/desktop/src/shell/actions/profileTopicChannel.ts
+++ b/apps/desktop/src/shell/actions/profileTopicChannel.ts
@@ -42,7 +42,7 @@ type ProfileTopicChannelParams = ActionsBaseParams & {
   activeTopic: string;
   channelAudienceInput: 'invite_only' | 'friend_only' | 'friend_plus';
   channelLabelInput: string;
-  communityNodeInput: Array<{ id: string; base_url: string; auto_approve: boolean }>;
+  communityNodeInput: Array<{ id: string; base_url: string }>;
   discoverySeedInput: string;
   inviteTokenInput: string;
   localProfile: {

--- a/apps/desktop/src/shell/page/DesktopShellSettingsDrawer.tsx
+++ b/apps/desktop/src/shell/page/DesktopShellSettingsDrawer.tsx
@@ -240,7 +240,6 @@ export function DesktopShellSettingsDrawer({
               {
                 id: createCommunityNodeDraftId(),
                 base_url: '',
-                auto_approve: false,
               },
             ]);
             setCommunityNodeEditorDirty(true);
@@ -248,12 +247,6 @@ export function DesktopShellSettingsDrawer({
           onNodeBaseUrlChange={(id, value) => {
             setCommunityNodeInput((current) =>
               current.map((node) => (node.id === id ? { ...node, base_url: value } : node))
-            );
-            setCommunityNodeEditorDirty(true);
-          }}
-          onNodeAutoApproveChange={(id, value) => {
-            setCommunityNodeInput((current) =>
-              current.map((node) => (node.id === id ? { ...node, auto_approve: value } : node))
             );
             setCommunityNodeEditorDirty(true);
           }}

--- a/apps/desktop/src/shell/presentation.test.ts
+++ b/apps/desktop/src/shell/presentation.test.ts
@@ -89,13 +89,12 @@ describe('mergeCommunityNodeStatus', () => {
     expect(merged.last_error).toBe('new failure');
   });
 
-  it('preserves config-ish fallbacks from the previous status', () => {
+  it('preserves resolved URL fallbacks from the previous status', () => {
     const resolvedUrls = {
       public_base_url: 'https://node.example',
       connectivity_urls: ['https://node.example/connect'],
     };
     const previous = baseStatus({
-      auto_approve: true,
       resolved_urls: resolvedUrls,
       last_error: 'old failure',
     });
@@ -103,7 +102,6 @@ describe('mergeCommunityNodeStatus', () => {
 
     const merged = mergeCommunityNodeStatus(previous, next);
 
-    expect(merged.auto_approve).toBe(true);
     expect(merged.resolved_urls).toEqual(resolvedUrls);
     expect(merged.last_error).toBeNull();
   });
@@ -289,7 +287,7 @@ describe('mergeCommunityNodeStatuses', () => {
       connectivity_urls: ['https://a.example/connect'],
     };
     const previous = [
-      baseStatus({ base_url: 'https://a.example', auto_approve: true, resolved_urls: resolvedUrls }),
+      baseStatus({ base_url: 'https://a.example', resolved_urls: resolvedUrls }),
       baseStatus({ base_url: 'https://b.example' }),
     ];
     const next = [
@@ -303,10 +301,8 @@ describe('mergeCommunityNodeStatuses', () => {
       'https://c.example',
       'https://a.example',
     ]);
-    // previous があるものは config-ish フィールドを引き継ぎ、無いものは merge の defaults
-    expect(merged[1].auto_approve).toBe(true);
+    // previous があるものは resolved URL を引き継ぎ、無いものは merge の defaults
     expect(merged[1].resolved_urls).toEqual(resolvedUrls);
-    expect(merged[0].auto_approve).toBe(false);
     expect(merged[0].session_phase).toBe('idle');
     expect(merged[0].retry_after).toBeNull();
   });
@@ -316,7 +312,7 @@ describe('upsertCommunityNodeStatus', () => {
   it('inserts or replaces by base_url, keeping merge fallbacks and sorting by base_url', () => {
     const current = [
       baseStatus({ base_url: 'https://c.example' }),
-      baseStatus({ base_url: 'https://a.example', auto_approve: true }),
+      baseStatus({ base_url: 'https://a.example' }),
     ];
 
     const inserted = upsertCommunityNodeStatus(current, baseStatus({ base_url: 'https://b.example' }));
@@ -334,45 +330,41 @@ describe('upsertCommunityNodeStatus', () => {
       'https://a.example',
       'https://c.example',
     ]);
-    expect(replaced[0].auto_approve).toBe(true);
     expect(replaced[0].last_error).toBe('boom');
   });
 });
 
 describe('syncCommunityNodeConfigWithStatus', () => {
-  it('applies status resolved_urls to the matching node only, keeping node auto_approve', () => {
+  it('applies status resolved_urls to the matching node only', () => {
     const resolvedUrls = {
       public_base_url: 'https://a.example',
       connectivity_urls: ['https://a.example/connect'],
     };
     const config: CommunityNodeConfig = {
       nodes: [
-        { base_url: 'https://a.example', auto_approve: true },
-        { base_url: 'https://b.example', auto_approve: false },
+        { base_url: 'https://a.example' },
+        { base_url: 'https://b.example' },
       ],
     };
     const status = baseStatus({ base_url: 'https://a.example', resolved_urls: resolvedUrls });
 
     const synced = syncCommunityNodeConfigWithStatus(config, status);
 
-    // status.auto_approve 欠落時は node 側の値を維持、resolved_urls は status 側を採用
     expect(synced.nodes[0]).toEqual({
       base_url: 'https://a.example',
-      auto_approve: true,
       resolved_urls: resolvedUrls,
     });
     // base_url が一致しない node は変更されない
-    expect(synced.nodes[1]).toEqual({ base_url: 'https://b.example', auto_approve: false });
+    expect(synced.nodes[1]).toEqual({ base_url: 'https://b.example' });
   });
 
-  it('falls back to auto_approve=false and resolved_urls=null when both sides are missing', () => {
+  it('falls back to resolved_urls=null when both sides are missing', () => {
     const config: CommunityNodeConfig = { nodes: [{ base_url: 'https://a.example' }] };
 
     const synced = syncCommunityNodeConfigWithStatus(config, baseStatus({ base_url: 'https://a.example' }));
 
     expect(synced.nodes[0]).toEqual({
       base_url: 'https://a.example',
-      auto_approve: false,
       resolved_urls: null,
     });
   });

--- a/apps/desktop/src/shell/presentation.ts
+++ b/apps/desktop/src/shell/presentation.ts
@@ -281,7 +281,6 @@ export function communityNodesToDraftNodes(config: CommunityNodeConfig): Communi
   return config.nodes.map((node, index) => ({
     id: `community-node-${index}-${node.base_url}`,
     base_url: node.base_url,
-    auto_approve: node.auto_approve ?? false,
   }));
 }
 
@@ -291,7 +290,6 @@ export function communityNodeDraftNodesToConfigInput(
   return draftNodes
     .map((node) => ({
       base_url: node.base_url.trim(),
-      auto_approve: node.auto_approve,
     }))
     .filter((node) => node.base_url.length > 0);
 }
@@ -548,7 +546,6 @@ export function mergeCommunityNodeStatus(
 ): CommunityNodeNodeStatus {
   return {
     ...next,
-    auto_approve: next.auto_approve ?? previous?.auto_approve ?? false,
     consent_state: next.auth_state.authenticated
       ? next.consent_state ?? previous?.consent_state ?? null
       : next.consent_state ?? null,
@@ -592,7 +589,6 @@ export function syncCommunityNodeConfigWithStatus(
       node.base_url === status.base_url
         ? {
             ...node,
-            auto_approve: status.auto_approve ?? node.auto_approve ?? false,
             resolved_urls: status.resolved_urls ?? node.resolved_urls ?? null,
           }
         : node

--- a/apps/desktop/src/shell/slices/connectivity.ts
+++ b/apps/desktop/src/shell/slices/connectivity.ts
@@ -13,7 +13,6 @@ import type { CommunityIndexNodePreference } from '@/lib/api/communityIndex';
 export type CommunityNodeDraftNode = {
   id: string;
   base_url: string;
-  auto_approve: boolean;
 };
 
 // public manifest endpoint (#356) からの取得状態。base_url ごとに保持する。

--- a/apps/desktop/src/shell/useDesktopShellData.test.tsx
+++ b/apps/desktop/src/shell/useDesktopShellData.test.tsx
@@ -330,7 +330,6 @@ describe('useDesktopShellData characterization', () => {
     const baseApi = createDesktopMockApi();
     const nodeStatus = (baseUrl: string, lastError: string | null) => ({
       base_url: baseUrl,
-      auto_approve: true,
       auth_state: { authenticated: true, expires_at: null },
       consent_state: { all_required_accepted: true, items: [] },
       resolved_urls: null,
@@ -346,8 +345,8 @@ describe('useDesktopShellData characterization', () => {
       ...baseApi,
       getCommunityNodeConfig: async () => ({
         nodes: [
-          { base_url: NODE_A, auto_approve: true, resolved_urls: null },
-          { base_url: NODE_B, auto_approve: true, resolved_urls: null },
+          { base_url: NODE_A, resolved_urls: null },
+          { base_url: NODE_B, resolved_urls: null },
         ],
       }),
       getCommunityNodeStatuses: async () => statuses,

--- a/apps/desktop/src/shell/viewModels/useSettingsViewModels.ts
+++ b/apps/desktop/src/shell/viewModels/useSettingsViewModels.ts
@@ -356,22 +356,15 @@ export function useSettingsViewModels({
         );
         const saved =
           communityNodeConfig.nodes.find(
-            (candidate) =>
-              candidate.base_url === node.base_url &&
-              (candidate.auto_approve ?? false) === node.auto_approve
+            (candidate) => candidate.base_url === node.base_url
           ) != null;
         const status = communityNodeStatusByBaseUrl[node.base_url];
         return {
           id: node.id,
           baseUrl: node.base_url,
-          autoApprove: node.auto_approve,
           saved,
           distanceOptoutEligible: distanceOptoutEligibleBaseUrls.includes(node.base_url),
           diagnostics: [
-            {
-              label: t('settings:communityNode.diagnostics.autoApprove'),
-              value: node.auto_approve ? t('common:states.yes') : t('common:states.no'),
-            },
             {
               label: t('settings:communityNode.diagnostics.auth'),
               value: communityNodeAuthLabel(status),

--- a/apps/desktop/tests/playwright/shell.smoke.spec.ts
+++ b/apps/desktop/tests/playwright/shell.smoke.spec.ts
@@ -361,7 +361,7 @@ test('browser mock shell can switch topics, publish, open thread, open author, a
   await settingsDialog.getByTestId('settings-section-community-node').click();
   await expect(
     settingsDialog.getByRole('checkbox', { name: 'Auto-approve consent for this node' })
-  ).toBeChecked();
+  ).toHaveCount(0);
   await expect(settingsDialog.getByText('active on current session', { exact: true })).toBeVisible();
   await expect(settingsDialog.getByText('connectivity urls active on current session')).toBeVisible();
 

--- a/crates/desktop-runtime/src/community_node/config_support.rs
+++ b/crates/desktop-runtime/src/community_node/config_support.rs
@@ -36,7 +36,6 @@ pub(crate) fn normalize_community_node_config(
     let mut deduped = std::collections::BTreeMap::<String, CommunityNodeNodeConfig>::new();
     for node in config.nodes {
         let base_url = normalize_http_url(node.base_url.as_str())?;
-        let incoming_auto_approve = node.auto_approve;
         let incoming_resolved_urls = match node.resolved_urls {
             Some(resolved) => Some(CommunityNodeResolvedUrls::new(
                 resolved.public_base_url,
@@ -53,15 +52,10 @@ pub(crate) fn normalize_community_node_config(
         } else {
             incoming_resolved_urls
         };
-        let auto_approve = deduped
-            .get(&base_url)
-            .map(|existing| existing.auto_approve || incoming_auto_approve)
-            .unwrap_or(incoming_auto_approve);
         deduped.insert(
             base_url.clone(),
             CommunityNodeNodeConfig {
                 base_url,
-                auto_approve,
                 resolved_urls,
             },
         );
@@ -198,7 +192,6 @@ mod tests {
         let config = CommunityNodeConfig {
             nodes: vec![CommunityNodeNodeConfig {
                 base_url: "https://community.example.com".to_string(),
-                auto_approve: false,
                 resolved_urls: Some(
                     CommunityNodeResolvedUrls::new(
                         "https://community.example.com",
@@ -232,7 +225,6 @@ mod tests {
         let config = CommunityNodeConfig {
             nodes: vec![CommunityNodeNodeConfig {
                 base_url: "https://community.example.com".to_string(),
-                auto_approve: false,
                 resolved_urls: Some(
                     CommunityNodeResolvedUrls::new(
                         "https://community.example.com",

--- a/crates/desktop-runtime/src/community_node/mod.rs
+++ b/crates/desktop-runtime/src/community_node/mod.rs
@@ -110,9 +110,6 @@ pub(crate) const COMMUNITY_NODE_TOPIC_RENDEZVOUS_REFRESH_MARGIN_SECONDS: i64 = 2
 pub struct CommunityNodeNodeConfig {
     pub base_url: String,
     #[serde(default)]
-    #[cfg_attr(feature = "ts", ts(as = "Option<bool>"))]
-    pub auto_approve: bool,
-    #[serde(default)]
     pub resolved_urls: Option<CommunityNodeResolvedUrls>,
 }
 
@@ -134,8 +131,6 @@ pub(crate) use kukuri_cn_protocol::{BootstrapNodesResponse, TopicRendezvousHeart
 #[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct SetCommunityNodeConfigNode {
     pub base_url: String,
-    #[serde(default)]
-    pub auto_approve: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -293,10 +288,6 @@ pub(crate) struct CommunityNodeSessionState {
 #[cfg_attr(feature = "ts", ts(optional_fields = nullable))]
 pub struct CommunityNodeNodeStatus {
     pub base_url: String,
-    // 現行 types.ts と同じく任意(#[serde(default)])。
-    #[serde(default)]
-    #[cfg_attr(feature = "ts", ts(as = "Option<bool>"))]
-    pub auto_approve: bool,
     pub auth_state: CommunityNodeAuthState,
     pub consent_state: Option<CommunityNodeConsentStatus>,
     /// #857: Node 別ローカル同意記録。空 = 未同意(この node へは通信しない)。

--- a/crates/desktop-runtime/src/community_node/session_runtime_support.rs
+++ b/crates/desktop-runtime/src/community_node/session_runtime_support.rs
@@ -264,7 +264,6 @@ impl DesktopRuntime {
         .iroh_relay_urls;
         Ok(CommunityNodeNodeStatus {
             base_url: node.base_url,
-            auto_approve: node.auto_approve,
             auth_state,
             consent_state,
             local_consent,

--- a/crates/desktop-runtime/src/runtime/community_node_api.rs
+++ b/crates/desktop-runtime/src/runtime/community_node_api.rs
@@ -126,7 +126,6 @@ impl DesktopRuntime {
                     .and_then(|node| node.resolved_urls.clone());
                 Ok(CommunityNodeNodeConfig {
                     base_url: normalized_base_url,
-                    auto_approve: base_url.auto_approve,
                     resolved_urls,
                 })
             })
@@ -151,7 +150,7 @@ impl DesktopRuntime {
         self.apply_runtime_connectivity_assist().await?;
         self.apply_effective_seed_peers().await?;
         // getter を読取専用化した(WP-Q2)ため、config 変更直後の登録はここで 1 tick 即時実行する。
-        // これが無いと新規 auto_approve ノードの bootstrap がスケジューラ次 tick(最大 15 秒)まで
+        // これが無いと新規 Node の bootstrap がスケジューラ次 tick(最大 15 秒)まで
         // 遅延する。tick は deadline ゲート済みの冪等設計で、直後の scheduler tick と二重でも安全。
         self.run_community_node_session_maintenance_once().await;
         Ok(next_config)

--- a/crates/desktop-runtime/src/tests/community_node/admission.rs
+++ b/crates/desktop-runtime/src/tests/community_node/admission.rs
@@ -144,7 +144,7 @@ async fn spawn_admission_mock(
     (base_url, state, server)
 }
 
-async fn admission_runtime(db_path: &Path, nodes: Vec<(String, bool)>) -> DesktopRuntime {
+async fn admission_runtime(db_path: &Path, nodes: Vec<String>) -> DesktopRuntime {
     let runtime = DesktopRuntime::new_with_config_and_identity(
         db_path,
         TransportNetworkConfig::loopback(),
@@ -152,15 +152,14 @@ async fn admission_runtime(db_path: &Path, nodes: Vec<(String, bool)>) -> Deskto
     )
     .await
     .expect("runtime");
-    for (base_url, _) in &nodes {
+    for base_url in &nodes {
         seed_local_community_node_consents(&runtime, base_url.as_str(), 1);
     }
     *runtime.community_node_config.lock().await = CommunityNodeConfig {
         nodes: nodes
             .into_iter()
-            .map(|(base_url, auto_approve)| CommunityNodeNodeConfig {
+            .map(|base_url| CommunityNodeNodeConfig {
                 base_url,
-                auto_approve,
                 resolved_urls: None,
             })
             .collect(),
@@ -207,7 +206,7 @@ async fn removing_or_clearing_node_config_deletes_its_invite_code() {
     let dir = tempdir().expect("tempdir");
     let db_path = dir.path().join("invite-config-cleanup.db");
     let base_url = "https://invite.example".to_string();
-    let runtime = admission_runtime(&db_path, vec![(base_url.clone(), false)]).await;
+    let runtime = admission_runtime(&db_path, vec![base_url.clone()]).await;
     persist_community_node_invite_code(
         &db_path,
         IdentityStorageMode::FileOnly,
@@ -229,7 +228,6 @@ async fn removing_or_clearing_node_config_deletes_its_invite_code() {
     *runtime.community_node_config.lock().await = CommunityNodeConfig {
         nodes: vec![CommunityNodeNodeConfig {
             base_url: base_url.clone(),
-            auto_approve: false,
             resolved_urls: None,
         }],
     };
@@ -261,11 +259,7 @@ async fn authentication_sends_invite_only_to_its_node() {
     let db_path = dir.path().join("invite-node-scope.db");
     let (base_url_a, state_a, server_a) = spawn_admission_mock(None).await;
     let (base_url_b, state_b, server_b) = spawn_admission_mock(None).await;
-    let runtime = admission_runtime(
-        &db_path,
-        vec![(base_url_a.clone(), false), (base_url_b.clone(), false)],
-    )
-    .await;
+    let runtime = admission_runtime(&db_path, vec![base_url_a.clone(), base_url_b.clone()]).await;
     persist_community_node_invite_code(
         &db_path,
         IdentityStorageMode::FileOnly,
@@ -300,7 +294,7 @@ async fn auth_verify_preserves_all_stable_admission_rejection_codes() {
     let dir = tempdir().expect("tempdir");
     let db_path = dir.path().join("admission-codes.db");
     let (base_url, state, server) = spawn_admission_mock(None).await;
-    let runtime = admission_runtime(&db_path, vec![(base_url.clone(), false)]).await;
+    let runtime = admission_runtime(&db_path, vec![base_url.clone()]).await;
     let cases = [
         (
             "INVITE_REQUIRED",
@@ -355,7 +349,7 @@ async fn admission_rejection_waits_for_user_and_saved_invite_recovers_session() 
     let dir = tempdir().expect("tempdir");
     let db_path = dir.path().join("admission-session.db");
     let (base_url, state, server) = spawn_admission_mock(Some("join-code")).await;
-    let runtime = admission_runtime(&db_path, vec![(base_url.clone(), true)]).await;
+    let runtime = admission_runtime(&db_path, vec![base_url.clone()]).await;
 
     runtime.run_community_node_session_maintenance_once().await;
     runtime.run_community_node_session_maintenance_once().await;
@@ -415,7 +409,7 @@ async fn admission_rejection_waits_for_user_and_saved_invite_recovers_session() 
 }
 
 #[tokio::test]
-async fn banned_auto_approve_node_does_not_schedule_retries() {
+async fn banned_node_does_not_schedule_retries() {
     let _resource = lock_test_resource(TestResource::CommunityNodeServer).await;
     let dir = tempdir().expect("tempdir");
     let db_path = dir.path().join("admission-banned.db");
@@ -424,7 +418,7 @@ async fn banned_auto_approve_node_does_not_schedule_retries() {
         code: "BANNED".into(),
         message: "node-local support denied".into(),
     });
-    let runtime = admission_runtime(&db_path, vec![(base_url.clone(), true)]).await;
+    let runtime = admission_runtime(&db_path, vec![base_url.clone()]).await;
 
     runtime.run_community_node_session_maintenance_once().await;
     runtime.run_community_node_session_maintenance_once().await;
@@ -461,7 +455,7 @@ async fn banned_member_with_stored_token_stops_self_heal_reauthentication() {
     let dir = tempdir().expect("tempdir");
     let db_path = dir.path().join("admission-banned-member.db");
     let (base_url, state, server) = spawn_admission_mock(None).await;
-    let runtime = admission_runtime(&db_path, vec![(base_url.clone(), true)]).await;
+    let runtime = admission_runtime(&db_path, vec![base_url.clone()]).await;
 
     // まず正常に認証・接続する。
     let ready = runtime

--- a/crates/desktop-runtime/src/tests/community_node/config.rs
+++ b/crates/desktop-runtime/src/tests/community_node/config.rs
@@ -6,7 +6,6 @@ fn community_node_config_normalizes_base_urls_and_connectivity_urls() {
         nodes: vec![
             CommunityNodeNodeConfig {
                 base_url: "https://community.example.com/".into(),
-                auto_approve: false,
                 resolved_urls: Some(
                     CommunityNodeResolvedUrls::new(
                         "https://public.example.com/",
@@ -22,7 +21,6 @@ fn community_node_config_normalizes_base_urls_and_connectivity_urls() {
             },
             CommunityNodeNodeConfig {
                 base_url: "https://community.example.com".into(),
-                auto_approve: true,
                 resolved_urls: None,
             },
         ],
@@ -31,7 +29,6 @@ fn community_node_config_normalizes_base_urls_and_connectivity_urls() {
 
     assert_eq!(config.nodes.len(), 1);
     assert_eq!(config.nodes[0].base_url, "https://community.example.com");
-    assert!(config.nodes[0].auto_approve);
     assert_eq!(
         config.nodes[0]
             .resolved_urls
@@ -58,7 +55,6 @@ fn community_node_config_preserves_public_kukuri_urls() {
     let config = normalize_community_node_config(CommunityNodeConfig {
         nodes: vec![CommunityNodeNodeConfig {
             base_url: "https://api.kukuri.app/".into(),
-            auto_approve: true,
             resolved_urls: Some(
                 CommunityNodeResolvedUrls::new(
                     "https://api.kukuri.app/",
@@ -128,7 +124,6 @@ async fn local_community_node_seed_peer_keeps_addr_hint_when_relay_urls_exist() 
     *runtime.community_node_config.lock().await = CommunityNodeConfig {
         nodes: vec![CommunityNodeNodeConfig {
             base_url: "https://api.example.com".to_string(),
-            auto_approve: false,
             resolved_urls: Some(
                 CommunityNodeResolvedUrls::new(
                     "https://api.example.com",
@@ -159,7 +154,6 @@ fn stored_community_node_config_restores_cached_connectivity_union() {
         &CommunityNodeConfig {
             nodes: vec![CommunityNodeNodeConfig {
                 base_url: "https://community.example.com".into(),
-                auto_approve: false,
                 resolved_urls: Some(
                     CommunityNodeResolvedUrls::new(
                         "https://public.example.com",
@@ -192,6 +186,36 @@ fn stored_community_node_config_restores_cached_connectivity_union() {
     );
 }
 
+#[test]
+fn legacy_auto_approve_field_is_ignored_and_removed_on_save() {
+    let dir = tempdir().expect("tempdir");
+    let db_path = dir.path().join("community-legacy-auto-approve.db");
+    let config_path = community_node_config_path(&db_path);
+    std::fs::write(
+        &config_path,
+        r#"{
+  "nodes": [
+    {
+      "base_url": "https://community.example.com/",
+      "auto_approve": true,
+      "resolved_urls": null
+    }
+  ]
+}"#,
+    )
+    .expect("write legacy config");
+
+    let config = load_community_node_config_from_file(&db_path)
+        .expect("load legacy config")
+        .expect("stored config");
+    assert_eq!(config.nodes.len(), 1);
+    assert_eq!(config.nodes[0].base_url, "https://community.example.com");
+
+    save_community_node_config(&db_path, &config).expect("save normalized config");
+    let saved = std::fs::read_to_string(config_path).expect("read normalized config");
+    assert!(!saved.contains("auto_approve"));
+}
+
 #[tokio::test]
 async fn runtime_preloads_distribution_community_node_only_when_config_file_is_missing() {
     let _resource = lock_test_resource(TestResource::ProcessEnvironment).await;
@@ -207,7 +231,6 @@ async fn runtime_preloads_distribution_community_node_only_when_config_file_is_m
         Some(CommunityNodeConfig {
             nodes: vec![CommunityNodeNodeConfig {
                 base_url: "https://distribution.example.com".to_string(),
-                auto_approve: true,
                 resolved_urls: None,
             }],
         }),
@@ -221,7 +244,6 @@ async fn runtime_preloads_distribution_community_node_only_when_config_file_is_m
         .expect("community node config");
     assert_eq!(config.nodes.len(), 1);
     assert_eq!(config.nodes[0].base_url, "https://distribution.example.com");
-    assert!(config.nodes[0].auto_approve);
     assert!(
         community_node_config_path(&db_path).exists(),
         "preloaded preview config should be persisted"
@@ -247,7 +269,6 @@ async fn runtime_does_not_restore_distribution_node_after_user_clears_config() {
         Some(CommunityNodeConfig {
             nodes: vec![CommunityNodeNodeConfig {
                 base_url: "https://distribution.example.com".to_string(),
-                auto_approve: true,
                 resolved_urls: None,
             }],
         }),
@@ -276,7 +297,6 @@ async fn runtime_does_not_restore_distribution_node_after_user_replaces_config()
         &CommunityNodeConfig {
             nodes: vec![CommunityNodeNodeConfig {
                 base_url: "https://user-selected.example.com".to_string(),
-                auto_approve: false,
                 resolved_urls: None,
             }],
         },
@@ -292,7 +312,6 @@ async fn runtime_does_not_restore_distribution_node_after_user_replaces_config()
         Some(CommunityNodeConfig {
             nodes: vec![CommunityNodeNodeConfig {
                 base_url: "https://distribution.example.com".to_string(),
-                auto_approve: true,
                 resolved_urls: None,
             }],
         }),

--- a/crates/desktop-runtime/src/tests/community_node/connectivity.rs
+++ b/crates/desktop-runtime/src/tests/community_node/connectivity.rs
@@ -181,7 +181,6 @@ async fn community_node_connectivity_assist_backfills_public_timeline_with_relay
     *runtime_a.community_node_config.lock().await = CommunityNodeConfig {
         nodes: vec![CommunityNodeNodeConfig {
             base_url: base_url.to_string(),
-            auto_approve: false,
             resolved_urls: Some(
                 CommunityNodeResolvedUrls::new(
                     base_url,
@@ -198,7 +197,6 @@ async fn community_node_connectivity_assist_backfills_public_timeline_with_relay
     *runtime_b.community_node_config.lock().await = CommunityNodeConfig {
         nodes: vec![CommunityNodeNodeConfig {
             base_url: base_url.to_string(),
-            auto_approve: false,
             resolved_urls: Some(
                 CommunityNodeResolvedUrls::new(
                     base_url,
@@ -343,7 +341,6 @@ async fn external_relay_endpoint_only_seed_peers_backfill_desktop_public_timelin
     *runtime_a.community_node_config.lock().await = CommunityNodeConfig {
         nodes: vec![CommunityNodeNodeConfig {
             base_url: base_url.to_string(),
-            auto_approve: false,
             resolved_urls: Some(
                 CommunityNodeResolvedUrls::new(
                     base_url,
@@ -360,7 +357,6 @@ async fn external_relay_endpoint_only_seed_peers_backfill_desktop_public_timelin
     *runtime_b.community_node_config.lock().await = CommunityNodeConfig {
         nodes: vec![CommunityNodeNodeConfig {
             base_url: base_url.to_string(),
-            auto_approve: false,
             resolved_urls: Some(
                 CommunityNodeResolvedUrls::new(
                     base_url,
@@ -691,7 +687,6 @@ async fn runtime_starts_with_unreachable_community_node_and_recovers_via_manual_
         &CommunityNodeConfig {
             nodes: vec![CommunityNodeNodeConfig {
                 base_url: community_base_url.to_string(),
-                auto_approve: true,
                 resolved_urls: Some(
                     CommunityNodeResolvedUrls::new(
                         community_base_url,

--- a/crates/desktop-runtime/src/tests/community_node/index_query.rs
+++ b/crates/desktop-runtime/src/tests/community_node/index_query.rs
@@ -216,7 +216,6 @@ async fn index_runtime(
     *runtime.community_node_config.lock().await = CommunityNodeConfig {
         nodes: vec![CommunityNodeNodeConfig {
             base_url: base_url.clone(),
-            auto_approve: false,
             resolved_urls: Some(
                 CommunityNodeResolvedUrls::new(base_url.clone(), Vec::new(), Vec::new())
                     .expect("resolved urls"),

--- a/crates/desktop-runtime/src/tests/community_node/metadata.rs
+++ b/crates/desktop-runtime/src/tests/community_node/metadata.rs
@@ -52,7 +52,6 @@ async fn community_node_status_refresh_updates_bootstrap_seed_peers() {
     *runtime.community_node_config.lock().await = CommunityNodeConfig {
         nodes: vec![CommunityNodeNodeConfig {
             base_url: base_url.clone(),
-            auto_approve: false,
             resolved_urls: Some(
                 CommunityNodeResolvedUrls::new(base_url.clone(), Vec::new(), Vec::new())
                     .expect("resolved urls"),
@@ -143,7 +142,6 @@ async fn community_node_session_maintenance_updates_bootstrap_seed_peers() {
     *runtime.community_node_config.lock().await = CommunityNodeConfig {
         nodes: vec![CommunityNodeNodeConfig {
             base_url: base_url.clone(),
-            auto_approve: false,
             resolved_urls: Some(
                 CommunityNodeResolvedUrls::new(base_url.clone(), Vec::new(), Vec::new())
                     .expect("resolved urls"),
@@ -229,7 +227,6 @@ async fn community_node_metadata_refresh_heartbeats_before_bootstrap_sync_even_w
     *runtime.community_node_config.lock().await = CommunityNodeConfig {
         nodes: vec![CommunityNodeNodeConfig {
             base_url: base_url.clone(),
-            auto_approve: false,
             resolved_urls: Some(
                 CommunityNodeResolvedUrls::new(base_url.clone(), Vec::new(), Vec::new())
                     .expect("resolved urls"),
@@ -361,7 +358,6 @@ async fn community_node_ready_transition_refreshes_bootstrap_metadata_before_nex
     *runtime.community_node_config.lock().await = CommunityNodeConfig {
         nodes: vec![CommunityNodeNodeConfig {
             base_url: base_url.clone(),
-            auto_approve: false,
             resolved_urls: Some(
                 CommunityNodeResolvedUrls::new(base_url.clone(), Vec::new(), Vec::new())
                     .expect("resolved urls"),
@@ -470,7 +466,6 @@ async fn community_node_ready_transition_refreshes_bootstrap_metadata_only_once_
     *runtime.community_node_config.lock().await = CommunityNodeConfig {
         nodes: vec![CommunityNodeNodeConfig {
             base_url: base_url.clone(),
-            auto_approve: false,
             resolved_urls: Some(
                 CommunityNodeResolvedUrls::new(base_url.clone(), Vec::new(), Vec::new())
                     .expect("resolved urls"),
@@ -546,7 +541,6 @@ async fn community_node_status_retries_bootstrap_metadata_when_seed_peers_are_em
     *runtime.community_node_config.lock().await = CommunityNodeConfig {
         nodes: vec![CommunityNodeNodeConfig {
             base_url: base_url.clone(),
-            auto_approve: false,
             resolved_urls: Some(
                 CommunityNodeResolvedUrls::new(base_url.clone(), Vec::new(), Vec::new())
                     .expect("resolved urls"),
@@ -663,7 +657,6 @@ async fn refresh_community_node_metadata_refreshes_registration_before_bootstrap
     *runtime.community_node_config.lock().await = CommunityNodeConfig {
         nodes: vec![CommunityNodeNodeConfig {
             base_url: base_url.clone(),
-            auto_approve: false,
             resolved_urls: Some(
                 CommunityNodeResolvedUrls::new(base_url.clone(), Vec::new(), Vec::new())
                     .expect("resolved urls"),
@@ -761,7 +754,6 @@ async fn refresh_community_node_metadata_requeues_heartbeat_when_runtime_connect
     *runtime.community_node_config.lock().await = CommunityNodeConfig {
         nodes: vec![CommunityNodeNodeConfig {
             base_url: base_url.clone(),
-            auto_approve: false,
             resolved_urls: Some(
                 CommunityNodeResolvedUrls::new(base_url.clone(), Vec::new(), Vec::new())
                     .expect("resolved urls"),

--- a/crates/desktop-runtime/src/tests/community_node/report_submission.rs
+++ b/crates/desktop-runtime/src/tests/community_node/report_submission.rs
@@ -62,7 +62,6 @@ async fn report_runtime(
     *runtime.community_node_config.lock().await = CommunityNodeConfig {
         nodes: vec![CommunityNodeNodeConfig {
             base_url: base_url.clone(),
-            auto_approve: false,
             resolved_urls: None,
         }],
     };

--- a/crates/desktop-runtime/src/tests/community_node/scheduler.rs
+++ b/crates/desktop-runtime/src/tests/community_node/scheduler.rs
@@ -76,7 +76,6 @@ async fn session_scheduler_keeps_bootstrap_registration_alive_without_getter_pol
     *runtime.community_node_config.lock().await = CommunityNodeConfig {
         nodes: vec![CommunityNodeNodeConfig {
             base_url: base_url.clone(),
-            auto_approve: false,
             resolved_urls: Some(
                 CommunityNodeResolvedUrls::new(base_url.clone(), Vec::new(), Vec::new())
                     .expect("resolved urls"),
@@ -198,7 +197,6 @@ async fn get_sync_status_is_read_only_for_community_node_session() {
     *runtime.community_node_config.lock().await = CommunityNodeConfig {
         nodes: vec![CommunityNodeNodeConfig {
             base_url: base_url.clone(),
-            auto_approve: false,
             resolved_urls: Some(
                 CommunityNodeResolvedUrls::new(base_url.clone(), Vec::new(), Vec::new())
                     .expect("resolved urls"),
@@ -279,7 +277,6 @@ async fn session_scheduler_reauthenticates_near_expiry_token_without_getter_poll
     *runtime.community_node_config.lock().await = CommunityNodeConfig {
         nodes: vec![CommunityNodeNodeConfig {
             base_url: base_url.clone(),
-            auto_approve: false,
             resolved_urls: Some(
                 CommunityNodeResolvedUrls::new(base_url.clone(), Vec::new(), Vec::new())
                     .expect("resolved urls"),
@@ -387,7 +384,6 @@ async fn topic_rendezvous_refresh_fires_between_bootstrap_heartbeats() {
     *runtime.community_node_config.lock().await = CommunityNodeConfig {
         nodes: vec![CommunityNodeNodeConfig {
             base_url: base_url.clone(),
-            auto_approve: false,
             resolved_urls: Some(
                 CommunityNodeResolvedUrls::new(base_url.clone(), Vec::new(), Vec::new())
                     .expect("resolved urls"),
@@ -532,7 +528,6 @@ async fn private_channel_rendezvous_refresh_uses_only_the_current_epoch_secret()
     *runtime.community_node_config.lock().await = CommunityNodeConfig {
         nodes: vec![CommunityNodeNodeConfig {
             base_url: base_url.clone(),
-            auto_approve: false,
             resolved_urls: Some(
                 CommunityNodeResolvedUrls::new(base_url.clone(), Vec::new(), Vec::new())
                     .expect("接続先を解決できる"),

--- a/crates/desktop-runtime/src/tests/community_node/session.rs
+++ b/crates/desktop-runtime/src/tests/community_node/session.rs
@@ -1,10 +1,10 @@
 use super::super::*;
 
 #[tokio::test]
-async fn auto_approve_node_bootstraps_session_on_maintenance_tick() {
+async fn consented_node_bootstraps_session_on_maintenance_tick() {
     let _resource = lock_test_resource(TestResource::CommunityNodeServer).await;
     let dir = tempdir().expect("tempdir");
-    let db_path = dir.path().join("community-auto-approve-session.db");
+    let db_path = dir.path().join("community-consented-session.db");
     let runtime = DesktopRuntime::new_with_config_and_identity(
         &db_path,
         TransportNetworkConfig::loopback(),
@@ -47,7 +47,6 @@ async fn auto_approve_node_bootstraps_session_on_maintenance_tick() {
     *runtime.community_node_config.lock().await = CommunityNodeConfig {
         nodes: vec![CommunityNodeNodeConfig {
             base_url: base_url.clone(),
-            auto_approve: true,
             resolved_urls: Some(
                 CommunityNodeResolvedUrls::new(base_url.clone(), Vec::new(), Vec::new())
                     .expect("resolved urls"),
@@ -73,7 +72,6 @@ async fn auto_approve_node_bootstraps_session_on_maintenance_tick() {
     assert_eq!(state.heartbeat_hits.load(Ordering::SeqCst), 1);
     assert_eq!(state.bootstrap_hits.load(Ordering::SeqCst), 1);
     assert_eq!(statuses.len(), 1);
-    assert!(statuses[0].auto_approve);
     assert!(statuses[0].auth_state.authenticated);
     assert_eq!(
         statuses[0].session_phase,
@@ -145,7 +143,6 @@ async fn status_getter_is_read_only_and_does_not_bootstrap_session() {
     *runtime.community_node_config.lock().await = CommunityNodeConfig {
         nodes: vec![CommunityNodeNodeConfig {
             base_url: base_url.clone(),
-            auto_approve: true,
             resolved_urls: Some(
                 CommunityNodeResolvedUrls::new(base_url.clone(), Vec::new(), Vec::new())
                     .expect("resolved urls"),
@@ -246,7 +243,6 @@ async fn near_expiry_token_triggers_proactive_community_node_reauthentication() 
     *runtime.community_node_config.lock().await = CommunityNodeConfig {
         nodes: vec![CommunityNodeNodeConfig {
             base_url: base_url.clone(),
-            auto_approve: false,
             resolved_urls: Some(
                 CommunityNodeResolvedUrls::new(base_url.clone(), Vec::new(), Vec::new())
                     .expect("resolved urls"),
@@ -344,8 +340,6 @@ async fn node_without_local_consent_is_never_contacted() {
     *runtime.community_node_config.lock().await = CommunityNodeConfig {
         nodes: vec![CommunityNodeNodeConfig {
             base_url: base_url.clone(),
-            // auto_approve でもローカル同意が無ければ通信しない。
-            auto_approve: true,
             resolved_urls: Some(
                 CommunityNodeResolvedUrls::new(base_url.clone(), Vec::new(), Vec::new())
                     .expect("resolved urls"),
@@ -468,7 +462,6 @@ async fn community_node_status_does_not_require_restart_when_connectivity_is_act
     .expect("resolved urls");
     let node = CommunityNodeNodeConfig {
         base_url: base_url.clone(),
-        auto_approve: false,
         resolved_urls: Some(resolved_urls.clone()),
     };
     persist_community_node_token(
@@ -537,7 +530,7 @@ async fn policy_update_is_not_silently_reaccepted() {
     // 黙って再受諾せず Idle に留め、ユーザーの再同意後にのみセッションを進める。
     let _resource = lock_test_resource(TestResource::CommunityNodeServer).await;
     let dir = tempdir().expect("tempdir");
-    let db_path = dir.path().join("community-auto-approve-update.db");
+    let db_path = dir.path().join("community-consent-update.db");
     let runtime = DesktopRuntime::new_with_config_and_identity(
         &db_path,
         TransportNetworkConfig::loopback(),
@@ -586,7 +579,6 @@ async fn policy_update_is_not_silently_reaccepted() {
     *runtime.community_node_config.lock().await = CommunityNodeConfig {
         nodes: vec![CommunityNodeNodeConfig {
             base_url: base_url.clone(),
-            auto_approve: true,
             resolved_urls: Some(
                 CommunityNodeResolvedUrls::new(base_url.clone(), Vec::new(), Vec::new())
                     .expect("resolved urls"),

--- a/crates/desktop-runtime/src/tests/community_node/tester_feedback_submission.rs
+++ b/crates/desktop-runtime/src/tests/community_node/tester_feedback_submission.rs
@@ -120,7 +120,6 @@ async fn tester_feedback_runtime(
     *runtime.community_node_config.lock().await = CommunityNodeConfig {
         nodes: vec![CommunityNodeNodeConfig {
             base_url: base_url.clone(),
-            auto_approve: false,
             resolved_urls: Some(
                 CommunityNodeResolvedUrls::new(base_url.clone(), Vec::new(), Vec::new())
                     .expect("resolved urls"),

--- a/crates/desktop-runtime/src/tests/community_node/trust_relation.rs
+++ b/crates/desktop-runtime/src/tests/community_node/trust_relation.rs
@@ -237,7 +237,6 @@ async fn trust_relation_runtime(
     *runtime.community_node_config.lock().await = CommunityNodeConfig {
         nodes: vec![CommunityNodeNodeConfig {
             base_url: base_url.clone(),
-            auto_approve: false,
             resolved_urls: Some(
                 CommunityNodeResolvedUrls::new(base_url.clone(), Vec::new(), Vec::new())
                     .expect("resolved urls"),

--- a/crates/desktop-runtime/src/tests/runtime_events.rs
+++ b/crates/desktop-runtime/src/tests/runtime_events.rs
@@ -92,7 +92,6 @@ async fn sync_status_observer_emits_only_changed_snapshot_parts_and_stops_on_shu
     *runtime.community_node_config.lock().await = CommunityNodeConfig {
         nodes: vec![CommunityNodeNodeConfig {
             base_url: "http://127.0.0.1:9".to_string(),
-            auto_approve: false,
             resolved_urls: None,
         }],
     };

--- a/crates/desktop-runtime/src/tests/support/mock_cn.rs
+++ b/crates/desktop-runtime/src/tests/support/mock_cn.rs
@@ -9,7 +9,6 @@ pub(crate) async fn apply_relay_backed_community_node_seed_peers(
     *runtime.community_node_config.lock().await = CommunityNodeConfig {
         nodes: vec![CommunityNodeNodeConfig {
             base_url: base_url.to_string(),
-            auto_approve: false,
             resolved_urls: Some(
                 CommunityNodeResolvedUrls::new(base_url, vec![relay_url.to_string()], seed_peers)
                     .expect("resolved urls"),

--- a/crates/harness/src/scenarios/community_node.rs
+++ b/crates/harness/src/scenarios/community_node.rs
@@ -162,7 +162,6 @@ pub(crate) async fn run_community_node_connectivity(
             .set_community_node_config(SetCommunityNodeConfigRequest {
                 nodes: vec![kukuri_desktop_runtime::SetCommunityNodeConfigNode {
                     base_url: stack.base_url.clone(),
-                    auto_approve: false,
                 }],
             })
             .await
@@ -171,7 +170,6 @@ pub(crate) async fn run_community_node_connectivity(
             .set_community_node_config(SetCommunityNodeConfigRequest {
                 nodes: vec![kukuri_desktop_runtime::SetCommunityNodeConfigNode {
                     base_url: stack.base_url.clone(),
-                    auto_approve: false,
                 }],
             })
             .await

--- a/crates/harness/src/scenarios/community_node_index.rs
+++ b/crates/harness/src/scenarios/community_node_index.rs
@@ -221,7 +221,6 @@ pub(crate) async fn run_community_node_index_query_client(
         .set_community_node_config(SetCommunityNodeConfigRequest {
             nodes: vec![SetCommunityNodeConfigNode {
                 base_url: base_url.clone(),
-                auto_approve: false,
             }],
         })
         .await?;

--- a/crates/harness/src/scenarios/community_node_trust_relation.rs
+++ b/crates/harness/src/scenarios/community_node_trust_relation.rs
@@ -346,7 +346,6 @@ pub(crate) async fn run_community_node_trust_relation_client(
         .set_community_node_config(SetCommunityNodeConfigRequest {
             nodes: vec![SetCommunityNodeConfigNode {
                 base_url: base_url.clone(),
-                auto_approve: false,
             }],
         })
         .await?;

--- a/docs/adr/0024-community-node-admission-data-classification.md
+++ b/docs/adr/0024-community-node-admission-data-classification.md
@@ -42,7 +42,7 @@ Accepted
   3. それ以外（未登録 pubkey）のみ mode を適用する（`open`=admit / `whitelist`=allowlist 登録のみ / `invite`=有効コード必須、ただし allowlist 該当はコード不要 bypass）。
 - 拒否は `POST /v1/auth/verify` で HTTP 403 + 専用コード（`INVITE_REQUIRED` / `INVITE_INVALID` / `INVITE_EXPIRED` / `INVITE_EXHAUSTED` / `INVITE_REVOKED` / `NOT_ALLOWLISTED` / `BANNED`）として返す。
 - client は HTTP 403 の応答本文を破棄せず、上記の安定コードと message を保持する。招待コードは入力対象の node にだけ送信し、別 node へ転用しない。
-- client は admission 拒否を一時的な通信失敗と区別し、自動再試行を止めて利用者対応待ちにする。招待関連の拒否はコードの入力または再取得を案内し、`NOT_ALLOWLISTED` と `BANNED` は node 運営者への連絡を案内する。この扱いは `auto_approve` の有無で変えない。
+- client は admission 拒否を一時的な通信失敗と区別し、自動再試行を止めて利用者対応待ちにする。招待関連の拒否はコードの入力または再取得を案内し、`NOT_ALLOWLISTED` と `BANNED` は node 運営者への連絡を案内する。この扱いは配布候補か利用者追加 Node かで変えない。
 
 ## Consequences
 - admission は node-local な「補助機能提供の可否」判断である。`docs/architecture/p2p-first-community-node-responsibility-boundary.md` の責任境界に従い、ban は kukuri network 全体からのアカウント凍結ではなく、この node が提供する接続補助・auth/consent をこの pubkey へ提供しないという node-local な制限として扱う。user identity / profile / social graph は node-independent であり admission の対象にしない。

--- a/docs/progress/2026-04-16-mvp-builder-preview-plan.md
+++ b/docs/progress/2026-04-16-mvp-builder-preview-plan.md
@@ -4,15 +4,15 @@
 
 - このマイルストーンは general launch ではなく `builder preview` の切り出しです。
 - capability baseline は [2026-03-10-foundation.md](./2026-03-10-foundation.md) を維持し、その上に `初回体験 / 配布 / 説明 / feedback loop` を載せます。
-- Community Node は最後まで単一の概念として扱います。preview 向けの自動導線は node ごとの `auto_approve` で制御します。
-- current preview surface は `launch -> default product Columns -> profile setup -> auto-approved community node ready -> starter topic -> post/reply -> private channel -> feedback` です。
+- Community Node は最後まで単一の概念として扱います。配布候補と利用者追加 Node はどちらも、Node 固有文書への明示同意後にセッションを自動確立・維持します。
+- current preview surface は `launch -> default product Columns -> profile setup -> community node consent -> node ready -> starter topic -> post/reply -> private channel -> feedback` です。
 
 ## Current Snapshot
 
-- runtime は `community-node.json` を後方互換で読みつつ、fresh install でだけ Tauri 配布設定の Community Node 一覧を preload します。preview 配布設定は `https://api.kukuri.app` を `auto_approve=true` で指定しますが、汎用 runtime はこの domain を知りません。保存済み一覧（空を含む）が常に優先されます。
-- `auto_approve=true` の node は起動時に `authenticate -> consent accept -> metadata refresh` を自動で進めます。
-- token は期限 5 分前から proactive refresh し、`401` は `re-authenticate -> retry`、`403 CONSENT_REQUIRED` は `auto_approve=true` node だけ `accept -> retry` します。
-- desktop settings は textarea editor をやめ、Community Node の単一 list 上で `base URL`, `auto_approve`, diagnostics, troubleshooting actions を扱います。
+- runtime は `community-node.json` を後方互換で読みつつ、fresh install でだけ Tauri 配布設定の Community Node 一覧を preload します。preview 配布設定は `https://api.kukuri.app` を候補として指定しますが、汎用 runtime はこの domain を知りません。保存済み一覧（空を含む）が常に優先されます。
+- Node 同意前は UI 操作起点の公開 manifest / 法務文書取得以外の通信を開始しません。利用者が提示された現行文書へ明示同意すると、`authenticate -> server consent sync -> metadata refresh` を自動で進めます。
+- token は期限 5 分前から proactive refresh し、`401` は `re-authenticate -> retry`、`403 CONSENT_REQUIRED` はローカル同意が server の現行 required 文書をカバーする場合だけ `server consent sync -> retry` します。版が上がった場合は自動受諾せず再同意を求めます。
+- desktop settings は textarea editor をやめ、Community Node の単一 list 上で `base URL`, diagnostics, consent / troubleshooting actions を扱います。
 - starter topic は `kukuri:topic:general`, `kukuri:topic:dev`, `kukuri:topic:test` を default とします（#805 で `demo / iroh / nostr / operators` から変更）。
 - 保存済みlayoutがないfresh installでは、`demo Timeline -> 自分のProfile -> Explore -> Notifications -> Messages`のpin済みColumnを表示し、Timelineをactiveにします。既存layoutは補完・移行しません。
 
@@ -27,9 +27,9 @@
 
 | Workstream | Status | Type | Notes |
 | --- | --- | --- | --- |
-| Community Node config `auto_approve` | landed | repo change | runtime persistence, Tauri payload, frontend type を更新 |
+| Community Node consent/session boundary | landed | repo change | Node 別明示同意を接続前提とし、同意後の session 維持を自動化 |
 | Distribution Community Node config | landed | repo change | preview 候補を Tauri 配布設定へ隔離し、削除・置換後に復活しない契約を追加 |
-| Startup auto onboarding | landed | repo change | auto-approved node の auth / consent / metadata refresh を自動化 |
+| Startup session maintenance | landed | repo change | 明示同意済み Node の auth / server consent sync / metadata refresh を自動化 |
 | Token expiry auto re-auth | landed | repo change | proactive refresh, `401` retry, `403` conditional accept を追加 |
 | Community Node unified settings surface | landed | repo change | official/custom split を作らず row editor に置換 |
 | Starter topics default | landed | repo change | desktop shell default tracked topics を 4 件に変更 |
@@ -62,6 +62,6 @@
 
 ## Assumptions
 
-- `auto_approve` は node ごとの UX policy であり、Community Node の新しい種別ではありません。
+- 配布候補と利用者追加 Node は同じ同意・セッション契約を使い、Node の種別差を作りません。
 - community-node server endpoint contract 自体は変更しません。
 - Linux binary packaging、hosted Storybook、general-public launch、moderation tooling はこの milestone の exit criteria に含めません。

--- a/docs/runbooks/mvp-troubleshooting.md
+++ b/docs/runbooks/mvp-troubleshooting.md
@@ -2,13 +2,10 @@
 
 ## Community Node の見方
 
-- `Auto-approve`
-  - `yes`: この node は preview happy path で consent を自動承認する
-  - `no`: token refresh は自動でも、consent は手動操作が必要
 - `Session Phase`
   - `connecting`: node 到達と session 準備を開始
   - `authenticating`: challenge / verify を実行中
-  - `accepting`: required consent を処理中
+  - `accepting`: ローカルで明示同意済みの required 文書を server の同意記録へ同期中
   - `refreshing`: bootstrap metadata, connectivity URL, seed peer を更新中
   - `ready`: current session で利用可能
   - `retrying`: backoff 中。`Retry After` 以降に再試行する
@@ -30,12 +27,12 @@
 ### `authenticating` と `retrying` を繰り返す
 
 - node の `base URL` が正しいか確認する
-- `auto_approve=no` の node や preview 既定外の node では、auth endpoint と consent endpoint が有効か確認する
+- Node の auth endpoint と consent endpoint が有効か確認する
 
 ### `accepting` で止まる
 
-- `auto_approve=yes` の node で起きる場合は `Last Error` を確認する
-- `auto_approve=no` の node は manual `Accept` を使う
+- `Last Error` を確認する
+- `Consents` を開き、表示された現行版の文書へ明示的に同意済みか確認する
 
 ### `restart required` が出る
 
@@ -44,13 +41,12 @@
 
 ## Manual Actions
 
-- `Authenticate`: token を明示的に取り直す
-- `Consents`: 現在の consent 状態を再取得する
-- `Accept`: required consent を明示的に受諾する
+- `Authenticate`: ローカル同意済み Node の token を明示的に取り直す
+- `Consents`: Node の公開文書を表示し、required 文書への同意・再同意・撤回を行う
 - `Refresh`: bootstrap metadata と connectivity assist を再取得する
 - `Clear Token`: 該当 node の token を破棄し、次回 auth をやり直す
 
-preview の primary UX は自動処理ですが、上の操作は troubleshooting 用に残しています。
+preview の primary UX は明示同意後のセッション確立・維持を自動処理しますが、上の操作は troubleshooting 用に残しています。
 
 ## Updates
 


### PR DESCRIPTION
## 概要
- Community Node の設定・状態・IPC から未使用の `auto_approve` フラグを削除
- 設定画面、mock、story、配布設定、現行文書から自動承認の概念を削除
- 旧キーを含む `community-node.json` を読み込み、再保存時に旧キーを除去する互換テストを追加

## 同意契約
- Issue #857 の Node 別・文書別の明示同意を維持
- 未同意 Node への通信禁止と policy 更新時の再同意要求を維持
- 明示同意後のサーバ同意同期とセッション維持のみ自動実行

## 検証
- `cargo xtask check`
- `cargo xtask test`（Rust 732件、harness 22件、UI 1069件）
- `cargo xtask rust-test`
- `cargo xtask tauri-check`
- `cargo xtask desktop-ui-check`（browser 58件、visual 14件を含む）
- `cargo xtask e2e-smoke`