### PR TITLE
fix: enforce Community Node consent network boundary

### DIFF
--- a/crates/desktop-runtime/src/community_node/config_support.rs
+++ b/crates/desktop-runtime/src/community_node/config_support.rs
@@ -125,6 +125,36 @@ pub(crate) fn community_node_seed_peers(
         })
 }
 
+/// 保存済みの Node 設定から、現在ローカル同意が有効な Node だけを transport 入力へ渡す。
+///
+/// `resolved_urls` 自体は再同意後の再接続に使う cache として保存し続ける。秘密領域の
+/// 同意記録が読めない場合は、Node 通信を開始しない側へ倒す。
+pub(crate) fn community_node_config_with_active_local_consents(
+    db_path: &Path,
+    identity_mode: IdentityStorageMode,
+    config: &CommunityNodeConfig,
+) -> CommunityNodeConfig {
+    let nodes = config
+        .nodes
+        .iter()
+        .filter(|node| {
+            match load_community_node_local_consents(db_path, identity_mode, &node.base_url) {
+                Ok(state) => state.has_active_consent(),
+                Err(error) => {
+                    warn!(
+                        base_url = %node.base_url,
+                        %error,
+                        "failed to load community-node consent; excluding node connectivity"
+                    );
+                    false
+                }
+            }
+        })
+        .cloned()
+        .collect();
+    CommunityNodeConfig { nodes }
+}
+
 pub(crate) fn seed_peer_from_community_node(seed_peer: &CommunityNodeSeedPeer) -> Option<SeedPeer> {
     let endpoint_id = seed_peer.endpoint_id.trim();
     if endpoint_id.is_empty() {

--- a/crates/desktop-runtime/src/community_node/report_routing_support.rs
+++ b/crates/desktop-runtime/src/community_node/report_routing_support.rs
@@ -1,4 +1,5 @@
 use super::*;
+use kukuri_cn_protocol::CONSENT_REQUIRED_CODE;
 use std::fmt;
 
 /// 分散通報ルーティング（#310）の通報送信リクエスト。
@@ -172,6 +173,15 @@ impl DesktopRuntime {
         ensure_report_endpoint_origin(base_url.as_str(), endpoint).map_err(|error| {
             CommunityNodeReportError::new("REPORT_ENDPOINT_MISMATCH", error.to_string())
         })?;
+        if self
+            .community_node_required_consent_is_pending(base_url.as_str())
+            .await
+        {
+            return Err(CommunityNodeReportError::new(
+                CONSENT_REQUIRED_CODE,
+                "community node required policies must be accepted before report submission",
+            ));
+        }
         let client = community_node_report_http_client().map_err(|error| {
             CommunityNodeReportError::new("REPORT_CLIENT_UNAVAILABLE", error.to_string())
         })?;

--- a/crates/desktop-runtime/src/community_node/requests_support.rs
+++ b/crates/desktop-runtime/src/community_node/requests_support.rs
@@ -493,7 +493,10 @@ impl DesktopRuntime {
             }
         }
         let rendezvous_peers = peers_by_endpoint.into_values().collect::<Vec<_>>();
-        *self.community_node_rendezvous_seed_peers.lock().await = rendezvous_peers;
+        self.community_node_rendezvous_seed_peers
+            .lock()
+            .await
+            .insert(base_url.to_string(), rendezvous_peers);
         self.apply_runtime_connectivity_assist()
             .await
             .map_err(CommunityNodeRequestError::Other)?;

--- a/crates/desktop-runtime/src/community_node/session_runtime_support.rs
+++ b/crates/desktop-runtime/src/community_node/session_runtime_support.rs
@@ -65,6 +65,8 @@ impl DesktopRuntime {
                 CommunityNodeSessionPhase::Idle,
             )
             .await;
+            self.deactivate_community_node_connectivity(base_url.as_str())
+                .await?;
             return Ok(());
         }
 
@@ -99,6 +101,8 @@ impl DesktopRuntime {
                     CommunityNodeSessionPhase::Idle,
                 )
                 .await;
+                self.deactivate_community_node_connectivity(base_url.as_str())
+                    .await?;
                 return Ok(());
             }
             self.set_community_node_local_consent_update_pending(base_url.as_str(), false)
@@ -133,6 +137,8 @@ impl DesktopRuntime {
                     CommunityNodeSessionPhase::Idle,
                 )
                 .await;
+                self.deactivate_community_node_connectivity(base_url.as_str())
+                    .await?;
                 return Ok(());
             }
             // ローカル同意済みの内容をサーバ記録へ同期する(#857)。
@@ -207,6 +213,51 @@ impl DesktopRuntime {
             .ok_or_else(|| anyhow!("community node `{base_url}` is not configured"))
     }
 
