### PR TITLE
[codex][contract] #855のバックアップ失敗契約を固定する

### DIFF
--- a/crates/core/src/tests/device_backup.rs
+++ b/crates/core/src/tests/device_backup.rs
@@ -1,4 +1,4 @@
-use std::io::Cursor;
+use std::io::{Cursor, Error, Result as IoResult, Write};
 
 use crate::{
     DEVICE_BACKUP_COMPONENT_VERSION, DEVICE_BACKUP_FORMAT_VERSION, DeviceBackupEntryV1,
@@ -41,6 +41,59 @@ fn archive_bytes(passphrase: &str) -> (DeviceBackupManifestV1, Vec<Vec<u8>>, Vec
     }
     let bytes = writer.finish().unwrap();
     (manifest, values, bytes)
+}
+
+#[derive(Debug)]
+struct FailingWriter {
+    remaining: Option<usize>,
+    fail_flush: bool,
+}
+
+impl FailingWriter {
+    fn after(bytes: usize) -> Self {
+        Self {
+            remaining: Some(bytes),
+            fail_flush: false,
+        }
+    }
+
+    fn on_flush() -> Self {
+        Self {
+            remaining: None,
+            fail_flush: true,
+        }
+    }
+}
+
+impl Write for FailingWriter {
+    fn write(&mut self, bytes: &[u8]) -> IoResult<usize> {
+        let Some(remaining) = self.remaining.as_mut() else {
+            return Ok(bytes.len());
+        };
+        if *remaining == 0 {
+            return Err(Error::other("simulated storage exhaustion"));
+        }
+        let written = bytes.len().min(*remaining);
+        *remaining -= written;
+        Ok(written)
+    }
+
+    fn flush(&mut self) -> IoResult<()> {
+        if self.fail_flush {
+            return Err(Error::other("simulated flush failure"));
+        }
+        Ok(())
+    }
+}
+
+fn archive_with_header_version(mut bytes: Vec<u8>, replacement: u8) -> Vec<u8> {
+    let needle = b"\"version\":1";
+    let index = bytes
+        .windows(needle.len())
+        .position(|window| window == needle)
+        .expect("backup header version");
+    bytes[index + needle.len() - 1] = replacement;
+    bytes
 }
 
 #[test]
@@ -147,4 +200,87 @@ fn weak_passphrase_and_invalid_manifest_are_rejected() {
         Err(error) => error,
     };
     assert!(err.to_string().contains("duplicate entry name"));
+}
+
+#[test]
+fn storage_exhaustion_and_flush_failures_are_propagated() {
+    let (manifest, values) = fixture();
+    let mut archive = DeviceBackupWriter::new(
+        FailingWriter::after(10_000),
+        "long enough passphrase",
+        manifest.clone(),
+    )
+    .expect("header and manifest fit before the simulated failure");
+    let mut error = None;
+    for value in &values {
+        if let Err(current) = archive.write_entry(Cursor::new(value), |_| Ok(())) {
+            error = Some(current);
+            break;
+        }
+    }
+    assert!(
+        error
+            .expect("entry write must hit the simulated capacity")
+            .to_string()
+            .contains("failed to write device backup frame")
+    );
+
+    let mut archive = DeviceBackupWriter::new(
+        FailingWriter::on_flush(),
+        "long enough passphrase",
+        manifest,
+    )
+    .expect("create writer");
+    for value in &values {
+        archive
+            .write_entry(Cursor::new(value), |_| Ok(()))
+            .expect("write entry before flush failure");
+    }
+    assert!(
+        archive
+            .finish()
+            .expect_err("flush failure must be returned")
+            .to_string()
+            .contains("failed to flush device backup")
+    );
+}
+
+#[test]
+fn unknown_format_and_component_versions_are_rejected() {
+    let (_, _, bytes) = archive_bytes("long enough passphrase");
+    let unknown_header = archive_with_header_version(bytes, b'9');
+    let error =
+        match DeviceBackupReader::open(Cursor::new(unknown_header), "long enough passphrase") {
+            Ok(_) => panic!("unknown header version unexpectedly succeeded"),
+            Err(error) => error,
+        };
+    assert!(
+        error
+            .to_string()
+            .contains("unsupported device backup version")
+    );
+
+    let (mut manifest, _) = fixture();
+    manifest.format_version += 1;
+    let error = match DeviceBackupWriter::new(Vec::new(), "long enough passphrase", manifest) {
+        Ok(_) => panic!("unknown manifest version unexpectedly succeeded"),
+        Err(error) => error,
+    };
+    assert!(
+        error
+            .to_string()
+            .contains("unsupported device backup manifest version")
+    );
+
+    let (mut manifest, _) = fixture();
+    manifest.component_version += 1;
+    let error = match DeviceBackupWriter::new(Vec::new(), "long enough passphrase", manifest) {
+        Ok(_) => panic!("unknown component version unexpectedly succeeded"),
+        Err(error) => error,
+    };
+    assert!(
+        error
+            .to_string()
+            .contains("unsupported device backup component version")
+    );
 }

