### PR TITLE
docs: align avatar and operator language contracts

### DIFF
--- a/docs/adr/0019-profile-avatar-blob-data-classification.md
+++ b/docs/adr/0019-profile-avatar-blob-data-classification.md
@@ -35,7 +35,7 @@ Accepted
 
 profile avatar は URL 文字列を primary source にしない。current `main` では、public author replica に保存された author-signed profile envelope/doc を header とし、画像本体は blob として同期する。
 
-legacy `picture` URL は read compatibility のため維持してよいが、新規 desktop UI の primary write path は blob-backed avatar に固定する。
+raw `picture` URL は data model と read / write path から除外し、互換読込を提供しない。desktop UI の avatar path は blob-backed `picture_asset` に固定する。
 
 ## Data Model
 
@@ -56,7 +56,7 @@ legacy `picture` URL は read compatibility のため維持してよいが、新
 
 1. profile / author detail は `picture_asset` があればそれを優先する
 2. client は既存の blob fetch path で avatar blob を lazy fetch する
-3. `picture_asset` がない場合だけ legacy `picture` URL を fallback として使う
+3. `picture_asset` がない場合は placeholder を表示し、外部 URL へ fallback しない
 
 ## Non-Goals
 

--- a/docs/runbooks/community-node-operator-docs.md
+++ b/docs/runbooks/community-node-operator-docs.md
@@ -182,7 +182,8 @@ dist/operator-docs/
 ## 法務文書の版管理と公開
 
 `legal` を設定した Node は、`server.contact`、15個の `retention.*_days`、7文書すべての
-slug、正の整数 version、ISO 形式の施行日、正文言語 `ja`、required を明示する。法務文書を
+slug、正の整数 version、ISO 形式の施行日、対応 renderer である正文言語 `ja` または
+`en`、required を明示する。法務文書を
 コード上の保持期間既定値で公開することはできない。利用規約とプライバシーポリシーだけを
 required とし、残りは公開開示文書として扱う。
 


### PR DESCRIPTION
## 概要

- ADR 0019からlegacyプロフィール画像URLのread compatibilityを削除し、picture_assetまたはplaceholderだけを使うasset-only contractへ同期
- Community Node operator runbookの正文言語要件を、対応rendererである ja または en へ同期

## 検証

- cargo test -p kukuri-cn-operator（113件成功）
- cargo test -p kukuri-core profile_parser_ignores_removed_picture_url_field -- --nocapture（1件成功）
- cargo xtask oversized-files
- git diff --check

Closes #854
Closes #860