+    async fn active_community_node_connectivity_config(&self) -> CommunityNodeConfig {
+        let config = self.community_node_config.lock().await.clone();
+        let mut active = community_node_config_with_active_local_consents(
+            &self.db_path,
+            self.identity_mode,
+            &config,
+        );
+        let sessions = self.community_node_sessions.lock().await;
+        active.nodes.retain(|node| {
+            !sessions
+                .get(node.base_url.as_str())
+                .is_some_and(|session| session.local_consent_update_pending)
+        });
+        active
+    }
+
+    async fn active_community_node_rendezvous_seed_peers(
+        &self,
+        active_config: &CommunityNodeConfig,
+    ) -> Vec<SeedPeer> {
+        let rendezvous_by_node = self.community_node_rendezvous_seed_peers.lock().await;
+        rendezvous_by_node
+            .iter()
+            .filter(|(base_url, _)| {
+                active_config
+                    .nodes
+                    .iter()
+                    .any(|node| node.base_url.as_str() == base_url.as_str())
+            })
+            .flat_map(|(_, peers)| peers.iter().cloned())
+            .collect()
+    }
+
+    pub(crate) async fn deactivate_community_node_connectivity(
+        &self,
+        base_url: &str,
+    ) -> Result<()> {
+        self.community_node_rendezvous_seed_peers
+            .lock()
+            .await
+            .remove(base_url);
+        self.apply_runtime_connectivity_assist().await?;
+        self.apply_effective_seed_peers().await
+    }
+
     pub(crate) async fn community_node_status(
         &self,
         node: CommunityNodeNodeConfig,
@@ -263,10 +314,9 @@ impl DesktopRuntime {
             node.base_url.as_str(),
         )?
         .is_some();
-        let current_connectivity_urls = relay_config_from_community_node_config(
-            &self.community_node_config.lock().await.clone(),
-        )
-        .iroh_relay_urls;
+        let active_config = self.active_community_node_connectivity_config().await;
+        let current_connectivity_urls =
+            relay_config_from_community_node_config(&active_config).iroh_relay_urls;
         Ok(CommunityNodeNodeStatus {
             base_url: node.base_url,
             auth_state,
@@ -286,14 +336,12 @@ impl DesktopRuntime {
 
     async fn apply_runtime_connectivity_assist_with_mode(&self, force: bool) -> Result<()> {
         let discovery_config = self.discovery_config.lock().await.clone();
-        let community_node_config = self.community_node_config.lock().await.clone();
+        let community_node_config = self.active_community_node_connectivity_config().await;
         let mut next_state =
             runtime_connectivity_assist_state(&discovery_config, &community_node_config);
         let rendezvous_seed_peers = self
-            .community_node_rendezvous_seed_peers
-            .lock()
-            .await
-            .clone();
+            .active_community_node_rendezvous_seed_peers(&community_node_config)
+            .await;
         next_state.bootstrap_seed_peers = normalize_seed_peers(
             next_state
                 .bootstrap_seed_peers
@@ -341,14 +389,12 @@ impl DesktopRuntime {
 
     pub(crate) async fn force_rebuild_runtime_connectivity_assist(&self) -> Result<()> {
         let discovery_config = self.discovery_config.lock().await.clone();
-        let community_node_config = self.community_node_config.lock().await.clone();
+        let community_node_config = self.active_community_node_connectivity_config().await;
         let mut next_state =
             runtime_connectivity_assist_state(&discovery_config, &community_node_config);
         let rendezvous_seed_peers = self
-            .community_node_rendezvous_seed_peers
-            .lock()
-            .await
-            .clone();
+            .active_community_node_rendezvous_seed_peers(&community_node_config)
+            .await;
         next_state.bootstrap_seed_peers = normalize_seed_peers(
             next_state
                 .bootstrap_seed_peers
@@ -380,14 +426,12 @@ impl DesktopRuntime {
 
     async fn apply_effective_seed_peers_with_mode(&self, force: bool) -> Result<()> {
         let discovery_config = self.discovery_config.lock().await.clone();
-        let community_node_config = self.community_node_config.lock().await.clone();
+        let community_node_config = self.active_community_node_connectivity_config().await;
         let mut next_state =
             effective_seed_peer_apply_state(&discovery_config, &community_node_config);
         let rendezvous_seed_peers = self
-            .community_node_rendezvous_seed_peers
-            .lock()
-            .await
-            .clone();
+            .active_community_node_rendezvous_seed_peers(&community_node_config)
+            .await;
         next_state.bootstrap_seed_peers = normalize_seed_peers(
             next_state
                 .bootstrap_seed_peers

--- a/crates/desktop-runtime/src/runtime/community_node_api.rs
+++ b/crates/desktop-runtime/src/runtime/community_node_api.rs
@@ -142,6 +142,10 @@ impl DesktopRuntime {
                 self.identity_mode,
                 removed_node.base_url.as_str(),
             )?;
+            self.community_node_rendezvous_seed_peers
+                .lock()
+                .await
+                .remove(removed_node.base_url.as_str());
         }
         save_community_node_config(&self.db_path, &next_config)?;
         *self.community_node_config.lock().await = next_config.clone();
@@ -171,6 +175,10 @@ impl DesktopRuntime {
         }
         save_community_node_config(&self.db_path, &CommunityNodeConfig::default())?;
         *self.community_node_config.lock().await = CommunityNodeConfig::default();
+        self.community_node_rendezvous_seed_peers
+            .lock()
+            .await
+            .clear();
         self.community_node_sessions.lock().await.clear();
         *self.community_node_reconnect_state.lock().await = Default::default();
         self.apply_runtime_connectivity_assist().await?;
@@ -410,6 +418,8 @@ impl DesktopRuntime {
             .await;
         self.clear_community_node_retry_state(base_url.as_str())
             .await;
+        self.apply_runtime_connectivity_assist().await?;
+        self.apply_effective_seed_peers().await?;
         self.refresh_community_node_registration_if_due(base_url.as_str())
             .await?;
         let refreshed = self.require_community_node(base_url.as_str()).await?;
@@ -439,8 +449,14 @@ impl DesktopRuntime {
         )?;
         self.set_community_node_local_consent_update_pending(base_url.as_str(), false)
             .await;
-        self.clear_community_node_token(CommunityNodeTargetRequest { base_url })
-            .await
+        self.clear_community_node_token(CommunityNodeTargetRequest {
+            base_url: base_url.clone(),
+        })
+        .await?;
+        self.deactivate_community_node_connectivity(base_url.as_str())
+            .await?;
+        let node = self.require_community_node(base_url.as_str()).await?;
+        self.community_node_status(node, None, None).await
     }
 
     pub async fn refresh_community_node_metadata(

--- a/crates/desktop-runtime/src/runtime/mod.rs
+++ b/crates/desktop-runtime/src/runtime/mod.rs
@@ -59,8 +59,9 @@ use crate::community_node::{
     SetCommunityNodeConfigRequest, SetCommunityNodeInviteCodeRequest,
     SubmitCommunityNodeReportRequest, SubmitCommunityNodeReportResult,
     SubmitIndexingRequestResponse, TrustUserReadResponse,
-    community_node_local_consent_covers_status, community_node_local_consent_satisfies_policies,
-    community_node_seed_peers, delete_community_node_invite_code, effective_seed_peer_apply_state,
+    community_node_config_with_active_local_consents, community_node_local_consent_covers_status,
+    community_node_local_consent_satisfies_policies, community_node_seed_peers,
+    delete_community_node_invite_code, effective_seed_peer_apply_state,
     load_community_node_config_from_file, load_community_node_local_consents,
     load_community_node_token, normalize_community_node_config, persist_community_node_invite_code,
     persist_community_node_local_consents, record_community_node_local_consents,
@@ -115,7 +116,8 @@ pub struct DesktopRuntime {
     pub(crate) community_node_sessions: Arc<Mutex<HashMap<String, CommunityNodeSessionState>>>,
     pub(crate) community_node_dome_heartbeats:
         Arc<Mutex<HashMap<String, kukuri_core::SignedDomeHostHeartbeatV1>>>,
-    pub(crate) community_node_rendezvous_seed_peers: Arc<Mutex<Vec<kukuri_transport::SeedPeer>>>,
+    pub(crate) community_node_rendezvous_seed_peers:
+        Arc<Mutex<HashMap<String, Vec<kukuri_transport::SeedPeer>>>>,
     pub(crate) community_node_session_guard: Arc<Mutex<()>>,
     pub(crate) community_node_reconnect_state: Arc<Mutex<CommunityNodeReconnectState>>,
     pub(crate) community_node_reconnect_guard: Arc<Mutex<()>>,
@@ -303,13 +305,18 @@ impl DesktopRuntime {
             }
             None => CommunityNodeConfig::default(),
         };
-        let relay_config = relay_config_from_community_node_config(&community_node_config);
+        let active_community_node_config = community_node_config_with_active_local_consents(
+            &db_path,
+            identity_mode,
+            &community_node_config,
+        );
+        let relay_config = relay_config_from_community_node_config(&active_community_node_config);
         let community_node_seed_peers =
-            community_node_seed_peers(&community_node_config).collect::<Vec<_>>();
+            community_node_seed_peers(&active_community_node_config).collect::<Vec<_>>();
         let initial_runtime_connectivity_state =
-            runtime_connectivity_assist_state(&discovery_config, &community_node_config);
+            runtime_connectivity_assist_state(&discovery_config, &active_community_node_config);
         let initial_effective_seed_peer_state =
-            effective_seed_peer_apply_state(&discovery_config, &community_node_config);
+            effective_seed_peer_apply_state(&discovery_config, &active_community_node_config);
         let docs_root = db_path.with_extension("iroh-data");
         let store = Arc::new(SqliteStore::connect_file(&db_path).await?);
         let iroh_stack = SharedIrohStack::new(
@@ -392,7 +399,7 @@ impl DesktopRuntime {
             community_node_config: Arc::new(Mutex::new(community_node_config)),
             community_node_sessions: Arc::new(Mutex::new(HashMap::new())),
             community_node_dome_heartbeats: Arc::new(Mutex::new(HashMap::new())),
-            community_node_rendezvous_seed_peers: Arc::new(Mutex::new(Vec::new())),
+            community_node_rendezvous_seed_peers: Arc::new(Mutex::new(HashMap::new())),
             community_node_session_guard: Arc::new(Mutex::new(())),
             community_node_reconnect_state: Arc::new(Mutex::new(
                 CommunityNodeReconnectState::default(),

--- a/crates/desktop-runtime/src/tests/community_node/config.rs
+++ b/crates/desktop-runtime/src/tests/community_node/config.rs
@@ -1,4 +1,216 @@
 use super::super::*;
+use crate::community_node::community_node_config_with_active_local_consents;
+
+#[tokio::test]
+async fn persisted_community_node_connectivity_is_not_applied_without_local_consent() {
+    let dir = tempdir().expect("tempdir");
+    let db_path = dir
+        .path()
+        .join("community-node-unconsented-connectivity.db");
+    let relay_url = "https://127.0.0.1:9";
+    let seed_peer = CommunityNodeSeedPeer::new(
+        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+        Some("127.0.0.1:9".to_string()),
+    )
+    .expect("seed peer");
+    let persisted = CommunityNodeConfig {
+        nodes: vec![CommunityNodeNodeConfig {
+            base_url: "https://community.example.com".to_string(),
+            resolved_urls: Some(
+                CommunityNodeResolvedUrls::new(
+                    "https://community.example.com",
+                    vec![relay_url.to_string()],
+                    vec![seed_peer],
+                )
+                .expect("resolved urls"),
+            ),
+        }],
+    };
+    save_community_node_config(&db_path, &persisted).expect("save community-node config");
+
+    let runtime = DesktopRuntime::new_with_config_and_identity(
+        &db_path,
+        TransportNetworkConfig::loopback(),
+        IdentityStorageMode::FileOnly,
+    )
+    .await
+    .expect("runtime");
+
+    assert!(runtime.active_connectivity_urls.lock().await.is_empty());
+    assert!(
+        runtime
+            .get_sync_status()
+            .await
+            .expect("sync status")
+            .discovery
+            .bootstrap_seed_peer_ids
+            .is_empty()
+    );
+    let stored = runtime
+        .get_community_node_config()
+        .await
+        .expect("stored community-node config");
+    assert_eq!(stored, persisted);
+
+    runtime.shutdown().await;
+}
+
+#[tokio::test]
+async fn withdrawing_community_node_consent_removes_transport_assist() {
+    let dir = tempdir().expect("tempdir");
+    let db_path = dir.path().join("community-node-withdraw-connectivity.db");
+    let base_url = "https://community.example.com";
+    let relay_url = "https://127.0.0.1:9";
+    let configured_seed = SeedPeer {
+        endpoint_id: "1111111111111111111111111111111111111111111111111111111111111111".to_string(),
+        addr_hint: Some("127.0.0.1:11001".to_string()),
+    };
+    let bootstrap_seed = CommunityNodeSeedPeer::new(
+        "2222222222222222222222222222222222222222222222222222222222222222",
+        Some("127.0.0.1:22002".to_string()),
+    )
+    .expect("bootstrap seed");
+    let rendezvous_seed = SeedPeer {
+        endpoint_id: "3333333333333333333333333333333333333333333333333333333333333333".to_string(),
+        addr_hint: Some("127.0.0.1:33003".to_string()),
+    };
+    let mut discovery_config = DiscoveryConfig::static_peer_default();
+    discovery_config.seed_peers = vec![configured_seed.clone()];
+    let runtime = DesktopRuntime::new_with_config_and_identity_and_discovery(
+        &db_path,
+        TransportNetworkConfig::loopback(),
+        IdentityStorageMode::FileOnly,
+        discovery_config,
+        DhtDiscoveryOptions::disabled(),
+        None,
+    )
+    .await
+    .expect("runtime");
+    seed_local_community_node_consents(&runtime, base_url, 1);
+    *runtime.community_node_config.lock().await = CommunityNodeConfig {
+        nodes: vec![CommunityNodeNodeConfig {
+            base_url: base_url.to_string(),
+            resolved_urls: Some(
+                CommunityNodeResolvedUrls::new(
+                    base_url,
+                    vec![relay_url.to_string()],
+                    vec![bootstrap_seed],
+                )
+                .expect("resolved urls"),
+            ),
+        }],
+    };
+    runtime
+        .community_node_rendezvous_seed_peers
+        .lock()
+        .await
+        .insert(base_url.to_string(), vec![rendezvous_seed]);
+    runtime
+        .apply_runtime_connectivity_assist()
+        .await
+        .expect("apply runtime connectivity");
+    runtime
+        .apply_effective_seed_peers()
+        .await
+        .expect("apply effective seeds");
+
+    assert_eq!(
+        *runtime.active_connectivity_urls.lock().await,
+        vec![relay_url.to_string()]
+    );
+    let before = runtime
+        .last_effective_seed_peer_apply_state
+        .lock()
+        .await
+        .clone()
+        .expect("effective seeds before withdrawal");
+    assert_eq!(before.configured_seed_peers, vec![configured_seed.clone()]);
+    assert_eq!(before.bootstrap_seed_peers.len(), 2);
+
+    runtime
+        .withdraw_community_node_consents(crate::CommunityNodeTargetRequest {
+            base_url: base_url.to_string(),
+        })
+        .await
+        .expect("withdraw consents");
+
+    assert!(runtime.active_connectivity_urls.lock().await.is_empty());
+    assert!(
+        runtime
+            .community_node_rendezvous_seed_peers
+            .lock()
+            .await
+            .get(base_url)
+            .is_none()
+    );
+    let after = runtime
+        .last_effective_seed_peer_apply_state
+        .lock()
+        .await
+        .clone()
+        .expect("effective seeds after withdrawal");
+    assert_eq!(after.configured_seed_peers, vec![configured_seed]);
+    assert!(after.bootstrap_seed_peers.is_empty());
+
+    runtime.shutdown().await;
+}
+
+#[tokio::test]
+async fn community_node_connectivity_filter_is_scoped_per_node() {
+    let dir = tempdir().expect("tempdir");
+    let db_path = dir.path().join("community-node-consent-filter.db");
+    let runtime = DesktopRuntime::new_with_config_and_identity(
+        &db_path,
+        TransportNetworkConfig::loopback(),
+        IdentityStorageMode::FileOnly,
+    )
+    .await
+    .expect("runtime");
+    let consented_base_url = "https://consented.example.com";
+    let pending_base_url = "https://pending.example.com";
+    seed_local_community_node_consents(&runtime, consented_base_url, 1);
+    let config = CommunityNodeConfig {
+        nodes: vec![
+            CommunityNodeNodeConfig {
+                base_url: consented_base_url.to_string(),
+                resolved_urls: Some(
+                    CommunityNodeResolvedUrls::new(
+                        consented_base_url,
+                        vec!["https://relay-consented.example.com".to_string()],
+                        Vec::new(),
+                    )
+                    .expect("consented resolved urls"),
+                ),
+            },
+            CommunityNodeNodeConfig {
+                base_url: pending_base_url.to_string(),
+                resolved_urls: Some(
+                    CommunityNodeResolvedUrls::new(
+                        pending_base_url,
+                        vec!["https://relay-pending.example.com".to_string()],
+                        Vec::new(),
+                    )
+                    .expect("pending resolved urls"),
+                ),
+            },
+        ],
+    };
+
+    let active = community_node_config_with_active_local_consents(
+        &db_path,
+        IdentityStorageMode::FileOnly,
+        &config,
+    );
+
+    assert_eq!(active.nodes.len(), 1);
+    assert_eq!(active.nodes[0].base_url, consented_base_url);
+    assert_eq!(
+        relay_config_from_community_node_config(&active).iroh_relay_urls,
+        vec!["https://relay-consented.example.com".to_string()]
+    );
+
+    runtime.shutdown().await;
+}
 
 #[test]
 fn community_node_config_normalizes_base_urls_and_connectivity_urls() {

--- a/crates/desktop-runtime/src/tests/community_node/connectivity.rs
+++ b/crates/desktop-runtime/src/tests/community_node/connectivity.rs
@@ -725,7 +725,7 @@ async fn runtime_starts_with_unreachable_community_node_and_recovers_via_manual_
         .expect("sync status before recovery");
     assert_eq!(
         status_before.discovery.connect_mode,
-        ConnectMode::DirectOrRelay
+        ConnectMode::DirectOnly
     );
     assert!(!status_before.connected);
     assert!(matches!(
@@ -737,6 +737,23 @@ async fn runtime_starts_with_unreachable_community_node_and_recovers_via_manual_
     // スケジューラ tick が駆動し、getter は読み取り専用。
     // #857: 同意済みでなければそもそも通信しないため、同意記録をシードしてから tick を回す。
     seed_local_community_node_consents(&runtime_a, community_base_url, 1);
+    runtime_a
+        .apply_runtime_connectivity_assist()
+        .await
+        .expect("apply consented connectivity");
+    runtime_a
+        .apply_effective_seed_peers()
+        .await
+        .expect("apply consented seeds");
+    assert_eq!(
+        runtime_a
+            .get_sync_status()
+            .await
+            .expect("sync status after consent")
+            .discovery
+            .connect_mode,
+        ConnectMode::DirectOrRelay
+    );
     runtime_a
         .run_community_node_session_maintenance_once()
         .await;

--- a/crates/desktop-runtime/src/tests/community_node/report_submission.rs
+++ b/crates/desktop-runtime/src/tests/community_node/report_submission.rs
@@ -1,6 +1,6 @@
 use super::super::*;
 use axum::response::{IntoResponse, Response};
-use kukuri_cn_protocol::ApiErrorBody;
+use kukuri_cn_protocol::{ApiErrorBody, CONSENT_REQUIRED_CODE};
 use serde_json::{Value, json};
 
 #[derive(Clone, Default)]
@@ -100,6 +100,7 @@ fn appeal_request(base_url: &str) -> SubmitCommunityNodeReportRequest {
 async fn community_node_report_client_sends_anonymous_appeal_and_reads_disputed_signal() {
     let _resource = lock_test_resource(TestResource::CommunityNodeServer).await;
     let (runtime, base_url, state, server, _dir) = report_runtime(false).await;
+    seed_local_community_node_consents(&runtime, base_url.as_str(), 1);
 
     let result = runtime
         .submit_community_node_report(appeal_request(base_url.as_str()))
@@ -120,6 +121,7 @@ async fn community_node_report_client_sends_anonymous_appeal_and_reads_disputed_
 async fn community_node_report_client_preserves_invalid_appeal_code() {
     let _resource = lock_test_resource(TestResource::CommunityNodeServer).await;
     let (runtime, base_url, _state, server, _dir) = report_runtime(true).await;
+    seed_local_community_node_consents(&runtime, base_url.as_str(), 1);
 
     let error = runtime
         .submit_community_node_report(appeal_request(base_url.as_str()))
@@ -172,6 +174,7 @@ async fn community_node_report_client_rejects_endpoint_on_another_origin() {
 async fn community_node_report_client_does_not_follow_redirects() {
     let _resource = lock_test_resource(TestResource::CommunityNodeServer).await;
     let (runtime, base_url, state, server, _dir) = report_runtime(false).await;
+    seed_local_community_node_consents(&runtime, base_url.as_str(), 1);
 
     let mut request = appeal_request(base_url.as_str());
     request.report_endpoint = format!("{base_url}/v1/report-moved");
@@ -185,6 +188,68 @@ async fn community_node_report_client_does_not_follow_redirects() {
         state.received.lock().await.is_empty(),
         "the report body must not reach the redirect target"
     );
+
+    runtime.shutdown().await;
+    server.abort();
+}
+
+#[tokio::test]
+async fn community_node_report_client_stops_before_http_without_active_local_consent() {
+    let _resource = lock_test_resource(TestResource::CommunityNodeServer).await;
+    let (runtime, base_url, state, server, _dir) = report_runtime(false).await;
+
+    let error = runtime
+        .submit_community_node_report(appeal_request(base_url.as_str()))
+        .await
+        .expect_err("report without local consent must be rejected");
+
+    assert_eq!(error.code, CONSENT_REQUIRED_CODE);
+    assert!(state.received.lock().await.is_empty());
+
+    runtime.shutdown().await;
+    server.abort();
+}
+
+#[tokio::test]
+async fn community_node_report_client_stops_before_http_after_consent_withdrawal() {
+    let _resource = lock_test_resource(TestResource::CommunityNodeServer).await;
+    let (runtime, base_url, state, server, _dir) = report_runtime(false).await;
+    seed_local_community_node_consents(&runtime, base_url.as_str(), 1);
+    runtime
+        .withdraw_community_node_consents(crate::CommunityNodeTargetRequest {
+            base_url: base_url.clone(),
+        })
+        .await
+        .expect("withdraw consents");
+
+    let error = runtime
+        .submit_community_node_report(appeal_request(base_url.as_str()))
+        .await
+        .expect_err("report after consent withdrawal must be rejected");
+
+    assert_eq!(error.code, CONSENT_REQUIRED_CODE);
+    assert!(state.received.lock().await.is_empty());
+
+    runtime.shutdown().await;
+    server.abort();
+}
+
+#[tokio::test]
+async fn community_node_report_client_stops_before_http_when_reconsent_is_pending() {
+    let _resource = lock_test_resource(TestResource::CommunityNodeServer).await;
+    let (runtime, base_url, state, server, _dir) = report_runtime(false).await;
+    seed_local_community_node_consents(&runtime, base_url.as_str(), 1);
+    runtime
+        .set_community_node_local_consent_update_pending(base_url.as_str(), true)
+        .await;
+
+    let error = runtime
+        .submit_community_node_report(appeal_request(base_url.as_str()))
+        .await
+        .expect_err("report while reconsent is pending must be rejected");
+
+    assert_eq!(error.code, CONSENT_REQUIRED_CODE);
+    assert!(state.received.lock().await.is_empty());
 
     runtime.shutdown().await;
     server.abort();

--- a/crates/desktop-runtime/src/tests/community_node/session.rs
+++ b/crates/desktop-runtime/src/tests/community_node/session.rs
@@ -315,6 +315,7 @@ async fn node_without_local_consent_is_never_contacted() {
         .route("/v1/consents/status", get(mock_managed_consent_status))
         .route("/v1/consents", post(mock_managed_accept_consents))
         .route("/v1/policies", get(mock_managed_policies))
+        .route("/v1/node/manifest", get(mock_managed_manifest))
         .route(
             "/v1/bootstrap/heartbeat",
             post(mock_managed_bootstrap_heartbeat),
@@ -375,6 +376,19 @@ async fn node_without_local_consent_is_never_contacted() {
         .expect("fetch policies");
     assert_eq!(state.policies_hits.load(Ordering::SeqCst), 1);
     assert_eq!(catalog.policies.len(), 1);
+
+    // 公開manifestも同意判断に必要な明示取得として許可する。
+    let manifest = runtime
+        .fetch_community_node_manifest(crate::CommunityNodeTargetRequest {
+            base_url: base_url.clone(),
+        })
+        .await
+        .expect("fetch manifest");
+    assert_eq!(
+        manifest.status,
+        crate::CommunityNodeManifestFetchStatus::Absent
+    );
+    assert_eq!(state.manifest_hits.load(Ordering::SeqCst), 1);
 
     // 同意モーダルでの受諾 → ローカル記録 → セッション確立(認証・サーバ同期)。
     let accepted = runtime
@@ -476,6 +490,7 @@ async fn community_node_status_does_not_require_restart_when_connectivity_is_act
         },
     )
     .expect("persist community-node token");
+    seed_local_community_node_consents(&runtime, base_url.as_str(), 1);
     *runtime.community_node_config.lock().await = CommunityNodeConfig {
         nodes: vec![node.clone()],
     };

--- a/crates/desktop-runtime/src/tests/support/lock_contract.rs
+++ b/crates/desktop-runtime/src/tests/support/lock_contract.rs
@@ -22,7 +22,7 @@ const LOCK_CLASSIFICATION: &[(&str, &str, usize)] = &[
     (
         "community_node/report_submission.rs",
         "CommunityNodeServer",
-        5,
+        8,
     ),
     ("community_node/scheduler.rs", "CommunityNodeServer", 5),
     ("community_node/session.rs", "CommunityNodeServer", 6),
@@ -106,9 +106,9 @@ fn lock_acquisitions_match_declared_classification() {
     );
     let total: usize = expected.values().sum();
     assert_eq!(
-        total, 93,
+        total, 96,
         "classification total drifted from the Q7 T6 baseline(#711 で index_query 試験を 1 件、\
          #802 で tester_feedback_submission 試験を 3 件、#862 で config 永続化試験を 2 件、\
-         #855 で device_backup 試験を 7 件へ拡充)"
+         #855 で device_backup 試験を 7 件へ拡充、#857 で report consent gate 試験を 3 件追加)"
     );
 }

--- a/crates/desktop-runtime/src/tests/support/mock_cn.rs
+++ b/crates/desktop-runtime/src/tests/support/mock_cn.rs
@@ -6,6 +6,7 @@ pub(crate) async fn apply_relay_backed_community_node_seed_peers(
     relay_url: &str,
     seed_peers: Vec<CommunityNodeSeedPeer>,
 ) {
+    seed_local_community_node_consents(runtime, base_url, 1);
     *runtime.community_node_config.lock().await = CommunityNodeConfig {
         nodes: vec![CommunityNodeNodeConfig {
             base_url: base_url.to_string(),
@@ -194,6 +195,7 @@ pub(crate) struct MockManagedCommunityNodeState {
     pub(crate) bootstrap_hits: Arc<AtomicUsize>,
     // #857: 認証不要の公開 policy カタログ(GET /v1/policies)の観測カウンタ。
     pub(crate) policies_hits: Arc<AtomicUsize>,
+    pub(crate) manifest_hits: Arc<AtomicUsize>,
     // true の場合、未同意状態を「版が上がった更新（旧版は同意済み）」として返す。
     // ローカル同意が旧版のままの node で黙って再受諾しない挙動の検証に使う（#384 / #857）。
     pub(crate) simulate_pending_update: Arc<AtomicBool>,
@@ -218,6 +220,7 @@ impl MockManagedCommunityNodeState {
             heartbeat_hits: Arc::new(AtomicUsize::new(0)),
             bootstrap_hits: Arc::new(AtomicUsize::new(0)),
             policies_hits: Arc::new(AtomicUsize::new(0)),
+            manifest_hits: Arc::new(AtomicUsize::new(0)),
             simulate_pending_update: Arc::new(AtomicBool::new(false)),
         }
     }
@@ -281,6 +284,13 @@ pub(crate) async fn mock_managed_policies(
         }],
         policy_snapshot_revision: None,
     })
+}
+
+pub(crate) async fn mock_managed_manifest(
+    State(state): State<Arc<MockManagedCommunityNodeState>>,
+) -> StatusCode {
+    state.manifest_hits.fetch_add(1, Ordering::SeqCst);
+    StatusCode::NOT_FOUND
 }
 
 pub(crate) fn managed_community_node_consent_status(accepted: bool) -> CommunityNodeConsentStatus {

--- a/crates/harness/src/scenarios/community_node.rs
+++ b/crates/harness/src/scenarios/community_node.rs
@@ -174,6 +174,33 @@ pub(crate) async fn run_community_node_connectivity(
             })
             .await
             .context("failed to configure community node for desktop b")?;
+        for (label, runtime) in [("desktop a", &runtime_a), ("desktop b", &runtime_b)] {
+            let status = runtime
+                .get_sync_status()
+                .await
+                .with_context(|| format!("failed to read {label} status before consent"))?;
+            anyhow::ensure!(
+                status.discovery.connect_mode == ConnectMode::DirectOnly,
+                "{label} enabled relay connectivity before community-node consent"
+            );
+            anyhow::ensure!(
+                status.discovery.bootstrap_seed_peer_ids.is_empty(),
+                "{label} applied community-node bootstrap seeds before consent: {:?}",
+                status.discovery.bootstrap_seed_peer_ids
+            );
+            let node_status = runtime
+                .get_community_node_statuses()
+                .await
+                .with_context(|| format!("failed to read {label} node status before consent"))?
+                .into_iter()
+                .next()
+                .with_context(|| format!("missing {label} node status before consent"))?;
+            anyhow::ensure!(
+                !node_status.local_consent.has_active_consent()
+                    && !node_status.auth_state.authenticated,
+                "{label} established a community-node session before consent"
+            );
+        }
         push_named_step(&mut steps, "configure_community_node", started_at);
 
         // #857: 同意モーダル相当のフロー — 認証(JWT 発行)前に公開カタログを取得し、
@@ -1050,6 +1077,110 @@ pub(crate) async fn run_community_node_connectivity(
         )
         .await
         .context("desktop a did not receive reconnect reaction summary")?;
+
+        if identity_mode == CommunityNodeIdentityMode::DistinctUsers {
+            let started_at = Instant::now();
+            let withdrawn_a = runtime_a
+                .withdraw_community_node_consents(CommunityNodeTargetRequest {
+                    base_url: stack.base_url.clone(),
+                })
+                .await
+                .context("failed to withdraw desktop a community-node consent")?;
+            let withdrawn_b = runtime_b
+                .withdraw_community_node_consents(CommunityNodeTargetRequest {
+                    base_url: stack.base_url.clone(),
+                })
+                .await
+                .context("failed to withdraw desktop b community-node consent")?;
+            anyhow::ensure!(
+                !withdrawn_a.local_consent.has_active_consent()
+                    && !withdrawn_b.local_consent.has_active_consent()
+                    && !withdrawn_a.auth_state.authenticated
+                    && !withdrawn_b.auth_state.authenticated,
+                "community-node consent withdrawal did not stop both sessions"
+            );
+            for (label, runtime) in [("desktop a", &runtime_a), ("desktop b", &runtime_b)] {
+                let status = runtime
+                    .get_sync_status()
+                    .await
+                    .with_context(|| format!("failed to read {label} status after withdrawal"))?;
+                anyhow::ensure!(
+                    status.discovery.connect_mode == ConnectMode::DirectOnly,
+                    "{label} retained relay connectivity after consent withdrawal"
+                );
+                anyhow::ensure!(
+                    status.discovery.bootstrap_seed_peer_ids.is_empty(),
+                    "{label} retained community-node bootstrap seeds after withdrawal: {:?}",
+                    status.discovery.bootstrap_seed_peer_ids
+                );
+                anyhow::ensure!(
+                    status
+                        .topic_diagnostics
+                        .iter()
+                        .all(|diagnostic| diagnostic.rendezvous_peer_ids.is_empty()),
+                    "{label} retained rendezvous peers after consent withdrawal"
+                );
+            }
+            // consent withdrawal は Node 由来 transport を再構築する。以後も利用者が
+            // 再構築後に発行した明示ticketを取り込めば、Nodeを経由せず直接P2Pを再確立できる。
+            let ticket_a = runtime_a
+                .local_peer_ticket()
+                .await
+                .context("failed to export desktop a ticket after consent withdrawal")?
+                .context("missing desktop a ticket after consent withdrawal")?;
+            let ticket_b = runtime_b
+                .local_peer_ticket()
+                .await
+                .context("failed to export desktop b ticket after consent withdrawal")?
+                .context("missing desktop b ticket after consent withdrawal")?;
+            runtime_a
+                .import_peer_ticket(ImportPeerTicketRequest {
+                    ticket: ticket_b.clone(),
+                })
+                .await
+                .context("failed to re-import desktop b ticket after consent withdrawal")?;
+            runtime_b
+                .import_peer_ticket(ImportPeerTicketRequest {
+                    ticket: ticket_a.clone(),
+                })
+                .await
+                .context("failed to re-import desktop a ticket after consent withdrawal")?;
+            for (label, runtime) in [("desktop a", &runtime_a), ("desktop b", &runtime_b)] {
+                runtime
+                    .list_timeline(ListTimelineRequest {
+                        topic: topic.to_string(),
+                        scope: TimelineScope::Public,
+                        cursor: None,
+                        limit: Some(20),
+                    })
+                    .await
+                    .with_context(|| {
+                        format!("failed to resubscribe {label} after consent withdrawal")
+                    })?;
+            }
+            for (label, runtime) in [("desktop a", &runtime_a), ("desktop b", &runtime_b)] {
+                wait_for_topic_delivery(runtime, topic, 1, reconnect_timeout)
+                    .await
+                    .with_context(|| {
+                        format!("{label} did not restore direct P2P after consent withdrawal")
+                    })?;
+            }
+            let _direct_post = replicate_public_post_with_retry(
+                &runtime_a,
+                &runtime_b,
+                topic,
+                "direct p2p after community node consent withdrawal",
+                reconnect_timeout,
+                PublicReplicationDirection::PreferDirectConnectedSubscriber,
+                PublicReplicationLabels {
+                    failure: "direct post after community-node consent withdrawal",
+                    publisher: "desktop a",
+                    subscriber: "desktop b",
+                },
+            )
+            .await?;
+            push_named_step(&mut steps, "consent_withdrawal_direct_p2p", started_at);
+        }
         let metrics_snapshot = if scenario.artifacts.metrics_snapshot {
             Some(
                 runtime_b

--- a/crates/harness/src/waiters/replication.rs
+++ b/crates/harness/src/waiters/replication.rs
@@ -242,7 +242,18 @@ pub(crate) async fn refresh_public_pair(
     }
 
     async fn force_public_runtime_connectivity(runtime: &DesktopRuntime) {
-        let _ = runtime.reapply_community_node_connectivity().await;
+        let has_active_node_consent =
+            runtime
+                .get_community_node_statuses()
+                .await
+                .is_ok_and(|statuses| {
+                    statuses
+                        .iter()
+                        .any(|status| status.local_consent.has_active_consent())
+                });
+        if has_active_node_consent {
+            let _ = runtime.reapply_community_node_connectivity().await;
+        }
     }
 
     let refresh_interval = Duration::from_secs(5);

--- a/docs/progress/2026-09-03-issue-857-community-node-consent-allowlist-rerun.md
+++ b/docs/progress/2026-09-03-issue-857-community-node-consent-allowlist-rerun.md
@@ -1,0 +1,32 @@
+# Issue #857 Community Node consent allowlist rerun
+
+## Summary
+
+無償 Preview 公開のブロッカー（#853 Phase A）であるアプリ同意と Community Node 同意の分離について、再監査で不足していた通信境界を補強した。Node ごとのローカル同意が有効な場合だけ、その Node の report、relay、bootstrap seed、topic rendezvous peer を利用できる。保存済み設定と `resolved_urls` は保持しつつ、起動時・設定変更時・同意更新時に実効 connectivity を fail-closed で再構築する。
+
+アプリ同意、Community Node の公開ポリシー取得、公開 manifest 取得は pre-consent allowlist のまま維持する。Node consent がない状態、撤回後、再同意待ちでは、認証 session、heartbeat、report、relay/seed/P2P assist を許可しない。
+
+## 実装内容
+
+- report 境界（`crates/desktop-runtime/src/community_node/report_routing_support.rs`）: same-origin と設定済み Node の検証に加え、Node ごとの active local consent と session の再同意待ち状態を送信前に検証する。同意なし・撤回後・再同意待ちは `CONSENT_REQUIRED` で停止し、HTTP POST が発生しない contract を追加した。匿名 report payload の既存仕様は変更していない。
+- 実効 connectivity（`crates/desktop-runtime/src/community_node/config_support.rs`、`session_runtime_support.rs`、`runtime/mod.rs`）: 保存済み Node 設定から active local consent を持つ Node だけを relay/seed の実効設定へ射影する。topic rendezvous peer は Node URL ごとに保持し、同意撤回、Node 削除、設定 clear、再同意待ちへの遷移で該当 Node の relay、bootstrap seed、rendezvous peer を即時除外する。保存済み `resolved_urls` は破棄しないため、再同意後は明示的な再取得なしで再適用できる。
+- API と harness（`crates/desktop-runtime/src/runtime/community_node_api.rs`、`crates/harness/src`）: consent accept 後の再適用と withdraw 後の無効化を runtime API 境界へ固定した。harness の接続再適用も active consent を条件にし、撤回後に Node assist が復活しないようにした。
+- allowlist contract: pre-consent で許可されるのは公開 policies と公開 manifest だけであり、認証・heartbeat 等へ進まないことを request hit 数で検証する。report は未同意、撤回後、再同意待ちの全ケースで 0 hit を確認する。起動時の保存済み relay/seed と複数 Node の per-node filtering も unit test で固定した。
+- 実通信 scenario（`community_node_public_connectivity`）: Node-assisted 接続を成立させた後に両クライアントの Node consent を撤回し、relay、bootstrap seed、rendezvous peer が空になることを確認する。その後に新しい manual ticket だけで Direct P2P を再確立し、投稿が複製されることを確認する。
+
+## 検証
+
+- `cargo test -p kukuri-desktop-runtime tests::community_node::report_submission -- --nocapture`: 8 件成功
+- `cargo test -p kukuri-desktop-runtime tests::community_node::config -- --nocapture`: 12 件成功
+- `cargo test -p kukuri-desktop-runtime tests::community_node::session -- --nocapture`: 6 件成功
+- `cargo test -p kukuri-desktop-runtime --lib`: 158 件成功
+- `cargo check -p kukuri-desktop-runtime -p kukuri-harness`: 成功
+- `cargo xtask scenario community_node_public_connectivity`: 15 step 成功
+- `cargo xtask doctor`: 成功
+- `cargo xtask check`: 成功
+- `cargo xtask cn-check`: 成功
+- `cargo xtask cn-test`: Community Node 全crateの unit / contract / integration / doc test 成功
+- `cargo xtask test`: Rust 754 件、harness 22 件、frontend 1074 件すべて成功（Rust 3 件 skip）
+- `cargo xtask e2e-smoke`: 成功
+
+関連: #853（親）、#857

--- a/docs/progress/2026-09-03-issue-857-community-node-consent-allowlist-rerun.md
+++ b/docs/progress/2026-09-03-issue-857-community-node-consent-allowlist-rerun.md
@@ -26,6 +26,7 @@
 - `cargo xtask check`: 成功
 - `cargo xtask cn-check`: 成功
 - `cargo xtask cn-test`: Community Node 全crateの unit / contract / integration / doc test 成功
+- `cargo xtask oversized-files`: 成功（Community Node scenario の 15 step 化を baseline へ記録）
 - `cargo xtask test`: Rust 754 件、harness 22 件、frontend 1074 件すべて成功（Rust 3 件 skip）
 - `cargo xtask e2e-smoke`: 成功
 

--- a/xtask/oversized-baseline.json
+++ b/xtask/oversized-baseline.json
@@ -9,6 +9,10 @@
       "path": "crates/cn-operator/src/config.rs"
     },
     {
+      "lines": 1228,
+      "path": "crates/harness/src/scenarios/community_node.rs"
+    },
+    {
       "lines": 1191,
       "path": "crates/metaverse-host/src/lib.rs"
     },
@@ -27,10 +31,6 @@
     {
       "lines": 1097,
       "path": "crates/app-api/src/service/private_channels_support.rs"
-    },
-    {
-      "lines": 1097,
-      "path": "crates/harness/src/scenarios/community_node.rs"
     },
     {
       "lines": 1096,


### PR DESCRIPTION
## 概要

- Node ごとの active local consent を report・relay・bootstrap seed・topic rendezvous peer の共通通信境界にしました。
- 未同意・撤回後・再同意待ちは fail-closed とし、保存済み resolved_urls は保持したまま実効 connectivity から除外します。
- pre-consent allowlist、撤回後の Direct P2P、report の HTTP 送信前停止を unit / scenario で固定しました。

## 検証

- cargo xtask doctor
- cargo xtask check
- cargo xtask test
- cargo xtask cn-check
- cargo xtask cn-test
- cargo xtask e2e-smoke
- cargo xtask scenario community_node_public_connectivity
- 対象 desktop-runtime tests（report 8、config 12、session 6、lib 158）

Closes #857
## 大型ファイルbaselineの正当化

既存の `crates/harness/src/scenarios/community_node.rs` は #857 の受入条件を実通信で固定するため、同意前のrelay/seed非適用と、同意撤回後のNode assist除去・Direct P2P再確立を同一のend-to-end lifecycleへ追加し、1097行から1228行へ増加しました。これは既存scenarioの段階的拡張であり、1500行未満かつ責務はCommunity Node connectivity検証のままです。`REFACTORING.md` のratchet手順に従って `xtask/oversized-baseline.json` を更新しました。