--- a/crates/desktop-runtime/src/backup.rs
+++ b/crates/desktop-runtime/src/backup.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 use std::fs::{self, File, OpenOptions};
+use std::io::Write;
 use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -32,6 +33,73 @@ const FRONTEND_STATE_ENTRY: &str = "frontend-state.json";
 const FILE_ENTRY_PREFIX: &str = "file/";
 const FRONTEND_STATE_MAX_BYTES: usize = 2 * 1024 * 1024;
 const RESTORE_JOURNAL_FILE: &str = "device-restore-journal.json";
+
+struct DeviceBackupOutputFile {
+    file: File,
+}
+
+impl DeviceBackupOutputFile {
+    fn create_new(path: &Path) -> std::io::Result<Self> {
+        let file = OpenOptions::new().create_new(true).write(true).open(path)?;
+        Ok(Self { file })
+    }
+
+    fn sync_all(&self) -> std::io::Result<()> {
+        self.file.sync_all()
+    }
+}
+
+impl Write for DeviceBackupOutputFile {
+    fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+        #[cfg(test)]
+        {
+            let remaining = DEVICE_BACKUP_TEST_WRITE_BUDGET.load(Ordering::Acquire);
+            if remaining != u64::MAX {
+                if remaining == 0 {
+                    return Err(std::io::Error::other(
+                        "simulated device backup storage exhaustion",
+                    ));
+                }
+                let allowed = bytes
+                    .len()
+                    .min(usize::try_from(remaining).unwrap_or(usize::MAX));
+                let written = self.file.write(&bytes[..allowed])?;
+                DEVICE_BACKUP_TEST_WRITE_BUDGET.fetch_sub(written as u64, Ordering::AcqRel);
+                return Ok(written);
+            }
+        }
+        self.file.write(bytes)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.file.flush()
+    }
+}
+
+#[cfg(test)]
+static DEVICE_BACKUP_TEST_WRITE_BUDGET: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(u64::MAX);
+
+#[cfg(test)]
+pub(crate) struct DeviceBackupWriteFailureGuard;
+
+#[cfg(test)]
+impl Drop for DeviceBackupWriteFailureGuard {
+    fn drop(&mut self) {
+        DEVICE_BACKUP_TEST_WRITE_BUDGET.store(u64::MAX, Ordering::Release);
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn fail_device_backup_writes_after(bytes: u64) -> DeviceBackupWriteFailureGuard {
+    let previous = DEVICE_BACKUP_TEST_WRITE_BUDGET.swap(bytes, Ordering::AcqRel);
+    assert_eq!(
+        previous,
+        u64::MAX,
+        "device backup write failure is already active"
+    );
+    DeviceBackupWriteFailureGuard
+}
 
 mod create;
 
@@ -357,10 +425,7 @@ where
                         fs::create_dir_all(parent)
                             .context("failed to create device restore entry directory")?;
                     }
-                    let output = OpenOptions::new()
-                        .create_new(true)
-                        .write(true)
-                        .open(&target)
+                    let output = DeviceBackupOutputFile::create_new(&target)
                         .with_context(|| format!("failed to create `{}`", target.display()))?;
                     archive.read_entry(output, |delta| {
                         cancellation.check()?;

--- a/crates/desktop-runtime/src/backup/create.rs
+++ b/crates/desktop-runtime/src/backup/create.rs
@@ -1,5 +1,5 @@
 use std::collections::BTreeMap;
-use std::fs::{self, File, OpenOptions};
+use std::fs::{self, File};
 use std::io::{Cursor, Read};
 use std::path::{Component, Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -11,9 +11,9 @@ use kukuri_core::{
 };
 
 use super::{
-    CreateDeviceBackupRequest, DeviceBackupCancellation, DeviceBackupPhase, DeviceBackupProgress,
-    DeviceBackupSummary, FILE_ENTRY_PREFIX, FRONTEND_STATE_ENTRY, FRONTEND_STATE_MAX_BYTES,
-    SECRETS_ENTRY, active_account_for_db, collect_secret_bundle,
+    CreateDeviceBackupRequest, DeviceBackupCancellation, DeviceBackupOutputFile, DeviceBackupPhase,
+    DeviceBackupProgress, DeviceBackupSummary, FILE_ENTRY_PREFIX, FRONTEND_STATE_ENTRY,
+    FRONTEND_STATE_MAX_BYTES, SECRETS_ENTRY, active_account_for_db, collect_secret_bundle,
     ensure_backup_path_outside_app_data,
 };
 use crate::paths::DB_FILE_NAME;
@@ -128,10 +128,7 @@ where
 
     let temp_path = partial_path(&destination)?;
     let result = (|| -> Result<()> {
-        let file = OpenOptions::new()
-            .create_new(true)
-            .write(true)
-            .open(&temp_path)
+        let file = DeviceBackupOutputFile::create_new(&temp_path)
             .with_context(|| format!("failed to create `{}`", temp_path.display()))?;
         let mut archive = DeviceBackupWriter::new(file, &request.passphrase, manifest)?;
         let mut written = 0u64;

--- a/crates/desktop-runtime/src/tests/device_backup.rs
+++ b/crates/desktop-runtime/src/tests/device_backup.rs
@@ -8,10 +8,21 @@ use crate::accounts::{ensure_accounts_initialized, list_accounts};
 use crate::backup::{
     CreateDeviceBackupRequest, DeviceBackupCancellation, PreviewDeviceBackupRequest,
     RestoreDeviceBackupRequest, commit_device_restore, create_device_backup,
-    finalize_device_restore, install_prepared_device_restore, prepare_device_restore,
-    preview_device_backup, recover_interrupted_restore,
+    fail_device_backup_writes_after, finalize_device_restore, install_prepared_device_restore,
+    prepare_device_restore, preview_device_backup, recover_interrupted_restore,
 };
-use crate::identity::{IdentityStorageMode, load_existing_keys};
+use crate::community_node::{
+    COMMUNITY_NODE_CONSENT_PURPOSE, COMMUNITY_NODE_INVITE_CODE_PURPOSE,
+    COMMUNITY_NODE_TOKEN_PURPOSE, CommunityNodeConfig, CommunityNodeNodeConfig,
+    load_community_node_config_from_file, save_community_node_config,
+};
+use crate::identity::{
+    IdentityStorageMode, load_existing_keys, load_optional_secret, persist_optional_secret,
+};
+use crate::runtime::{
+    GOSSIP_SUBSCRIPTION_STATE_KEY, GOSSIP_SUBSCRIPTION_STATE_PURPOSE,
+    PRIVATE_CHANNEL_CAPABILITIES_KEY, PRIVATE_CHANNEL_CAPABILITIES_PURPOSE,
+};
 
 const PASSPHRASE: &str = "correct horse battery staple";
 
@@ -24,6 +35,48 @@ async fn initialized_app_data() -> (tempfile::TempDir, std::path::PathBuf) {
         .expect("initialize sqlite");
     store.close().await;
     (dir, db_path)
+}
+
+fn app_data_snapshot(root: &std::path::Path) -> BTreeMap<String, Vec<u8>> {
+    fn collect(
+        root: &std::path::Path,
+        current: &std::path::Path,
+        files: &mut BTreeMap<String, Vec<u8>>,
+    ) {
+        let mut entries = fs::read_dir(current)
+            .expect("read snapshot directory")
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .expect("collect snapshot directory");
+        entries.sort_by_key(|entry| entry.file_name());
+        for entry in entries {
+            let file_type = entry.file_type().expect("snapshot file type");
+            if file_type.is_dir() {
+                collect(root, &entry.path(), files);
+            } else if file_type.is_file() {
+                let relative = entry
+                    .path()
+                    .strip_prefix(root)
+                    .expect("snapshot relative path")
+                    .to_string_lossy()
+                    .replace('\\', "/");
+                files.insert(relative, fs::read(entry.path()).expect("snapshot file"));
+            }
+        }
+    }
+
+    let mut files = BTreeMap::new();
+    collect(root, root, &mut files);
+    files
+}
+
+fn archive_with_header_version(mut bytes: Vec<u8>, replacement: u8) -> Vec<u8> {
+    let needle = b"\"version\":1";
+    let index = bytes
+        .windows(needle.len())
+        .position(|window| window == needle)
+        .expect("backup header version");
+    bytes[index + needle.len() - 1] = replacement;
+    bytes
 }
 
 #[tokio::test]
@@ -39,6 +92,53 @@ async fn encrypted_device_backup_restores_one_account_as_one_file() {
         .expect("write portable marker");
     fs::write(iroh_dir.join("endpoint-secret.json"), b"device-bound")
         .expect("write endpoint secret");
+    let node_base_url = "https://backup-node.example";
+    save_community_node_config(
+        &source_db,
+        &CommunityNodeConfig {
+            nodes: vec![CommunityNodeNodeConfig {
+                base_url: node_base_url.to_string(),
+                resolved_urls: None,
+            }],
+        },
+    )
+    .expect("persist community node config");
+    for (purpose, key, value) in [
+        (
+            PRIVATE_CHANNEL_CAPABILITIES_PURPOSE,
+            PRIVATE_CHANNEL_CAPABILITIES_KEY,
+            "private-channel-capability",
+        ),
+        (
+            GOSSIP_SUBSCRIPTION_STATE_PURPOSE,
+            GOSSIP_SUBSCRIPTION_STATE_KEY,
+            "gossip-subscription",
+        ),
+        (
+            COMMUNITY_NODE_INVITE_CODE_PURPOSE,
+            node_base_url,
+            "portable-invite",
+        ),
+        (
+            COMMUNITY_NODE_TOKEN_PURPOSE,
+            node_base_url,
+            "device-session-token",
+        ),
+        (
+            COMMUNITY_NODE_CONSENT_PURPOSE,
+            node_base_url,
+            "device-consent-record",
+        ),
+    ] {
+        persist_optional_secret(
+            &source_db,
+            IdentityStorageMode::FileOnly,
+            purpose,
+            key,
+            value,
+        )
+        .expect("persist backup secret fixture");
+    }
 
     let archive_dir = tempdir().expect("archive tempdir");
     let archive_path = archive_dir.path().join("account.kukuri-backup");
@@ -131,6 +231,44 @@ async fn encrypted_device_backup_restores_one_account_as_one_file() {
     let snapshot = list_accounts(target.path()).expect("list restored accounts");
     assert_eq!(snapshot.active_account_id, result.account.id);
     assert_eq!(snapshot.accounts.len(), 2);
+    assert_eq!(
+        load_community_node_config_from_file(&restored_db)
+            .expect("load restored community node config")
+            .expect("restored community node config"),
+        CommunityNodeConfig {
+            nodes: vec![CommunityNodeNodeConfig {
+                base_url: node_base_url.to_string(),
+                resolved_urls: None,
+            }],
+        }
+    );
+    for (purpose, key, expected) in [
+        (
+            PRIVATE_CHANNEL_CAPABILITIES_PURPOSE,
+            PRIVATE_CHANNEL_CAPABILITIES_KEY,
+            Some("private-channel-capability"),
+        ),
+        (
+            GOSSIP_SUBSCRIPTION_STATE_PURPOSE,
+            GOSSIP_SUBSCRIPTION_STATE_KEY,
+            Some("gossip-subscription"),
+        ),
+        (
+            COMMUNITY_NODE_INVITE_CODE_PURPOSE,
+            node_base_url,
+            Some("portable-invite"),
+        ),
+        (COMMUNITY_NODE_TOKEN_PURPOSE, node_base_url, None),
+        (COMMUNITY_NODE_CONSENT_PURPOSE, node_base_url, None),
+    ] {
+        assert_eq!(
+            load_optional_secret(&restored_db, IdentityStorageMode::FileOnly, purpose, key)
+                .expect("load restored optional secret")
+                .as_deref(),
+            expected,
+            "unexpected restored value for {purpose}/{key}"
+        );
+    }
 }
 
 #[tokio::test]
@@ -152,6 +290,7 @@ async fn restore_failures_preserve_the_existing_account_registry() {
     )
     .expect("create backup");
     let before = list_accounts(app_data.path()).expect("list accounts before failure");
+    let state_before = app_data_snapshot(app_data.path());
 
     let wrong_passphrase = prepare_device_restore(
         app_data.path(),
@@ -169,6 +308,44 @@ async fn restore_failures_preserve_the_existing_account_registry() {
         list_accounts(app_data.path()).expect("list accounts after wrong passphrase"),
         before
     );
+    assert_eq!(app_data_snapshot(app_data.path()), state_before);
+
+    let original = fs::read(&archive_path).expect("read backup for rejection fixtures");
+    let corrupt_path = archive_dir.path().join("corrupt.kukuri-backup");
+    let mut corrupt = original.clone();
+    let corrupt_index = corrupt.len() - 8;
+    corrupt[corrupt_index] ^= 0x80;
+    fs::write(&corrupt_path, corrupt).expect("write corrupt backup");
+    let truncated_path = archive_dir.path().join("truncated.kukuri-backup");
+    fs::write(&truncated_path, &original[..original.len() - 6]).expect("write truncated backup");
+    let unknown_path = archive_dir.path().join("unknown-version.kukuri-backup");
+    fs::write(&unknown_path, archive_with_header_version(original, b'9'))
+        .expect("write unknown-version backup");
+
+    for rejected_path in [&corrupt_path, &truncated_path, &unknown_path] {
+        let rejected = prepare_device_restore(
+            app_data.path(),
+            &RestoreDeviceBackupRequest {
+                path: rejected_path.display().to_string(),
+                passphrase: PASSPHRASE.to_string(),
+                replace_existing: true,
+                apply_frontend_state: false,
+            },
+            &DeviceBackupCancellation::default(),
+            |_| {},
+        );
+        assert!(
+            rejected.is_err(),
+            "{} was accepted",
+            rejected_path.display()
+        );
+        assert_eq!(
+            app_data_snapshot(app_data.path()),
+            state_before,
+            "{} changed existing app data",
+            rejected_path.display()
+        );
+    }
 
     let replacement_without_confirmation = prepare_device_restore(
         app_data.path(),
@@ -186,6 +363,151 @@ async fn restore_failures_preserve_the_existing_account_registry() {
         list_accounts(app_data.path()).expect("list accounts after rejected replacement"),
         before
     );
+    assert_eq!(app_data_snapshot(app_data.path()), state_before);
+}
+
+#[tokio::test]
+async fn canceled_backup_removes_partial_output_and_preserves_source_state() {
+    let _resource = lock_test_resource(TestResource::IdentityStorage).await;
+    let (source, source_db) = initialized_app_data().await;
+    let iroh_dir = source_db.with_extension("iroh-data");
+    fs::create_dir_all(iroh_dir.join("blobs")).expect("create iroh blobs");
+    fs::write(
+        iroh_dir.join("blobs").join("large.bin"),
+        vec![7u8; 256 * 1024],
+    )
+    .expect("write large portable blob");
+    let state_before = app_data_snapshot(source.path());
+    let archive_dir = tempdir().expect("archive tempdir");
+    let archive_path = archive_dir.path().join("canceled.kukuri-backup");
+    let partial_path = archive_dir.path().join(".canceled.kukuri-backup.partial");
+    let cancellation = DeviceBackupCancellation::default();
+    let result = create_device_backup(
+        source.path(),
+        &source_db,
+        &CreateDeviceBackupRequest {
+            path: archive_path.display().to_string(),
+            passphrase: PASSPHRASE.to_string(),
+            frontend_state: BTreeMap::new(),
+        },
+        &cancellation,
+        |progress| {
+            if progress.phase == crate::backup::DeviceBackupPhase::Encrypting {
+                cancellation.cancel();
+            }
+        },
+    );
+    assert!(
+        result
+            .expect_err("canceled backup unexpectedly succeeded")
+            .to_string()
+            .contains("canceled")
+    );
+    assert!(!archive_path.exists());
+    assert!(!partial_path.exists());
+    assert_eq!(app_data_snapshot(source.path()), state_before);
+}
+
+#[tokio::test]
+async fn existing_backup_destination_is_never_overwritten() {
+    let _resource = lock_test_resource(TestResource::IdentityStorage).await;
+    let (source, source_db) = initialized_app_data().await;
+    let archive_dir = tempdir().expect("archive tempdir");
+    let archive_path = archive_dir.path().join("existing.kukuri-backup");
+    fs::write(&archive_path, b"existing backup").expect("write existing destination");
+
+    let result = create_device_backup(
+        source.path(),
+        &source_db,
+        &CreateDeviceBackupRequest {
+            path: archive_path.display().to_string(),
+            passphrase: PASSPHRASE.to_string(),
+            frontend_state: BTreeMap::new(),
+        },
+        &DeviceBackupCancellation::default(),
+        |_| {},
+    );
+    assert!(result.is_err());
+    assert_eq!(
+        fs::read(&archive_path).expect("read protected destination"),
+        b"existing backup"
+    );
+}
+
+#[tokio::test]
+async fn storage_exhaustion_during_backup_removes_partial_output() {
+    let _resource = lock_test_resource(TestResource::IdentityStorage).await;
+    let (source, source_db) = initialized_app_data().await;
+    let state_before = app_data_snapshot(source.path());
+    let archive_dir = tempdir().expect("archive tempdir");
+    let archive_path = archive_dir.path().join("storage-full.kukuri-backup");
+    let partial_path = archive_dir
+        .path()
+        .join(".storage-full.kukuri-backup.partial");
+    let _failure = fail_device_backup_writes_after(1);
+
+    let error = create_device_backup(
+        source.path(),
+        &source_db,
+        &CreateDeviceBackupRequest {
+            path: archive_path.display().to_string(),
+            passphrase: PASSPHRASE.to_string(),
+            frontend_state: BTreeMap::new(),
+        },
+        &DeviceBackupCancellation::default(),
+        |_| {},
+    )
+    .expect_err("storage exhaustion unexpectedly succeeded");
+    assert!(error.to_string().contains("failed to write backup magic"));
+    assert!(!archive_path.exists());
+    assert!(!partial_path.exists());
+    assert_eq!(app_data_snapshot(source.path()), state_before);
+}
+
+#[tokio::test]
+async fn storage_exhaustion_during_restore_preserves_existing_state() {
+    let _resource = lock_test_resource(TestResource::IdentityStorage).await;
+    let (source, source_db) = initialized_app_data().await;
+    let archive_dir = tempdir().expect("archive tempdir");
+    let archive_path = archive_dir
+        .path()
+        .join("restore-storage-full.kukuri-backup");
+    create_device_backup(
+        source.path(),
+        &source_db,
+        &CreateDeviceBackupRequest {
+            path: archive_path.display().to_string(),
+            passphrase: PASSPHRASE.to_string(),
+            frontend_state: BTreeMap::new(),
+        },
+        &DeviceBackupCancellation::default(),
+        |_| {},
+    )
+    .expect("create restore fixture");
+
+    let (target, _target_db) = initialized_app_data().await;
+    let state_before = app_data_snapshot(target.path());
+    let _failure = fail_device_backup_writes_after(1);
+    let error = match prepare_device_restore(
+        target.path(),
+        &RestoreDeviceBackupRequest {
+            path: archive_path.display().to_string(),
+            passphrase: PASSPHRASE.to_string(),
+            replace_existing: false,
+            apply_frontend_state: false,
+        },
+        &DeviceBackupCancellation::default(),
+        |_| {},
+    ) {
+        Ok(_) => panic!("restore storage exhaustion unexpectedly succeeded"),
+        Err(error) => error,
+    };
+    assert!(
+        error
+            .to_string()
+            .contains("failed to restore device backup entry")
+    );
+    assert_eq!(app_data_snapshot(target.path()), state_before);
 }
 
 #[tokio::test]

--- a/crates/desktop-runtime/src/tests/support/lock_contract.rs
+++ b/crates/desktop-runtime/src/tests/support/lock_contract.rs
@@ -32,7 +32,7 @@ const LOCK_CLASSIFICATION: &[(&str, &str, usize)] = &[
         3,
     ),
     ("community_node/trust_relation.rs", "CommunityNodeServer", 4),
-    ("device_backup.rs", "IdentityStorage", 3),
+    ("device_backup.rs", "IdentityStorage", 7),
     ("identity_restart.rs", "IdentityStorage", 2),
     ("media_blob_restore.rs", "IrohNetwork", 11),
     ("private_channels/friend_only.rs", "IrohNetwork", 1),
@@ -106,9 +106,9 @@ fn lock_acquisitions_match_declared_classification() {
     );
     let total: usize = expected.values().sum();
     assert_eq!(
-        total, 89,
+        total, 93,
         "classification total drifted from the Q7 T6 baseline(#711 で index_query 試験を 1 件、\
          #802 で tester_feedback_submission 試験を 3 件、#862 で config 永続化試験を 2 件、\
-         #855 で device_backup 試験を 3 件追加)"
+         #855 で device_backup 試験を 7 件へ拡充)"
     );
 }

--- a/crates/harness/src/scenarios/device_backup.rs
+++ b/crates/harness/src/scenarios/device_backup.rs
@@ -1,10 +1,13 @@
 use std::collections::BTreeMap;
 
 use kukuri_desktop_runtime::{
-    CreateDeviceBackupRequest, DeviceBackupCancellation, PreviewDeviceBackupRequest,
-    RestoreDeviceBackupRequest, commit_device_restore, create_device_backup,
-    ensure_accounts_initialized_from_env, finalize_device_restore, install_prepared_device_restore,
-    list_accounts, prepare_device_restore, preview_device_backup,
+    AuthorRequest, BookmarkPostRequest, CommunityNodeConfig, CommunityNodeNodeConfig,
+    CreateDeviceBackupRequest, CreatePostRequest, CreatePrivateChannelRequest,
+    DeviceBackupCancellation, GetBlobMediaRequest, ListJoinedPrivateChannelsRequest,
+    ListTimelineRequest, PreviewDeviceBackupRequest, RestoreDeviceBackupRequest,
+    commit_device_restore, create_device_backup, ensure_accounts_initialized_from_env,
+    finalize_device_restore, install_prepared_device_restore, list_accounts,
+    prepare_device_restore, preview_device_backup,
 };
 
 use crate::*;
@@ -26,20 +29,101 @@ pub(crate) async fn run_device_backup_restore(
 
     let started = Instant::now();
     let source_db = ensure_accounts_initialized_from_env(&source_dir)?;
-    let source_store = SqliteStore::connect_file(&source_db).await?;
-    source_store.close().await;
-    let iroh_dir = source_db.with_extension("iroh-data");
-    std::fs::create_dir_all(iroh_dir.join("blobs"))?;
+    let source_runtime = DesktopRuntime::new(&source_db).await?;
+    let topic = scenario.fixtures.topic.clone();
+    let post_content = "offline backup post";
+    let attachment_bytes = b"portable attachment bytes";
+    let post_id = source_runtime
+        .create_post(CreatePostRequest {
+            topic: topic.clone(),
+            content: post_content.to_string(),
+            reply_to: None,
+            channel_ref: ChannelRef::Public,
+            attachments: vec![image_attachment_request(
+                "backup.png",
+                "image/png",
+                attachment_bytes,
+            )],
+            content_labels: Vec::new(),
+        })
+        .await?;
+    source_runtime
+        .bookmark_post(BookmarkPostRequest {
+            topic: topic.clone(),
+            object_id: post_id.clone(),
+            channel_ref: ChannelRef::Public,
+        })
+        .await?;
+    let remote_pubkey = KukuriKeys::generate().public_key_hex();
+    source_runtime
+        .mute_author(AuthorRequest {
+            pubkey: remote_pubkey.clone(),
+        })
+        .await?;
+    source_runtime
+        .block_author(AuthorRequest {
+            pubkey: remote_pubkey.clone(),
+        })
+        .await?;
+    let private_channel = source_runtime
+        .create_private_channel(CreatePrivateChannelRequest {
+            topic: topic.clone(),
+            label: "portable private channel".to_string(),
+            audience_kind: ChannelAudienceKind::InviteOnly,
+        })
+        .await?;
+    let source_timeline = source_runtime
+        .list_timeline(ListTimelineRequest {
+            topic: topic.clone(),
+            scope: TimelineScope::Public,
+            cursor: None,
+            limit: Some(20),
+        })
+        .await?;
+    let source_post = source_timeline
+        .items
+        .iter()
+        .find(|post| post.object_id == post_id)
+        .context("source post missing before backup")?;
+    let attachment = source_post
+        .attachments
+        .first()
+        .context("source attachment missing before backup")?;
+    let attachment_hash = attachment.hash.clone();
+    source_runtime.shutdown().await;
+    drop(source_runtime);
+
+    let node_config = CommunityNodeConfig {
+        nodes: vec![CommunityNodeNodeConfig {
+            base_url: "https://backup-node.example".to_string(),
+            resolved_urls: None,
+        }],
+    };
     std::fs::write(
-        iroh_dir.join("blobs").join("scenario.bin"),
-        b"portable state",
+        source_db.with_extension("community-node.json"),
+        serde_json::to_vec(&node_config)?,
     )?;
-    std::fs::write(iroh_dir.join("endpoint-secret.json"), b"device-only")?;
+    let iroh_dir = source_db.with_extension("iroh-data");
+    anyhow::ensure!(
+        iroh_dir.join("endpoint-secret.json").is_file(),
+        "source endpoint secret was not created"
+    );
     push_named_step(&mut steps, "source_ready", started);
 
     let started = Instant::now();
     let backup_path = run_dir.path().join("account.kukuri-backup");
-    let frontend_state = BTreeMap::from([("kukuri.desktop.locale".to_string(), "ja".to_string())]);
+    let frontend_state = BTreeMap::from([
+        ("kukuri.desktop.locale".to_string(), "ja".to_string()),
+        (
+            "kukuri.workspace.layout".to_string(),
+            "{\"version\":1,\"columns\":[\"timeline\"]}".to_string(),
+        ),
+        (
+            "kukuri.composer.drafts".to_string(),
+            "{\"public\":\"portable draft\"}".to_string(),
+        ),
+        ("kukuri.desktop.theme".to_string(), "dark".to_string()),
+    ]);
     create_device_backup(
         &source_dir,
         &source_db,
@@ -106,14 +190,6 @@ pub(crate) async fn run_device_backup_restore(
     finalize_device_restore(installed)?;
     anyhow::ensure!(result.frontend_state == frontend_state);
     anyhow::ensure!(
-        std::fs::read(
-            restored_db
-                .with_extension("iroh-data")
-                .join("blobs")
-                .join("scenario.bin")
-        )? == b"portable state"
-    );
-    anyhow::ensure!(
         !restored_db
             .with_extension("iroh-data")
             .join("endpoint-secret.json")
@@ -121,6 +197,75 @@ pub(crate) async fn run_device_backup_restore(
         "device-bound endpoint secret was restored"
     );
     anyhow::ensure!(list_accounts(&target_dir)?.active_account_id == result.account.id);
+
+    let restored_runtime = DesktopRuntime::new(&restored_db).await?;
+    let restored_timeline = restored_runtime
+        .list_timeline(ListTimelineRequest {
+            topic: topic.clone(),
+            scope: TimelineScope::Public,
+            cursor: None,
+            limit: Some(20),
+        })
+        .await?;
+    let restored_post = restored_timeline
+        .items
+        .iter()
+        .find(|post| post.object_id == post_id && post.content == post_content)
+        .context("restored offline post missing")?;
+    anyhow::ensure!(
+        restored_post
+            .attachments
+            .iter()
+            .any(|item| item.hash == attachment_hash),
+        "restored attachment metadata missing"
+    );
+    let restored_payload = restored_runtime
+        .get_blob_media_payload(GetBlobMediaRequest {
+            hash: attachment_hash,
+            mime: "image/png".to_string(),
+        })
+        .await?
+        .context("restored attachment payload missing")?;
+    anyhow::ensure!(
+        BASE64_STANDARD.decode(restored_payload.bytes_base64.as_bytes())? == attachment_bytes
+    );
+    anyhow::ensure!(
+        restored_runtime
+            .list_bookmarked_posts()
+            .await?
+            .iter()
+            .any(|bookmark| bookmark.post.object_id == post_id),
+        "restored bookmark missing"
+    );
+    let restored_social = restored_runtime
+        .get_author_social_view(AuthorRequest {
+            pubkey: remote_pubkey,
+        })
+        .await?;
+    anyhow::ensure!(restored_social.muted, "restored mute state missing");
+    anyhow::ensure!(restored_social.blocking, "restored block state missing");
+    anyhow::ensure!(
+        restored_runtime
+            .list_joined_private_channels(ListJoinedPrivateChannelsRequest {
+                topic: topic.clone(),
+            })
+            .await?
+            .iter()
+            .any(|channel| channel.channel_id == private_channel.channel_id),
+        "restored private channel missing"
+    );
+    anyhow::ensure!(
+        restored_runtime.get_community_node_config().await? == node_config,
+        "restored Community Node config mismatch"
+    );
+    anyhow::ensure!(
+        !restored_runtime
+            .get_content_display_settings()
+            .adult_content_enabled,
+        "adult content display was restored as enabled"
+    );
+    restored_runtime.shutdown().await;
+    drop(restored_runtime);
     push_named_step(&mut steps, "restored_and_activated", started);
 
     let run_dir = run_dir.keep();

--- a/docs/progress/2026-09-03-issue-855-device-backup-restore-rerun.md
+++ b/docs/progress/2026-09-03-issue-855-device-backup-restore-rerun.md
@@ -1,0 +1,28 @@
+# Issue #855 device backup / restore rerun
+
+## Summary
+
+無償 Preview 公開のブロッカー(#853 Phase A)である端末バックアップ・復元について、再監査で不足していた失敗契約と実データ復元 scenario を補強した。既存の ADR 0048 と v1 archive format、公開 API、ユーザー向け挙動は変更していない。今回の再実行では、容量枯渇・flush 失敗・キャンセル・既存出力先・破損/切詰め/未知 version を実装境界で再現し、失敗時に部分出力を残さず、既存アカウント registry と app data を変更しないことを固定した。
+
+意図的にやらなかったこと: 未知の将来 version を推測して移行する処理、backup format の変更、restore による Community Node の bearer token・同意状態・年齢自己申告・成人向け表示許可の引継ぎ。v1 以外は fail-closed で拒否し、端末固有または再同意が必要な状態は従来どおり除外する。
+
+## 実装内容
+
+- core archive contract (`crates/core/src/tests/device_backup.rs`): 容量枯渇 writer と flush 失敗を使い、I/O error の伝搬を固定。未知の archive format version と component version、切詰め、末尾データ、弱い passphrase、invalid manifest の拒否を網羅した。
+- desktop runtime failure contract (`crates/desktop-runtime/src/backup.rs`、`backup/create.rs`、`tests/device_backup.rs`): production では `File` に透過する内部 writer wrapper を追加し、test 時だけ deterministic な write budget で ENOSPC 相当を注入できるようにした。backup/restore の容量枯渇、キャンセル、既存 destination、誤 passphrase、破損、切詰め、未知 version、replace 拒否で、部分出力 cleanup と既存 app data の byte-for-byte 不変を検証する。新規テストの共有 IdentityStorage lock は lock classification contract に宣言した。
+- 実データ scenario (`crates/harness/src/scenarios/device_backup.rs`): offline で画像添付投稿、下書き、bookmark、mute、block、private channel、Community Node 設定を作成して runtime を停止後に backup。空の別 app data へ restore し、投稿本文、添付 metadata と blob bytes、下書き、bookmark、mute/block、private channel、Node 設定が戻ることを実 API で検証する。endpoint secret と成人向け表示許可が戻らないことも確認する。bearer token と Node 同意の除外は desktop runtime contract で固定し、アプリ同意と年齢自己申告の非移行は既存の Tauri state contract を維持する。
+
+## 検証
+
+- `cargo test -p kukuri-core device_backup -- --nocapture`: 7 件成功
+- `cargo test -p kukuri-desktop-runtime tests::device_backup -- --nocapture`: 7 件成功
+- `cargo test -p kukuri-desktop-runtime tests::support::lock_contract::lock_acquisitions_match_declared_classification -- --nocapture`: 成功
+- `cargo test -p kukuri-harness -- --nocapture`: 22 件成功
+- `cargo xtask scenario desktop_device_backup_restore`: 成功
+- `cargo xtask check`: 成功
+- `cargo xtask test`: Rust 748 件、harness 22 件、frontend 1074 件すべて成功(Rust 3 件 skip)
+- `cargo xtask rust-test`: Rust 748 件、harness 22 件、doc-test すべて成功(Rust 3 件 skip)
+- `cargo xtask e2e-smoke`: `desktop_smoke_post_persist` 成功
+- `cargo xtask doctor`: 成功
+
+関連: #853(親)、#855、#859(アカウント鍵 export/import)、ADR 0048


### PR DESCRIPTION
## 概要

Issue #855 の再監査で不足していたバックアップ/復元の失敗契約と、実データ復元 scenario を補強します。

- 容量枯渇・flush 失敗・キャンセル・既存出力先で部分出力を残さないことを固定
- 誤 passphrase・破損・切詰め・未知 version・replace 拒否で既存 app data/registry が不変であることを固定
- offline post/draft、画像添付と blob bytes、bookmark、mute/block、private channel、Community Node 設定を新規端末相当へ復元する scenario を追加
- bearer token・Node 同意・endpoint secret・成人向け表示許可を自動継承しない既存契約を維持

Closes #855

## 種別

contract test / scenario / test-only fault injection。archive format、公開 API、ユーザー向け挙動の変更はありません。

## 検証

- cargo xtask check
- cargo xtask test (Rust 748/748、harness 22/22、frontend 1074/1074)
- cargo xtask rust-test (Rust 748/748、harness 22/22、doc-test)
- cargo xtask scenario desktop_device_backup_restore
- cargo xtask e2e-smoke
- cargo xtask doctor
- cargo fmt --all -- --check
- git diff --check

## リスク

production の内部 output wrapper は std::fs::File へ透過委譲します。fault injection は cfg(test) の write budget のみに限定しています。

## 後続対応

なし。v1 以外の将来 version は、対応 migration が実装されるまで fail-closed で拒否します。