### PR TITLE
fix: Community Node同意preflightの固定残件を解消

### DIFF
--- a/apps/desktop/src-tauri/src/commands/community_node.rs
+++ b/apps/desktop/src-tauri/src/commands/community_node.rs
@@ -368,18 +368,6 @@ pub async fn clear_community_node_token(
         .map_err(map_error)
 }
 
-#[tauri::command]
-pub async fn get_community_node_consent_status(
-    state: tauri::State<'_, DesktopState>,
-    request: CommunityNodeTargetRequest,
-) -> Result<CommunityNodeNodeStatus, CommandError> {
-    state
-        .runtime()
-        .get_community_node_consent_status(request)
-        .await
-        .map_err(map_error)
-}
-
 /// #857: 認証不要の公開 policy カタログ。同意モーダルの提示内容を組み立てるために呼ぶ。
 #[tauri::command]
 pub async fn fetch_community_node_policies(

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -264,7 +264,6 @@ pub fn run() {
             commands::community_node::authenticate_community_node,
             commands::community_node::set_community_node_invite_code,
             commands::community_node::clear_community_node_token,
-            commands::community_node::get_community_node_consent_status,
             commands::community_node::fetch_community_node_policies,
             commands::community_node::accept_community_node_consents,
             commands::community_node::withdraw_community_node_consents,

--- a/apps/desktop/src/components/settings/CommunityNodePanel.tsx
+++ b/apps/desktop/src/components/settings/CommunityNodePanel.tsx
@@ -38,7 +38,7 @@ type CommunityNodePanelProps = {
     documents: CommunityNodeConsentDocumentRef[]
   ) => void | Promise<void>;
   onWithdrawConsents?: (baseUrl: string) => void | Promise<void>;
-  onRefresh: (baseUrl: string) => void;
+  onRefresh: (baseUrl: string) => boolean | void | Promise<boolean | void>;
   onClearToken: (baseUrl: string) => void;
   onSubmitInviteCode: (baseUrl: string, inviteCode: string) => Promise<void>;
   onGetRelationOptout?: (baseUrl: string) => Promise<RelationOptoutResponse>;
@@ -169,6 +169,22 @@ export function CommunityNodePanel({
       );
     } finally {
       setConsentBusy(false);
+    }
+  }
+
+  async function refreshCommunityNode(node: CommunityNodePanelView['nodes'][number]) {
+    const knownConsentRequired =
+      !node.consent.hasLocalConsent ||
+      node.consent.withdrawn ||
+      node.consent.hasPendingUpdate ||
+      (node.consent.loaded && !node.consent.allRequiredAccepted);
+    if (knownConsentRequired) {
+      await openConsentDialog(node.baseUrl);
+      return;
+    }
+    const consentRequired = await onRefresh(node.baseUrl);
+    if (consentRequired) {
+      await openConsentDialog(node.baseUrl);
     }
   }
 
@@ -425,7 +441,7 @@ export function CommunityNodePanel({
                 <Button
                   variant='secondary'
                   disabled={nodeActionsDisabled || !node.saved || !node.baseUrl.trim()}
-                  onClick={() => onRefresh(node.baseUrl)}
+                  onClick={() => void refreshCommunityNode(node)}
                 >
                   {t('common:actions.refresh')}
                 </Button>

--- a/apps/desktop/src/components/settings/SettingsPanels.test.tsx
+++ b/apps/desktop/src/components/settings/SettingsPanels.test.tsx
@@ -272,6 +272,91 @@ test('community node consent dialog shows policy body, version, and update notic
   ]);
 });
 
+test('community node refresh opens consent dialog without protected refresh when consent is missing', async () => {
+  const user = userEvent.setup();
+  const onFetchConsents = vi.fn().mockResolvedValue(undefined);
+  const onRefresh = vi.fn().mockResolvedValue(false);
+  const communityNodePanelFixture = createCommunityNodePanelFixture();
+  const view = {
+    ...communityNodePanelFixture,
+    nodes: communityNodePanelFixture.nodes.map((node, index) =>
+      index === 0
+        ? {
+            ...node,
+            consent: {
+              ...node.consent,
+              hasLocalConsent: false,
+              allRequiredAccepted: false,
+            },
+          }
+        : node
+    ),
+  };
+
+  render(
+    <CommunityNodePanel
+      view={view}
+      saveDisabled={false}
+      resetDisabled={false}
+      clearDisabled={false}
+      onAddNode={() => {}}
+      onNodeBaseUrlChange={() => {}}
+      onRemoveNode={() => {}}
+      onSaveNodes={() => {}}
+      onReset={() => {}}
+      onClearNodes={() => {}}
+      onAuthenticate={() => {}}
+      onSubmitInviteCode={async () => {}}
+      onFetchConsents={onFetchConsents}
+      onAcceptConsents={() => {}}
+      onWithdrawConsents={() => {}}
+      onRefresh={onRefresh}
+      onClearToken={() => {}}
+    />
+  );
+
+  await user.click(screen.getAllByRole('button', { name: 'Refresh' })[0]);
+
+  expect(onRefresh).not.toHaveBeenCalled();
+  expect(onFetchConsents).toHaveBeenCalledWith('https://api.kukuri.app');
+  expect(await screen.findByRole('dialog')).toBeInTheDocument();
+});
+
+test('community node refresh opens consent dialog when runtime detects a policy update', async () => {
+  const user = userEvent.setup();
+  const onFetchConsents = vi.fn().mockResolvedValue(undefined);
+  const onRefresh = vi.fn().mockResolvedValue(true);
+  const communityNodePanelFixture = createCommunityNodePanelFixture();
+
+  render(
+    <CommunityNodePanel
+      view={communityNodePanelFixture}
+      saveDisabled={false}
+      resetDisabled={false}
+      clearDisabled={false}
+      onAddNode={() => {}}
+      onNodeBaseUrlChange={() => {}}
+      onRemoveNode={() => {}}
+      onSaveNodes={() => {}}
+      onReset={() => {}}
+      onClearNodes={() => {}}
+      onAuthenticate={() => {}}
+      onSubmitInviteCode={async () => {}}
+      onFetchConsents={onFetchConsents}
+      onAcceptConsents={() => {}}
+      onWithdrawConsents={() => {}}
+      onRefresh={onRefresh}
+      onClearToken={() => {}}
+    />
+  );
+
+  await user.click(screen.getAllByRole('button', { name: 'Refresh' })[0]);
+
+  expect(onRefresh).toHaveBeenCalledWith('https://api.kukuri.app');
+  expect(onFetchConsents).toHaveBeenCalledWith('https://api.kukuri.app');
+  expect(await screen.findByRole('dialog')).toBeInTheDocument();
+});
+
 test('community node consent dialog disables accept when latest policy fetch fails', async () => {
   const user = userEvent.setup();
   const onFetchConsents = vi.fn().mockRejectedValue(new Error('offline'));

--- a/apps/desktop/src/lib/api/commands/runtimeApi.ts
+++ b/apps/desktop/src/lib/api/commands/runtimeApi.ts
@@ -852,13 +852,6 @@ export const runtimeApi: DesktopApi = {
       } satisfies CommunityNodeTargetRequest,
     });
   }),
-  getCommunityNodeConsentStatus: command('getCommunityNodeConsentStatus', async (baseUrl) => {
-    return invokeDesktop<CommunityNodeNodeStatus>('get_community_node_consent_status', {
-      request: {
-        base_url: baseUrl,
-      } satisfies CommunityNodeTargetRequest,
-    });
-  }),
   fetchCommunityNodePolicies: command('fetchCommunityNodePolicies', async (baseUrl, language) => {
     return invokeDesktop<CommunityNodePoliciesResponse>('fetch_community_node_policies', {
       request: {

--- a/apps/desktop/src/lib/api/types.ts
+++ b/apps/desktop/src/lib/api/types.ts
@@ -488,7 +488,6 @@ export interface DesktopApi {
     inviteCode: string | null
   ): Promise<CommunityNodeNodeStatus>;
   clearCommunityNodeToken(baseUrl: string): Promise<CommunityNodeNodeStatus>;
-  getCommunityNodeConsentStatus(baseUrl: string): Promise<CommunityNodeNodeStatus>;
   // #857: 認証不要の公開 policy カタログ。同意モーダルの提示内容を組み立てる。
   fetchCommunityNodePolicies(
     baseUrl: string,

--- a/apps/desktop/src/mocks/api/connectivity.ts
+++ b/apps/desktop/src/mocks/api/connectivity.ts
@@ -20,7 +20,6 @@ type ConnectivityMock = Pick<
   | 'authenticateCommunityNode'
   | 'setCommunityNodeInviteCode'
   | 'clearCommunityNodeToken'
-  | 'getCommunityNodeConsentStatus'
   | 'fetchCommunityNodePolicies'
   | 'acceptCommunityNodeConsents'
   | 'withdrawCommunityNodeConsents'
@@ -164,9 +163,6 @@ export function createConnectivityMock(runtime: MockRuntime): ConnectivityMock {
             }
           : status
       );
-      return runtime.communityNodeStatuses.find((status) => status.base_url === baseUrl)!;
-    },
-    async getCommunityNodeConsentStatus(baseUrl) {
       return runtime.communityNodeStatuses.find((status) => status.base_url === baseUrl)!;
     },
     // #857: 認証不要の公開 policy カタログ。consent items と同じ slug / 版を返す。

--- a/apps/desktop/src/shell/actions/profileTopicChannel.ts
+++ b/apps/desktop/src/shell/actions/profileTopicChannel.ts
@@ -685,12 +685,21 @@ export function createProfileTopicChannelActions({
       setCommunityNodeConfig((current) => syncCommunityNodeConfigWithStatus(current, nextStatus));
       setCommunityNodeError(null);
       await loadTopics(trackedTopics, activeTopic, selectedThread);
+      const localConsent = nextStatus.local_consent;
+      return (
+        nextStatus.consent_update_pending === true ||
+        localConsent == null ||
+        localConsent.records.length === 0 ||
+        localConsent.withdrawn_at != null ||
+        nextStatus.consent_state?.all_required_accepted === false
+      );
     } catch (refreshError) {
       setCommunityNodeError(
         refreshError instanceof Error
           ? refreshError.message
           : translate('common:errors.failedToRefreshCommunityNode')
       );
+      return false;
     }
   }
 

--- a/apps/desktop/src/shell/page/DesktopShellSettingsDrawer.tsx
+++ b/apps/desktop/src/shell/page/DesktopShellSettingsDrawer.tsx
@@ -58,7 +58,7 @@ type DesktopShellSettingsDrawerProps = {
     documents: CommunityNodeConsentDocumentRef[]
   ) => Promise<void>;
   handleWithdrawCommunityNodeConsents: (baseUrl: string) => Promise<void>;
-  handleRefreshCommunityNode: (baseUrl: string) => Promise<void>;
+  handleRefreshCommunityNode: (baseUrl: string) => Promise<boolean>;
   handleClearCommunityNodeToken: (baseUrl: string) => Promise<void>;
   handleCreateCustomReactionAsset: (
     file: File,
@@ -269,7 +269,7 @@ export function DesktopShellSettingsDrawer({
             handleAcceptCommunityNodeConsents(baseUrl, documents)
           }
           onWithdrawConsents={(baseUrl) => handleWithdrawCommunityNodeConsents(baseUrl)}
-          onRefresh={(baseUrl) => void handleRefreshCommunityNode(baseUrl)}
+          onRefresh={handleRefreshCommunityNode}
           onClearToken={(baseUrl) => void handleClearCommunityNodeToken(baseUrl)}
           onGetRelationOptout={(baseUrl) => api.getCommunityNodeRelationOptout(baseUrl)}
           onSetRelationOptout={(baseUrl) => api.setCommunityNodeRelationOptout(baseUrl)}

--- a/crates/desktop-runtime/src/community_node/consent_preflight_support.rs
+++ b/crates/desktop-runtime/src/community_node/consent_preflight_support.rs
@@ -1,0 +1,73 @@
+use super::*;
+
+#[derive(Clone, Debug)]
+pub(crate) enum CommunityNodeConsentPreflight {
+    Current {
+        base_url: String,
+        local_consent: CommunityNodeLocalConsentState,
+    },
+    Required {
+        base_url: String,
+        local_consent: CommunityNodeLocalConsentState,
+        policy_update: bool,
+    },
+}
+
+impl CommunityNodeConsentPreflight {
+    pub(crate) fn base_url(&self) -> &str {
+        match self {
+            Self::Current { base_url, .. } | Self::Required { base_url, .. } => base_url,
+        }
+    }
+
+    pub(crate) fn local_consent(&self) -> &CommunityNodeLocalConsentState {
+        match self {
+            Self::Current { local_consent, .. } | Self::Required { local_consent, .. } => {
+                local_consent
+            }
+        }
+    }
+}
+
+impl DesktopRuntime {
+    /// Community Node の token・認証・保護 API より前に必ず通す同意境界。
+    ///
+    /// 設定 membership と active local consent を先に確認し、active な場合だけ公開
+    /// policy catalog を取得して、required 文書の版と snapshot revision を照合する。
+    /// session や connectivity は変更せず、呼び出し元が結果に応じた状態遷移を行う。
+    pub(crate) async fn preflight_community_node_consent(
+        &self,
+        raw_base_url: &str,
+    ) -> Result<CommunityNodeConsentPreflight> {
+        let base_url = normalize_http_url(raw_base_url)?;
+        self.require_community_node(base_url.as_str()).await?;
+        let local_consent = load_community_node_local_consents(
+            &self.db_path,
+            self.identity_mode,
+            base_url.as_str(),
+        )?;
+        if !local_consent.has_active_consent() {
+            return Ok(CommunityNodeConsentPreflight::Required {
+                base_url,
+                local_consent,
+                policy_update: false,
+            });
+        }
+
+        let catalog = self
+            .request_community_node_policies(base_url.as_str(), None)
+            .await?;
+        if !community_node_local_consent_satisfies_policies(&local_consent, &catalog.policies) {
+            return Ok(CommunityNodeConsentPreflight::Required {
+                base_url,
+                local_consent,
+                policy_update: true,
+            });
+        }
+
+        Ok(CommunityNodeConsentPreflight::Current {
+            base_url,
+            local_consent,
+        })
+    }
+}

--- a/crates/desktop-runtime/src/community_node/consent_storage_support.rs
+++ b/crates/desktop-runtime/src/community_node/consent_storage_support.rs
@@ -67,7 +67,7 @@ pub(crate) fn persist_community_node_local_consents(
     )
 }
 
-/// 公開カタログ(`GET /v1/policies`)の required 文書すべてを、現行版以上で
+/// 公開カタログ(`GET /v1/policies`)の required 文書すべてを、現行版・snapshotで
 /// ローカル同意済みか。認証(JWT 発行)を開始してよいかの判定に使う。
 pub(crate) fn community_node_local_consent_satisfies_policies(
     state: &CommunityNodeLocalConsentState,
@@ -80,18 +80,13 @@ pub(crate) fn community_node_local_consent_satisfies_policies(
             .all(|policy| {
                 state.records.iter().any(|record| {
                     record.policy_slug == policy.policy_slug
-                        && record.policy_version >= policy.policy_version
-                        && policy
-                            .policy_snapshot_revision
-                            .as_ref()
-                            .is_none_or(|revision| {
-                                record.policy_snapshot_revision.as_ref() == Some(revision)
-                            })
+                        && record.policy_version == policy.policy_version
+                        && record.policy_snapshot_revision == policy.policy_snapshot_revision
                 })
             })
 }
 
-/// サーバの consent status が示す required 文書すべてを現行版以上でローカル同意済みか。
+/// サーバの consent status が示す required 文書すべてを現行版・snapshotでローカル同意済みか。
 /// 真なら POST /v1/consents での同期(auto 受諾)を許可し、偽なら再同意待ちとして
 /// セッションを進めない(#857: 重要変更時の再同意)。
 pub(crate) fn community_node_local_consent_covers_status(
@@ -106,13 +101,8 @@ pub(crate) fn community_node_local_consent_covers_status(
             .all(|item| {
                 state.records.iter().any(|record| {
                     record.policy_slug == item.policy_slug
-                        && record.policy_version >= item.policy_version
-                        && item
-                            .policy_snapshot_revision
-                            .as_ref()
-                            .is_none_or(|revision| {
-                                record.policy_snapshot_revision.as_ref() == Some(revision)
-                            })
+                        && record.policy_version == item.policy_version
+                        && record.policy_snapshot_revision == item.policy_snapshot_revision
                 })
             })
 }
@@ -210,7 +200,7 @@ mod tests {
     }
 
     #[test]
-    fn satisfies_policies_requires_current_or_newer_version_per_required_policy() {
+    fn satisfies_policies_requires_exact_current_version_per_required_policy() {
         let state = CommunityNodeLocalConsentState {
             records: vec![record("terms", 2)],
             withdrawn_at: None,
@@ -218,6 +208,11 @@ mod tests {
         assert!(community_node_local_consent_satisfies_policies(
             &state,
             &[policy("terms", 2, true)]
+        ));
+        // 未公開版の記録でも、現行版との完全一致でなければ成立しない。
+        assert!(!community_node_local_consent_satisfies_policies(
+            &state,
+            &[policy("terms", 1, true)]
         ));
         // 版が上がったら再同意が必要。
         assert!(!community_node_local_consent_satisfies_policies(

--- a/crates/desktop-runtime/src/community_node/dome_hosting_support.rs
+++ b/crates/desktop-runtime/src/community_node/dome_hosting_support.rs
@@ -30,10 +30,7 @@ impl std::fmt::Display for DomeHostingRequestError {
 
 impl std::error::Error for DomeHostingRequestError {}
 
-use super::{
-    community_node_http_client, community_node_local_consent_satisfies_policies,
-    load_community_node_local_consents, load_community_node_token,
-};
+use super::{CommunityNodeConsentPreflight, community_node_http_client, load_community_node_token};
 use crate::runtime::DesktopRuntime;
 
 impl DesktopRuntime {
@@ -51,32 +48,20 @@ impl DesktopRuntime {
                     status: 400,
                 })
             })?;
-        let local_consent = load_community_node_local_consents(
-            &self.db_path,
-            self.identity_mode,
-            base_url.as_str(),
-        )?;
-        if !local_consent.has_active_consent() {
-            return Err(DomeHostingRequestError {
-                code: CONSENT_REQUIRED_CODE.to_string(),
-                message: "community node consent is required before Dome hosting".to_string(),
-                status: 403,
-            }
-            .into());
-        }
-
-        // #857: Dome hostingも認証前に公開policyの現行版を照合する。policy取得は
-        // pre-consent allowlist内だが、token読込・JWT発行・Dome APIはこの判定後に限る。
-        let catalog = self
-            .request_community_node_policies(base_url.as_str(), None)
+        let preflight = self
+            .preflight_community_node_consent(base_url.as_str())
             .await?;
-        if !community_node_local_consent_satisfies_policies(&local_consent, &catalog.policies) {
-            self.set_community_node_local_consent_update_pending(base_url.as_str(), true)
+        if let CommunityNodeConsentPreflight::Required { policy_update, .. } = preflight {
+            self.set_community_node_local_consent_update_pending(base_url.as_str(), policy_update)
                 .await;
+            let message = if policy_update {
+                "current community node policies must be accepted before Dome hosting"
+            } else {
+                "community node consent is required before Dome hosting"
+            };
             return Err(DomeHostingRequestError {
                 code: CONSENT_REQUIRED_CODE.to_string(),
-                message: "current community node policies must be accepted before Dome hosting"
-                    .to_string(),
+                message: message.to_string(),
                 status: 403,
             }
             .into());

--- a/crates/desktop-runtime/src/community_node/mod.rs
+++ b/crates/desktop-runtime/src/community_node/mod.rs
@@ -27,6 +27,7 @@ use crate::paths::community_node_config_path;
 use crate::runtime::DesktopRuntime;
 
 mod config_support;
+mod consent_preflight_support;
 mod consent_storage_support;
 mod dome_hosting_support;
 mod http_client_support;
@@ -45,6 +46,7 @@ mod token_storage_support;
 mod trust_relation_support;
 
 pub(crate) use config_support::*;
+pub(crate) use consent_preflight_support::*;
 pub use consent_storage_support::{
     CommunityNodeLocalConsentRecord, CommunityNodeLocalConsentState,
 };

--- a/crates/desktop-runtime/src/community_node/report_routing_support.rs
+++ b/crates/desktop-runtime/src/community_node/report_routing_support.rs
@@ -173,6 +173,18 @@ impl DesktopRuntime {
         ensure_report_endpoint_origin(base_url.as_str(), endpoint).map_err(|error| {
             CommunityNodeReportError::new("REPORT_ENDPOINT_MISMATCH", error.to_string())
         })?;
+        let preflight = self
+            .preflight_community_node_consent(base_url.as_str())
+            .await
+            .map_err(|error| {
+                CommunityNodeReportError::new("REPORT_CONSENT_CHECK_FAILED", error.to_string())
+            })?;
+        if matches!(preflight, CommunityNodeConsentPreflight::Required { .. }) {
+            return Err(CommunityNodeReportError::new(
+                CONSENT_REQUIRED_CODE,
+                "current community node policies must be accepted before report submission",
+            ));
+        }
         if self
             .community_node_required_consent_is_pending(base_url.as_str())
             .await

--- a/crates/desktop-runtime/src/community_node/session_runtime_support.rs
+++ b/crates/desktop-runtime/src/community_node/session_runtime_support.rs
@@ -2,6 +2,15 @@ use super::*;
 
 impl DesktopRuntime {
     pub(crate) async fn ensure_community_node_session(&self, base_url: &str) -> Result<()> {
+        self.ensure_community_node_session_with_mode(base_url, false)
+            .await
+    }
+
+    pub(crate) async fn ensure_community_node_session_with_mode(
+        &self,
+        base_url: &str,
+        force_refresh: bool,
+    ) -> Result<()> {
         let base_url = normalize_http_url(base_url)?;
         let now = Utc::now().timestamp();
         let session_gate = self
@@ -16,7 +25,7 @@ impl DesktopRuntime {
             return Ok(());
         }
         let retry_after = session_gate.map(|(retry_after, _)| retry_after);
-        if retry_after.is_some_and(|retry_after| retry_after > now) {
+        if !force_refresh && retry_after.is_some_and(|retry_after| retry_after > now) {
             self.set_community_node_session_phase(
                 base_url.as_str(),
                 CommunityNodeSessionPhase::Retrying,
@@ -39,7 +48,7 @@ impl DesktopRuntime {
             return Ok(());
         }
         let retry_after = session_gate.map(|(retry_after, _)| retry_after);
-        if retry_after.is_some_and(|retry_after| retry_after > now) {
+        if !force_refresh && retry_after.is_some_and(|retry_after| retry_after > now) {
             self.set_community_node_session_phase(
                 base_url.as_str(),
                 CommunityNodeSessionPhase::Retrying,
@@ -48,17 +57,17 @@ impl DesktopRuntime {
             return Ok(());
         }
 
-        // #857: 未同意 node へは一切通信しない(公開 manifest / 法務文書の取得は UI 操作
-        // 起点のみ)。scheduler tick もここで止まるため、同意前の登録・認証は発火しない。
-        let local_consent = load_community_node_local_consents(
-            &self.db_path,
-            self.identity_mode,
-            base_url.as_str(),
-        )?;
-        if !local_consent.has_active_consent() {
+        let preflight = self
+            .preflight_community_node_consent(base_url.as_str())
+            .await?;
+        let base_url = preflight.base_url().to_string();
+        let local_consent = preflight.local_consent().clone();
+        if let CommunityNodeConsentPreflight::Required { policy_update, .. } = preflight {
             self.clear_community_node_retry_state(base_url.as_str())
                 .await;
             self.set_community_node_cached_consent(base_url.as_str(), None)
+                .await;
+            self.set_community_node_local_consent_update_pending(base_url.as_str(), policy_update)
                 .await;
             self.set_community_node_session_phase(
                 base_url.as_str(),
@@ -69,6 +78,8 @@ impl DesktopRuntime {
                 .await?;
             return Ok(());
         }
+        self.set_community_node_local_consent_update_pending(base_url.as_str(), false)
+            .await;
 
         let was_ready = self
             .community_node_session_was_ready(base_url.as_str())
@@ -78,7 +89,6 @@ impl DesktopRuntime {
             CommunityNodeSessionPhase::Connecting,
         )
         .await;
-        self.require_community_node(base_url.as_str()).await?;
         let mut token =
             load_community_node_token(&self.db_path, self.identity_mode, base_url.as_str())?;
 
@@ -86,27 +96,6 @@ impl DesktopRuntime {
             .as_ref()
             .is_none_or(|token| Self::community_node_token_requires_refresh(token, now))
         {
-            // #857: 認証(JWT 発行)前に、公開カタログの現行版への同意を確認する。
-            // 版が上がっていたら再同意待ちとして停止し、認証を開始しない。
-            let catalog = self
-                .request_community_node_policies(base_url.as_str(), None)
-                .await?;
-            if !community_node_local_consent_satisfies_policies(&local_consent, &catalog.policies) {
-                self.set_community_node_local_consent_update_pending(base_url.as_str(), true)
-                    .await;
-                self.clear_community_node_retry_state(base_url.as_str())
-                    .await;
-                self.set_community_node_session_phase(
-                    base_url.as_str(),
-                    CommunityNodeSessionPhase::Idle,
-                )
-                .await;
-                self.deactivate_community_node_connectivity(base_url.as_str())
-                    .await?;
-                return Ok(());
-            }
-            self.set_community_node_local_consent_update_pending(base_url.as_str(), false)
-                .await;
             self.set_community_node_session_phase(
                 base_url.as_str(),
                 CommunityNodeSessionPhase::Authenticating,
@@ -169,7 +158,7 @@ impl DesktopRuntime {
         self.refresh_community_node_registration_with_token_if_due(
             base_url.as_str(),
             &mut token,
-            false,
+            force_refresh,
         )
         .await?;
         self.clear_community_node_retry_state(base_url.as_str())
@@ -295,18 +284,9 @@ impl DesktopRuntime {
         let retry_after = session
             .map(|s| s.session_retry_deadline)
             .filter(|deadline| *deadline > now);
-        let session_phase = session.map(|s| s.session_phase).unwrap_or_else(|| {
-            if auth_state.authenticated
-                && consent_state
-                    .as_ref()
-                    .is_none_or(|consent| consent.all_required_accepted)
-                && node.resolved_urls.is_some()
-            {
-                CommunityNodeSessionPhase::Ready
-            } else {
-                CommunityNodeSessionPhase::Idle
-            }
-        });
+        let session_phase = session
+            .map(|s| s.session_phase)
+            .unwrap_or(CommunityNodeSessionPhase::Idle);
         drop(sessions);
         let invite_code_saved = load_community_node_invite_code(
             &self.db_path,

--- a/crates/desktop-runtime/src/runtime/community_node_api.rs
+++ b/crates/desktop-runtime/src/runtime/community_node_api.rs
@@ -192,29 +192,25 @@ impl DesktopRuntime {
     ) -> Result<CommunityNodeNodeStatus> {
         let base_url = normalize_http_url(request.base_url.as_str())?;
         let node = self.require_community_node(base_url.as_str()).await?;
-        // #857: 同意前に認証(JWT 発行)を開始しない。ローカル同意が無ければ拒否し、
-        // 版が上がっていれば再同意待ちとして停止する。
-        let local_consent = load_community_node_local_consents(
-            &self.db_path,
-            self.identity_mode,
-            base_url.as_str(),
-        )?;
-        if !local_consent.has_active_consent() {
-            return Err(anyhow!(
-                "community node consent is required before authentication"
-            ));
-        }
-        let catalog = self
-            .request_community_node_policies(base_url.as_str(), None)
+        let preflight = self
+            .preflight_community_node_consent(base_url.as_str())
             .await?;
-        if !community_node_local_consent_satisfies_policies(&local_consent, &catalog.policies) {
-            self.set_community_node_local_consent_update_pending(base_url.as_str(), true)
+        let local_consent = preflight.local_consent().clone();
+        if let CommunityNodeConsentPreflight::Required { policy_update, .. } = preflight {
+            self.set_community_node_local_consent_update_pending(base_url.as_str(), policy_update)
                 .await;
             self.set_community_node_session_phase(
                 base_url.as_str(),
                 CommunityNodeSessionPhase::Idle,
             )
             .await;
+            self.deactivate_community_node_connectivity(base_url.as_str())
+                .await?;
+            if !policy_update {
+                return Err(anyhow!(
+                    "community node consent is required before authentication"
+                ));
+            }
             return self.community_node_status(node, None, None).await;
         }
         self.set_community_node_local_consent_update_pending(base_url.as_str(), false)
@@ -355,24 +351,6 @@ impl DesktopRuntime {
         self.community_node_status(node, None, None).await
     }
 
-    pub async fn get_community_node_consent_status(
-        &self,
-        request: CommunityNodeTargetRequest,
-    ) -> Result<CommunityNodeNodeStatus> {
-        let base_url = normalize_http_url(request.base_url.as_str())?;
-        let node = self.require_community_node(base_url.as_str()).await?;
-        let mut token =
-            load_community_node_token(&self.db_path, self.identity_mode, base_url.as_str())?
-                .ok_or_else(|| anyhow!("community node authentication is required"))?;
-        let status = self
-            .fetch_community_node_consent_status_with_retry(base_url.as_str(), &mut token, true)
-            .await
-            .context("failed to fetch community node consent status")?;
-        self.set_community_node_cached_consent(base_url.as_str(), Some(status.clone()))
-            .await;
-        self.community_node_status(node, Some(status), None).await
-    }
-
     /// 認証不要の公開 policy カタログ取得(#857)。同意モーダルの提示内容を組み立てる
     /// ために UI 操作起点で呼ぶ。Node 同意前に許可される通信に含まれる。
     pub async fn fetch_community_node_policies(
@@ -418,8 +396,6 @@ impl DesktopRuntime {
             .await;
         self.clear_community_node_retry_state(base_url.as_str())
             .await;
-        self.apply_runtime_connectivity_assist().await?;
-        self.apply_effective_seed_peers().await?;
         self.refresh_community_node_registration_if_due(base_url.as_str())
             .await?;
         let refreshed = self.require_community_node(base_url.as_str()).await?;
@@ -465,28 +441,11 @@ impl DesktopRuntime {
     ) -> Result<CommunityNodeNodeStatus> {
         let base_url = normalize_http_url(request.base_url.as_str())?;
         self.require_community_node(base_url.as_str()).await?;
-        let mut token =
-            load_community_node_token(&self.db_path, self.identity_mode, base_url.as_str())?
-                .ok_or_else(|| anyhow!("community node authentication is required"))?;
-        self.set_community_node_session_phase(
-            base_url.as_str(),
-            CommunityNodeSessionPhase::Refreshing,
-        )
-        .await;
         match self
-            .refresh_community_node_registration_with_token_if_due(
-                base_url.as_str(),
-                &mut token,
-                true,
-            )
+            .ensure_community_node_session_with_mode(base_url.as_str(), true)
             .await
         {
-            Ok(()) => {
-                self.clear_community_node_retry_state(base_url.as_str())
-                    .await;
-                self.set_community_node_session_ready(base_url.as_str(), false)
-                    .await;
-            }
+            Ok(()) => {}
             Err(error) => {
                 // 心拍 401 → 再認証 → 参加拒否(403)の経路は、定期処理と同じく AwaitingAdmission へ
                 // 落として利用者の操作待ちにする。それ以外の失敗は従来どおり呼び出し元へ返す(#708)。

--- a/crates/desktop-runtime/src/runtime/mod.rs
+++ b/crates/desktop-runtime/src/runtime/mod.rs
@@ -47,11 +47,11 @@ use crate::attachments::{
 };
 use crate::community_node::{
     AcceptCommunityNodeConsentsRequest, COMMUNITY_NODE_TOKEN_PURPOSE, CommunityNodeConfig,
-    CommunityNodeIndexQueryError, CommunityNodeIndexQueryRequest, CommunityNodeIndexingRequest,
-    CommunityNodeIndexingRequestError, CommunityNodeManifestFetch, CommunityNodeNodeConfig,
-    CommunityNodeNodeStatus, CommunityNodeReconnectState, CommunityNodeRelationNeighborsRequest,
-    CommunityNodeReportError, CommunityNodeSessionPhase, CommunityNodeSessionState,
-    CommunityNodeTargetRequest, CommunityNodeTesterFeedbackError,
+    CommunityNodeConsentPreflight, CommunityNodeIndexQueryError, CommunityNodeIndexQueryRequest,
+    CommunityNodeIndexingRequest, CommunityNodeIndexingRequestError, CommunityNodeManifestFetch,
+    CommunityNodeNodeConfig, CommunityNodeNodeStatus, CommunityNodeReconnectState,
+    CommunityNodeRelationNeighborsRequest, CommunityNodeReportError, CommunityNodeSessionPhase,
+    CommunityNodeSessionState, CommunityNodeTargetRequest, CommunityNodeTesterFeedbackError,
     CommunityNodeTesterFeedbackResponse, CommunityNodeTesterFeedbackSubmission,
     CommunityNodeTrustRelationError, CommunityNodeUserAdvisoryRequest,
     FetchCommunityNodePoliciesRequest, IndexOperation, IndexQueryResponse,
@@ -59,11 +59,10 @@ use crate::community_node::{
     SetCommunityNodeConfigRequest, SetCommunityNodeInviteCodeRequest,
     SubmitCommunityNodeReportRequest, SubmitCommunityNodeReportResult,
     SubmitIndexingRequestResponse, TrustUserReadResponse,
-    community_node_config_with_active_local_consents, community_node_local_consent_covers_status,
-    community_node_local_consent_satisfies_policies, community_node_seed_peers,
+    community_node_local_consent_covers_status, community_node_seed_peers,
     delete_community_node_invite_code, effective_seed_peer_apply_state,
     load_community_node_config_from_file, load_community_node_local_consents,
-    load_community_node_token, normalize_community_node_config, persist_community_node_invite_code,
+    normalize_community_node_config, persist_community_node_invite_code,
     persist_community_node_local_consents, record_community_node_local_consents,
     relay_config_from_community_node_config, runtime_connectivity_assist_state,
     save_community_node_config,
@@ -305,11 +304,9 @@ impl DesktopRuntime {
             }
             None => CommunityNodeConfig::default(),
         };
-        let active_community_node_config = community_node_config_with_active_local_consents(
-            &db_path,
-            identity_mode,
-            &community_node_config,
-        );
+        // 保存済みの Node relay / seed は、公開 policy とサーバ同意を確認する前の
+        // 起動入力へ渡さない。設定と resolved_urls は保持し、scheduler 成功後に再適用する。
+        let active_community_node_config = CommunityNodeConfig::default();
         let relay_config = relay_config_from_community_node_config(&active_community_node_config);
         let community_node_seed_peers =
             community_node_seed_peers(&active_community_node_config).collect::<Vec<_>>();

--- a/crates/desktop-runtime/src/tests/community_node/config.rs
+++ b/crates/desktop-runtime/src/tests/community_node/config.rs
@@ -56,6 +56,84 @@ async fn persisted_community_node_connectivity_is_not_applied_without_local_cons
 }
 
 #[tokio::test]
+async fn startup_does_not_apply_persisted_community_node_connectivity_before_preflight() {
+    let dir = tempdir().expect("tempdir");
+    let db_path = dir.path().join("community-node-preflight-connectivity.db");
+    let base_url = "https://community.example.com";
+    let relay_url = "https://127.0.0.1:9";
+    let community_seed = CommunityNodeSeedPeer::new(
+        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+        Some("127.0.0.1:9".to_string()),
+    )
+    .expect("community seed");
+    let configured_seed = SeedPeer {
+        endpoint_id: "1111111111111111111111111111111111111111111111111111111111111111".to_string(),
+        addr_hint: Some("127.0.0.1:11001".to_string()),
+    };
+    save_community_node_config(
+        &db_path,
+        &CommunityNodeConfig {
+            nodes: vec![CommunityNodeNodeConfig {
+                base_url: base_url.to_string(),
+                resolved_urls: Some(
+                    CommunityNodeResolvedUrls::new(
+                        base_url,
+                        vec![relay_url.to_string()],
+                        vec![community_seed],
+                    )
+                    .expect("resolved urls"),
+                ),
+            }],
+        },
+    )
+    .expect("save community-node config");
+    let mut local_consent = crate::CommunityNodeLocalConsentState::default();
+    crate::community_node::record_community_node_local_consents(
+        &mut local_consent,
+        &[crate::CommunityNodeConsentDocumentRef {
+            policy_slug: MOCK_MANAGED_POLICY_SLUG.to_string(),
+            policy_version: 1,
+            policy_snapshot_revision: None,
+        }],
+        "ja",
+        "test-app",
+        Utc::now().timestamp(),
+    );
+    crate::community_node::persist_community_node_local_consents(
+        &db_path,
+        IdentityStorageMode::FileOnly,
+        base_url,
+        &local_consent,
+    )
+    .expect("persist local consent");
+    let mut discovery_config = DiscoveryConfig::static_peer_default();
+    discovery_config.seed_peers = vec![configured_seed.clone()];
+
+    let runtime = DesktopRuntime::new_with_config_and_identity_and_discovery(
+        &db_path,
+        TransportNetworkConfig::loopback(),
+        IdentityStorageMode::FileOnly,
+        discovery_config,
+        DhtDiscoveryOptions::disabled(),
+        None,
+    )
+    .await
+    .expect("runtime");
+
+    assert!(runtime.active_connectivity_urls.lock().await.is_empty());
+    let applied = runtime
+        .last_effective_seed_peer_apply_state
+        .lock()
+        .await
+        .clone()
+        .expect("initial effective seed state");
+    assert_eq!(applied.configured_seed_peers, vec![configured_seed]);
+    assert!(applied.bootstrap_seed_peers.is_empty());
+
+    runtime.shutdown().await;
+}
+
+#[tokio::test]
 async fn withdrawing_community_node_consent_removes_transport_assist() {
     let dir = tempdir().expect("tempdir");
     let db_path = dir.path().join("community-node-withdraw-connectivity.db");

--- a/crates/desktop-runtime/src/tests/community_node/index_query.rs
+++ b/crates/desktop-runtime/src/tests/community_node/index_query.rs
@@ -180,6 +180,7 @@ async fn index_runtime(
     let managed_router = Router::new()
         .route("/v1/auth/challenge", post(mock_managed_auth_challenge))
         .route("/v1/auth/verify", post(mock_managed_auth_verify))
+        .route("/v1/policies", get(mock_managed_policies))
         .route("/v1/consents/status", get(mock_managed_consent_status))
         .route("/v1/consents", post(mock_managed_accept_consents))
         .route(

--- a/crates/desktop-runtime/src/tests/community_node/metadata.rs
+++ b/crates/desktop-runtime/src/tests/community_node/metadata.rs
@@ -31,6 +31,7 @@ async fn community_node_status_refresh_updates_bootstrap_seed_peers() {
         bootstrap_hits: Arc::new(AtomicUsize::new(0)),
     });
     let app = Router::new()
+        .route("/v1/policies", get(mock_current_policies))
         .route("/v1/consents/status", get(mock_bootstrap_consent_status))
         .route("/v1/bootstrap/heartbeat", post(mock_bootstrap_heartbeat))
         .route("/v1/bootstrap/nodes", get(mock_bootstrap_nodes))
@@ -121,6 +122,7 @@ async fn community_node_session_maintenance_updates_bootstrap_seed_peers() {
         bootstrap_hits: Arc::new(AtomicUsize::new(0)),
     });
     let app = Router::new()
+        .route("/v1/policies", get(mock_current_policies))
         .route("/v1/consents/status", get(mock_bootstrap_consent_status))
         .route("/v1/bootstrap/heartbeat", post(mock_bootstrap_heartbeat))
         .route("/v1/bootstrap/nodes", get(mock_bootstrap_nodes))
@@ -206,6 +208,7 @@ async fn community_node_metadata_refresh_heartbeats_before_bootstrap_sync_even_w
         bootstrap_hits: Arc::new(AtomicUsize::new(0)),
     });
     let app = Router::new()
+        .route("/v1/policies", get(mock_current_policies))
         .route("/v1/consents/status", get(mock_bootstrap_consent_status))
         .route("/v1/bootstrap/heartbeat", post(mock_bootstrap_heartbeat))
         .route("/v1/bootstrap/nodes", get(mock_bootstrap_nodes))
@@ -337,6 +340,7 @@ async fn community_node_ready_transition_refreshes_bootstrap_metadata_before_nex
         bootstrap_hits: Arc::new(AtomicUsize::new(0)),
     });
     let app = Router::new()
+        .route("/v1/policies", get(mock_current_policies))
         .route("/v1/consents/status", get(mock_bootstrap_consent_status))
         .route("/v1/bootstrap/heartbeat", post(mock_bootstrap_heartbeat))
         .route("/v1/bootstrap/nodes", get(mock_bootstrap_nodes))
@@ -445,6 +449,7 @@ async fn community_node_ready_transition_refreshes_bootstrap_metadata_only_once_
         bootstrap_hits: Arc::new(AtomicUsize::new(0)),
     });
     let app = Router::new()
+        .route("/v1/policies", get(mock_current_policies))
         .route("/v1/consents/status", get(mock_bootstrap_consent_status))
         .route("/v1/bootstrap/heartbeat", post(mock_bootstrap_heartbeat))
         .route("/v1/bootstrap/nodes", get(mock_bootstrap_nodes))
@@ -520,6 +525,7 @@ async fn community_node_status_retries_bootstrap_metadata_when_seed_peers_are_em
         bootstrap_hits: Arc::new(AtomicUsize::new(0)),
     });
     let app = Router::new()
+        .route("/v1/policies", get(mock_current_policies))
         .route("/v1/consents/status", get(mock_bootstrap_consent_status))
         .route("/v1/bootstrap/heartbeat", post(mock_bootstrap_heartbeat))
         .route("/v1/bootstrap/nodes", get(mock_bootstrap_nodes))
@@ -636,6 +642,7 @@ async fn refresh_community_node_metadata_refreshes_registration_before_bootstrap
         bootstrap_hits: Arc::new(AtomicUsize::new(0)),
     });
     let app = Router::new()
+        .route("/v1/policies", get(mock_current_policies))
         .route("/v1/consents/status", get(mock_bootstrap_consent_status))
         .route("/v1/bootstrap/heartbeat", post(mock_bootstrap_heartbeat))
         .route("/v1/bootstrap/nodes", get(mock_bootstrap_nodes))
@@ -727,6 +734,7 @@ async fn refresh_community_node_metadata_requeues_heartbeat_when_runtime_connect
         bootstrap_hits: Arc::new(AtomicUsize::new(0)),
     });
     let app = Router::new()
+        .route("/v1/policies", get(mock_current_policies))
         .route("/v1/consents/status", get(mock_bootstrap_consent_status))
         .route(
             "/v1/bootstrap/heartbeat",
@@ -894,4 +902,90 @@ async fn reapply_community_node_connectivity_forces_unchanged_runtime_inputs() {
 
     runtime.shutdown().await;
     seed_peer_runtime.shutdown().await;
+}
+
+#[tokio::test]
+async fn manual_refresh_stops_before_protected_requests_on_snapshot_update() {
+    let _resource = lock_test_resource(TestResource::CommunityNodeServer).await;
+    let dir = tempdir().expect("tempdir");
+    let db_path = dir.path().join("community-refresh-snapshot-update.db");
+    let runtime = DesktopRuntime::new_with_config_and_identity(
+        &db_path,
+        TransportNetworkConfig::loopback(),
+        IdentityStorageMode::FileOnly,
+    )
+    .await
+    .expect("runtime");
+
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind listener");
+    let base_url = format!("http://{}", listener.local_addr().expect("local addr"));
+    let state = Arc::new(MockManagedCommunityNodeState::new(
+        base_url.clone(),
+        vec![],
+        true,
+        Arc::new(Mutex::new("saved-token".into())),
+    ));
+    state.simulate_snapshot_update.store(true, Ordering::SeqCst);
+    let app = Router::new()
+        .route("/v1/auth/challenge", post(mock_managed_auth_challenge))
+        .route("/v1/auth/verify", post(mock_managed_auth_verify))
+        .route("/v1/consents/status", get(mock_managed_consent_status))
+        .route("/v1/consents", post(mock_managed_accept_consents))
+        .route("/v1/policies", get(mock_managed_policies))
+        .route(
+            "/v1/bootstrap/heartbeat",
+            post(mock_managed_bootstrap_heartbeat),
+        )
+        .route("/v1/bootstrap/nodes", get(mock_managed_bootstrap_nodes))
+        .with_state(state.clone());
+    let server = tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+
+    persist_community_node_token(
+        &db_path,
+        IdentityStorageMode::FileOnly,
+        base_url.as_str(),
+        &StoredCommunityNodeToken {
+            access_token: "saved-token".into(),
+            expires_at: Utc::now().timestamp() + 3600,
+        },
+    )
+    .expect("persist token");
+    *runtime.community_node_config.lock().await = CommunityNodeConfig {
+        nodes: vec![CommunityNodeNodeConfig {
+            base_url: base_url.clone(),
+            resolved_urls: Some(
+                CommunityNodeResolvedUrls::new(base_url.clone(), Vec::new(), Vec::new())
+                    .expect("resolved urls"),
+            ),
+        }],
+    };
+    seed_local_community_node_consents_with_snapshot(
+        &runtime,
+        base_url.as_str(),
+        1,
+        Some("snapshot-1"),
+    );
+
+    let status = runtime
+        .refresh_community_node_metadata(crate::CommunityNodeTargetRequest {
+            base_url: base_url.clone(),
+        })
+        .await
+        .expect("refresh returns consent status");
+
+    assert_eq!(state.policies_hits.load(Ordering::SeqCst), 1);
+    assert_eq!(state.challenge_hits.load(Ordering::SeqCst), 0);
+    assert_eq!(state.verify_hits.load(Ordering::SeqCst), 0);
+    assert_eq!(state.consent_status_hits.load(Ordering::SeqCst), 0);
+    assert_eq!(state.heartbeat_hits.load(Ordering::SeqCst), 0);
+    assert_eq!(state.bootstrap_hits.load(Ordering::SeqCst), 0);
+    assert_eq!(status.session_phase, crate::CommunityNodeSessionPhase::Idle);
+    assert!(status.consent_update_pending);
+
+    runtime.shutdown().await;
+    server.abort();
 }

--- a/crates/desktop-runtime/src/tests/community_node/report_submission.rs
+++ b/crates/desktop-runtime/src/tests/community_node/report_submission.rs
@@ -7,6 +7,8 @@ use serde_json::{Value, json};
 struct MockReportState {
     received: Arc<Mutex<Vec<Value>>>,
     invalid_appeal: bool,
+    policies_hits: Arc<AtomicUsize>,
+    simulate_snapshot_update: Arc<AtomicBool>,
 }
 
 async fn mock_report(State(state): State<MockReportState>, Json(payload): Json<Value>) -> Response {
@@ -26,6 +28,45 @@ async fn mock_report(State(state): State<MockReportState>, Json(payload): Json<V
         "disputed_risk_signal_id": "signal-1"
     }))
     .into_response()
+}
+
+async fn mock_report_policies(
+    State(state): State<MockReportState>,
+) -> Json<kukuri_cn_protocol::CommunityNodePoliciesResponse> {
+    state.policies_hits.fetch_add(1, Ordering::SeqCst);
+    let snapshot_revision = state
+        .simulate_snapshot_update
+        .load(Ordering::SeqCst)
+        .then(|| "snapshot-2".to_string());
+    Json(kukuri_cn_protocol::CommunityNodePoliciesResponse {
+        policies: vec![kukuri_cn_protocol::CommunityNodePolicyDocument {
+            policy_slug: MOCK_MANAGED_POLICY_SLUG.to_string(),
+            policy_version: 1,
+            title: "Builder Preview".to_string(),
+            body_markdown: "Builder preview policy body.".to_string(),
+            required: true,
+            effective_date: Some("2026-09-02".to_string()),
+            language: Some("ja".to_string()),
+            policy_snapshot_revision: snapshot_revision.clone(),
+            authoritative_language: Some("ja".to_string()),
+            reference_translation: false,
+            translation_revision: None,
+            translation_of_version: None,
+            fallback: false,
+            requested_language: None,
+            material_change: false,
+            requires_reconsent: false,
+            is_current: true,
+            publication_status: Some("current".to_string()),
+            published_at: None,
+            retired_at: None,
+            previous_policy_version: None,
+            previous_policy_snapshot_revision: None,
+            next_policy_version: None,
+            next_policy_snapshot_revision: None,
+        }],
+        policy_snapshot_revision: snapshot_revision,
+    })
 }
 
 async fn report_runtime(
@@ -50,8 +91,11 @@ async fn report_runtime(
     let state = MockReportState {
         received: Arc::new(Mutex::new(Vec::new())),
         invalid_appeal,
+        policies_hits: Arc::new(AtomicUsize::new(0)),
+        simulate_snapshot_update: Arc::new(AtomicBool::new(false)),
     };
     let app = Router::new()
+        .route("/v1/policies", get(mock_report_policies))
         .route("/v1/report", post(mock_report))
         .route("/v1/report-moved", post(mock_report_redirect))
         .with_state(state.clone());
@@ -204,6 +248,7 @@ async fn community_node_report_client_stops_before_http_without_active_local_con
         .expect_err("report without local consent must be rejected");
 
     assert_eq!(error.code, CONSENT_REQUIRED_CODE);
+    assert_eq!(state.policies_hits.load(Ordering::SeqCst), 0);
     assert!(state.received.lock().await.is_empty());
 
     runtime.shutdown().await;
@@ -228,6 +273,32 @@ async fn community_node_report_client_stops_before_http_after_consent_withdrawal
         .expect_err("report after consent withdrawal must be rejected");
 
     assert_eq!(error.code, CONSENT_REQUIRED_CODE);
+    assert_eq!(state.policies_hits.load(Ordering::SeqCst), 0);
+    assert!(state.received.lock().await.is_empty());
+
+    runtime.shutdown().await;
+    server.abort();
+}
+
+#[tokio::test]
+async fn community_node_report_client_stops_before_body_post_on_snapshot_update() {
+    let _resource = lock_test_resource(TestResource::CommunityNodeServer).await;
+    let (runtime, base_url, state, server, _dir) = report_runtime(false).await;
+    seed_local_community_node_consents_with_snapshot(
+        &runtime,
+        base_url.as_str(),
+        1,
+        Some("snapshot-1"),
+    );
+    state.simulate_snapshot_update.store(true, Ordering::SeqCst);
+
+    let error = runtime
+        .submit_community_node_report(appeal_request(base_url.as_str()))
+        .await
+        .expect_err("report after policy snapshot update must be rejected");
+
+    assert_eq!(error.code, CONSENT_REQUIRED_CODE);
+    assert_eq!(state.policies_hits.load(Ordering::SeqCst), 1);
     assert!(state.received.lock().await.is_empty());
 
     runtime.shutdown().await;

--- a/crates/desktop-runtime/src/tests/community_node/scheduler.rs
+++ b/crates/desktop-runtime/src/tests/community_node/scheduler.rs
@@ -55,6 +55,7 @@ async fn session_scheduler_keeps_bootstrap_registration_alive_without_getter_pol
         bootstrap_hits: Arc::new(AtomicUsize::new(0)),
     });
     let app = Router::new()
+        .route("/v1/policies", get(mock_current_policies))
         .route("/v1/consents/status", get(mock_bootstrap_consent_status))
         .route("/v1/bootstrap/heartbeat", post(mock_bootstrap_heartbeat))
         .route("/v1/bootstrap/nodes", get(mock_bootstrap_nodes))
@@ -176,6 +177,7 @@ async fn get_sync_status_is_read_only_for_community_node_session() {
         bootstrap_hits: Arc::new(AtomicUsize::new(0)),
     });
     let app = Router::new()
+        .route("/v1/policies", get(mock_current_policies))
         .route("/v1/consents/status", get(mock_bootstrap_consent_status))
         .route("/v1/bootstrap/heartbeat", post(mock_bootstrap_heartbeat))
         .route("/v1/bootstrap/nodes", get(mock_bootstrap_nodes))
@@ -356,6 +358,7 @@ async fn topic_rendezvous_refresh_fires_between_bootstrap_heartbeats() {
         rendezvous_requests: Arc::new(Mutex::new(Vec::new())),
     });
     let app = Router::new()
+        .route("/v1/policies", get(mock_current_policies))
         .route("/v1/consents/status", get(mock_bootstrap_consent_status))
         .route(
             "/v1/bootstrap/heartbeat",
@@ -501,6 +504,7 @@ async fn private_channel_rendezvous_refresh_uses_only_the_current_epoch_secret()
         rendezvous_requests: Arc::new(Mutex::new(Vec::new())),
     });
     let app = Router::new()
+        .route("/v1/policies", get(mock_current_policies))
         .route("/v1/consents/status", get(mock_bootstrap_consent_status))
         .route(
             "/v1/bootstrap/heartbeat",

--- a/crates/desktop-runtime/src/tests/community_node/session.rs
+++ b/crates/desktop-runtime/src/tests/community_node/session.rs
@@ -538,6 +538,7 @@ async fn community_node_status_does_not_require_restart_when_connectivity_is_act
             .connectivity_urls,
         vec![connectivity_url]
     );
+    assert_eq!(status.session_phase, crate::CommunityNodeSessionPhase::Idle);
     assert!(!status.restart_required);
 
     timeout(test_timeout, runtime.shutdown())
@@ -616,7 +617,10 @@ async fn policy_update_is_not_silently_reaccepted() {
         .await
         .expect("community node statuses");
     // 更新時は auto 受諾しない。
-    assert_eq!(state.consent_status_hits.load(Ordering::SeqCst), 1);
+    assert_eq!(state.policies_hits.load(Ordering::SeqCst), 1);
+    assert_eq!(state.challenge_hits.load(Ordering::SeqCst), 0);
+    assert_eq!(state.verify_hits.load(Ordering::SeqCst), 0);
+    assert_eq!(state.consent_status_hits.load(Ordering::SeqCst), 0);
     assert_eq!(state.consent_accept_hits.load(Ordering::SeqCst), 0);
     assert_eq!(state.heartbeat_hits.load(Ordering::SeqCst), 0);
     assert_eq!(state.bootstrap_hits.load(Ordering::SeqCst), 0);
@@ -626,12 +630,7 @@ async fn policy_update_is_not_silently_reaccepted() {
     );
     // 再同意が必要なことが status で client に見えている(#857)。
     assert!(statuses[0].consent_update_pending);
-    let consent_state = statuses[0].consent_state.as_ref().expect("consent state");
-    assert!(!consent_state.all_required_accepted);
-    // 更新（旧版同意済み・現行版未同意）が client に見えている。
-    let item = &consent_state.items[0];
-    assert!(item.accepted_at.is_none());
-    assert_eq!(item.previously_accepted_version, Some(1));
+    assert!(statuses[0].consent_state.is_none());
 
     // ユーザーが新版(2)へ明示的に再同意すれば ready になる。
     let accepted = runtime
@@ -660,6 +659,94 @@ async fn policy_update_is_not_silently_reaccepted() {
     assert_eq!(state.consent_accept_hits.load(Ordering::SeqCst), 1);
     // 旧版と新版の記録が両方履歴に残る。
     assert_eq!(accepted.local_consent.records.len(), 2);
+
+    runtime.shutdown().await;
+    server.abort();
+}
+
+#[tokio::test]
+async fn saved_token_does_not_bypass_same_version_snapshot_preflight() {
+    let _resource = lock_test_resource(TestResource::CommunityNodeServer).await;
+    let dir = tempdir().expect("tempdir");
+    let db_path = dir.path().join("community-consent-snapshot-update.db");
+    let runtime = DesktopRuntime::new_with_config_and_identity(
+        &db_path,
+        TransportNetworkConfig::loopback(),
+        IdentityStorageMode::FileOnly,
+    )
+    .await
+    .expect("runtime");
+
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind listener");
+    let base_url = format!("http://{}", listener.local_addr().expect("local addr"));
+    let state = Arc::new(MockManagedCommunityNodeState::new(
+        base_url.clone(),
+        vec![],
+        true,
+        Arc::new(Mutex::new("saved-token".into())),
+    ));
+    state.simulate_snapshot_update.store(true, Ordering::SeqCst);
+    let app = Router::new()
+        .route("/v1/auth/challenge", post(mock_managed_auth_challenge))
+        .route("/v1/auth/verify", post(mock_managed_auth_verify))
+        .route("/v1/consents/status", get(mock_managed_consent_status))
+        .route("/v1/consents", post(mock_managed_accept_consents))
+        .route("/v1/policies", get(mock_managed_policies))
+        .route(
+            "/v1/bootstrap/heartbeat",
+            post(mock_managed_bootstrap_heartbeat),
+        )
+        .route("/v1/bootstrap/nodes", get(mock_managed_bootstrap_nodes))
+        .with_state(state.clone());
+    let server = tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+
+    persist_community_node_token(
+        &db_path,
+        IdentityStorageMode::FileOnly,
+        base_url.as_str(),
+        &StoredCommunityNodeToken {
+            access_token: "saved-token".into(),
+            expires_at: Utc::now().timestamp() + 3600,
+        },
+    )
+    .expect("persist token");
+    *runtime.community_node_config.lock().await = CommunityNodeConfig {
+        nodes: vec![CommunityNodeNodeConfig {
+            base_url: base_url.clone(),
+            resolved_urls: Some(
+                CommunityNodeResolvedUrls::new(base_url.clone(), Vec::new(), Vec::new())
+                    .expect("resolved urls"),
+            ),
+        }],
+    };
+    seed_local_community_node_consents_with_snapshot(
+        &runtime,
+        base_url.as_str(),
+        1,
+        Some("snapshot-1"),
+    );
+
+    runtime.run_community_node_session_maintenance_once().await;
+    let statuses = runtime
+        .get_community_node_statuses()
+        .await
+        .expect("community node statuses");
+
+    assert_eq!(state.policies_hits.load(Ordering::SeqCst), 1);
+    assert_eq!(state.challenge_hits.load(Ordering::SeqCst), 0);
+    assert_eq!(state.verify_hits.load(Ordering::SeqCst), 0);
+    assert_eq!(state.consent_status_hits.load(Ordering::SeqCst), 0);
+    assert_eq!(state.heartbeat_hits.load(Ordering::SeqCst), 0);
+    assert_eq!(state.bootstrap_hits.load(Ordering::SeqCst), 0);
+    assert_eq!(
+        statuses[0].session_phase,
+        crate::CommunityNodeSessionPhase::Idle
+    );
+    assert!(statuses[0].consent_update_pending);
 
     runtime.shutdown().await;
     server.abort();

--- a/crates/desktop-runtime/src/tests/community_node/tester_feedback_submission.rs
+++ b/crates/desktop-runtime/src/tests/community_node/tester_feedback_submission.rs
@@ -91,6 +91,7 @@ async fn tester_feedback_runtime(
     let managed_router = Router::new()
         .route("/v1/auth/challenge", post(mock_managed_auth_challenge))
         .route("/v1/auth/verify", post(mock_managed_auth_verify))
+        .route("/v1/policies", get(mock_managed_policies))
         .route("/v1/consents/status", get(mock_managed_consent_status))
         .route("/v1/consents", post(mock_managed_accept_consents))
         .route(

--- a/crates/desktop-runtime/src/tests/community_node/trust_relation.rs
+++ b/crates/desktop-runtime/src/tests/community_node/trust_relation.rs
@@ -196,6 +196,7 @@ async fn trust_relation_runtime(
     let managed_router = Router::new()
         .route("/v1/auth/challenge", post(mock_managed_auth_challenge))
         .route("/v1/auth/verify", post(mock_managed_auth_verify))
+        .route("/v1/policies", get(mock_managed_policies))
         .route("/v1/consents/status", get(mock_managed_consent_status))
         .route("/v1/consents", post(mock_managed_accept_consents))
         .route(

--- a/crates/desktop-runtime/src/tests/support/lock_contract.rs
+++ b/crates/desktop-runtime/src/tests/support/lock_contract.rs
@@ -19,14 +19,14 @@ const LOCK_CLASSIFICATION: &[(&str, &str, usize)] = &[
     ("community_node/connectivity.rs", "IrohNetwork", 6),
     ("community_node/dome_hosting.rs", "CommunityNodeServer", 6),
     ("community_node/index_query.rs", "CommunityNodeServer", 11),
-    ("community_node/metadata.rs", "CommunityNodeServer", 9),
+    ("community_node/metadata.rs", "CommunityNodeServer", 10),
     (
         "community_node/report_submission.rs",
         "CommunityNodeServer",
-        8,
+        9,
     ),
     ("community_node/scheduler.rs", "CommunityNodeServer", 5),
-    ("community_node/session.rs", "CommunityNodeServer", 6),
+    ("community_node/session.rs", "CommunityNodeServer", 7),
     (
         "community_node/tester_feedback_submission.rs",
         "CommunityNodeServer",
@@ -107,10 +107,10 @@ fn lock_acquisitions_match_declared_classification() {
     );
     let total: usize = expected.values().sum();
     assert_eq!(
-        total, 102,
+        total, 105,
         "classification total drifted from the Q7 T6 baseline(#711 で index_query 試験を 1 件、\
          #802 で tester_feedback_submission 試験を 3 件、#862 で config 永続化試験を 2 件、\
          #855 で device_backup 試験を 7 件へ拡充、#857 で report consent gate 試験を 3 件、\
-         Dome hosting consent gate 試験を 6 件追加)"
+         Dome hosting consent gate 試験を 6 件、固定面回帰で session・metadata・report を各 1 件追加)"
     );
 }

--- a/crates/desktop-runtime/src/tests/support/mock_cn.rs
+++ b/crates/desktop-runtime/src/tests/support/mock_cn.rs
@@ -84,6 +84,39 @@ pub(crate) async fn mock_bootstrap_consent_status() -> Json<CommunityNodeConsent
     Json(managed_community_node_consent_status(true))
 }
 
+pub(crate) async fn mock_current_policies()
+-> Json<kukuri_cn_protocol::CommunityNodePoliciesResponse> {
+    Json(kukuri_cn_protocol::CommunityNodePoliciesResponse {
+        policies: vec![kukuri_cn_protocol::CommunityNodePolicyDocument {
+            policy_slug: MOCK_MANAGED_POLICY_SLUG.to_string(),
+            policy_version: 1,
+            title: "Builder Preview".to_string(),
+            body_markdown: "Builder preview policy body.".to_string(),
+            required: true,
+            effective_date: Some("2026-09-02".to_string()),
+            language: Some("ja".to_string()),
+            policy_snapshot_revision: None,
+            authoritative_language: Some("ja".to_string()),
+            reference_translation: false,
+            translation_revision: None,
+            translation_of_version: None,
+            fallback: false,
+            requested_language: None,
+            material_change: false,
+            requires_reconsent: false,
+            is_current: true,
+            publication_status: Some("current".to_string()),
+            published_at: None,
+            retired_at: None,
+            previous_policy_version: None,
+            previous_policy_snapshot_revision: None,
+            next_policy_version: None,
+            next_policy_snapshot_revision: None,
+        }],
+        policy_snapshot_revision: None,
+    })
+}
+
 pub(crate) async fn mock_heartbeat_echo_bootstrap_heartbeat(
     State(state): State<Arc<MockHeartbeatEchoCommunityNodeState>>,
     Json(request): Json<serde_json::Value>,
@@ -201,6 +234,8 @@ pub(crate) struct MockManagedCommunityNodeState {
     // true の場合、未同意状態を「版が上がった更新（旧版は同意済み）」として返す。
     // ローカル同意が旧版のままの node で黙って再受諾しない挙動の検証に使う（#384 / #857）。
     pub(crate) simulate_pending_update: Arc<AtomicBool>,
+    // true の場合、文書版は据え置いたまま snapshot revision だけを更新する。
+    pub(crate) simulate_snapshot_update: Arc<AtomicBool>,
 }
 
 impl MockManagedCommunityNodeState {
@@ -226,6 +261,7 @@ impl MockManagedCommunityNodeState {
             dome_get_hits: Arc::new(AtomicUsize::new(0)),
             dome_post_hits: Arc::new(AtomicUsize::new(0)),
             simulate_pending_update: Arc::new(AtomicBool::new(false)),
+            simulate_snapshot_update: Arc::new(AtomicBool::new(false)),
         }
     }
 }
@@ -275,13 +311,22 @@ pub(crate) fn seed_local_community_node_consents(
     base_url: &str,
     version: i32,
 ) {
+    seed_local_community_node_consents_with_snapshot(runtime, base_url, version, None);
+}
+
+pub(crate) fn seed_local_community_node_consents_with_snapshot(
+    runtime: &DesktopRuntime,
+    base_url: &str,
+    version: i32,
+    policy_snapshot_revision: Option<&str>,
+) {
     let mut state = crate::CommunityNodeLocalConsentState::default();
     crate::community_node::record_community_node_local_consents(
         &mut state,
         &[crate::CommunityNodeConsentDocumentRef {
             policy_slug: MOCK_MANAGED_POLICY_SLUG.to_string(),
             policy_version: version,
-            policy_snapshot_revision: None,
+            policy_snapshot_revision: policy_snapshot_revision.map(str::to_string),
         }],
         "ja",
         "test-app",
@@ -302,6 +347,7 @@ pub(crate) async fn mock_managed_policies(
 ) -> Json<kukuri_cn_protocol::CommunityNodePoliciesResponse> {
     state.policies_hits.fetch_add(1, Ordering::SeqCst);
     let pending_update = state.simulate_pending_update.load(Ordering::SeqCst);
+    let snapshot_update = state.simulate_snapshot_update.load(Ordering::SeqCst);
     Json(kukuri_cn_protocol::CommunityNodePoliciesResponse {
         policies: vec![kukuri_cn_protocol::CommunityNodePolicyDocument {
             policy_slug: MOCK_MANAGED_POLICY_SLUG.to_string(),
@@ -311,7 +357,7 @@ pub(crate) async fn mock_managed_policies(
             required: true,
             effective_date: Some("2026-09-02".to_string()),
             language: Some("ja".to_string()),
-            policy_snapshot_revision: None,
+            policy_snapshot_revision: snapshot_update.then(|| "snapshot-2".to_string()),
             authoritative_language: Some("ja".to_string()),
             reference_translation: false,
             translation_revision: None,
@@ -329,7 +375,7 @@ pub(crate) async fn mock_managed_policies(
             next_policy_version: None,
             next_policy_snapshot_revision: None,
         }],
-        policy_snapshot_revision: None,
+        policy_snapshot_revision: snapshot_update.then(|| "snapshot-2".to_string()),
     })
 }
 
@@ -427,10 +473,17 @@ pub(crate) async fn mock_managed_consent_status(
     authorize_managed_community_node_request(&headers, state.as_ref()).await?;
     state.consent_status_hits.fetch_add(1, Ordering::SeqCst);
     let accepted = state.consent_accepted.load(Ordering::SeqCst);
-    Ok(Json(managed_community_node_consent_status_with_update(
+    let mut status = managed_community_node_consent_status_with_update(
         accepted,
         !accepted && state.simulate_pending_update.load(Ordering::SeqCst),
-    )))
+    );
+    if state.simulate_snapshot_update.load(Ordering::SeqCst) {
+        status.policy_snapshot_revision = Some("snapshot-2".to_string());
+        for item in &mut status.items {
+            item.policy_snapshot_revision = Some("snapshot-2".to_string());
+        }
+    }
+    Ok(Json(status))
 }
 
 pub(crate) async fn mock_managed_accept_consents(

--- a/docs/progress/2026-09-04-issue-857-community-node-consent-fixed-surface-rerun.md
+++ b/docs/progress/2026-09-04-issue-857-community-node-consent-fixed-surface-rerun.md
@@ -1,0 +1,60 @@
+# Issue #857 Community Node consent fixed-surface rerun
+
+## 結論
+
+#857 の再監査で固定した残件を実装し、Community Node 同意境界を有限の監査面で閉じた。設定済み Node、active local consent、公開 current required policy bundle の順に確認する共通 preflight を追加し、保存 token、manual Refresh、report、起動時 connectivity、Dome hosting が同じ判定を利用する。
+
+未同意・撤回・同一 version で異なる snapshot の場合、公開 policy 取得以外の認証、consent status、heartbeat、bootstrap、rendezvous、report 本文送信、保護 API は開始しない。Node 設定と保存済み `resolved_urls` は保持するが、Node 由来 relay / seed は明示的な session 成立後にだけ runtime へ適用する。
+
+## 実装
+
+- `consent_preflight_support.rs` に副作用のない共通 preflight を追加した。URL 正規化、設定 membership、active local consent、公開 policy catalog、required 文書の `(policy_slug, policy_version, policy_snapshot_revision)` 完全一致を順に検証する。
+- `ensure_community_node_session` は保存 token の有効期限にかかわらず preflight を先行する。不成立時は token 読み込み前に `Idle`、再同意状態、Node connectivity 無効化へ遷移する。manual Refresh は同じ処理の強制 refresh mode を利用する。
+- report は endpoint 形式・設定 membership・same-origin 検証後、本文構築・POST より前に preflight する。policy 更新直後でも旧 snapshot のまま本文を送らない。
+- runtime 起動時は保存済み Community Node relay / seed を Iroh の初期入力へ渡さない。利用者が設定した discovery seed は維持し、server consent を含む session 成立後に既存 scheduler から Node connectivity を再適用する。
+- session record がない status は常に `Idle` とし、保存 token や `resolved_urls` から `Ready` を合成しない。
+- Settings の Refresh は既知の不同意・撤回・再同意待ちでは保護 refresh を呼ばず、既存の対象 Node 同意ダイアログを開く。refresh 中に policy 更新を検出した場合も同じダイアログへ戻す。
+- caller のない `get_community_node_consent_status` / `getCommunityNodeConsentStatus` IPC を runtime、Tauri command / 登録、TypeScript interface / implementation、mock から削除した。互換 alias は残していない。
+- Dome hosting は共通 preflight の判定本体だけを共有し、既存の target / consent error contract と固定済み 9 application command の挙動を維持した。
+
+## テスト先行の再現
+
+実装前に、次の不足を回帰テストで失敗させた。
+
+- session record のない status が保存状態から `Ready` を合成した。
+- 有効な保存 token が公開 policy preflight を迂回した。
+- 同一 version・異 snapshot の policy 更新後も report 本文が POST された。
+- 保存済み Node relay / seed が runtime 起動直後から有効になった。
+- Settings の Refresh が同意ダイアログへ戻らなかった。
+
+修正後は未同意、撤回、同一 version・異 snapshot、current consent の各 fixture で policy、auth challenge / verify、consent status、heartbeat、bootstrap、rendezvous、report POST の hit 数を個別に固定した。
+
+## 固定 inventory
+
+- consent-status IPC 削除後の `commands::community_node::*` 登録: 47 件。
+- 既存 Dome hosting application command: 9 件。共通 GET / request helper の preflight contract 6 件で未同意、撤回、policy 更新、未設定、current consent、401 再認証を維持。
+- 通常 UI: Settings Refresh と既存同意ダイアログ。
+- background / startup: runtime 初期化、session scheduler、manual Refresh、report。
+- 削除対象名 `get_community_node_consent_status|getCommunityNodeConsentStatus`: 0 件。
+- 上記固定面の未分類経路: 0 件。固定面外の将来 route、独自 client、policy cache 最適化は #857 の Close 条件へ追加しない。
+
+## 検証
+
+- Community Node 対象 test: session 7件、report 9件、config 13件、metadata 10件、Dome 6件、admission 7件、connectivity 6件、index query 11件、tester feedback 3件、trust relation 4件、scheduler 5件、合計 85件すべて成功。
+- `cargo xtask doctor`: 成功。
+- `cargo xtask check`: format、clippy `-D warnings`、Tauri check、frontend lint / typecheck すべて成功。
+- `cargo xtask oversized-files`: 成功（既存 baseline warning のみ。変更対象 `runtimeApi.ts` は縮小）。
+- `cargo xtask ipc-types --check`: 成功。
+- `cargo xtask rust-test`: workspace 769件、harness 22件、doc test すべて成功（workspace 3件 skip）。
+- `cargo xtask test`: Rust 769件、harness 22件、frontend 1089件すべて成功（Rust 3件 skip）。
+- `cargo xtask desktop-ui-check`: lint、typecheck、unit 1089件、Storybook build、browser 58件、visual 14件すべて成功。
+- `cargo xtask tauri-check`: 成功。
+- `cargo xtask e2e-smoke`: `desktop_smoke_post_persist` 6 step 成功。
+- `cargo xtask scenario community_node_public_connectivity`: 15 step 成功。
+- `git diff --check`: 成功。
+
+## Scope boundary
+
+#860 が所有する Community Node server 側の heartbeat、auth verify、trust pull、DB / API contract は変更していない。#857 は本書の固定 inventory と検証結果をもって Close 可能であり、親 #853 の残否は #860 を含む他の既知 child 条件だけで判定する。
+
+関連: #853、#857、#860


### PR DESCRIPTION
## 概要

#857 の固定監査面で残っていた Community Node 同意境界を共通 preflight へ統一します。保存 token、manual Refresh、report、起動時 connectivity、status、Dome hosting を現行 policy snapshot の成立前に fail-closed とし、未使用 consent-status IPC を削除します。

Closes #857

## 種別

- 不具合修正
- consent / connectivity contract の回帰テスト追加
- 未使用 IPC 削除
- 監査進捗記録

## 挙動変更

- current 判定を required policy の slug / version / snapshot 完全一致にします。
- 有効な保存 token があっても public policy preflight を先行します。
- 未同意・撤回・policy 更新時は auth、consent status、heartbeat、bootstrap、rendezvous、report POST、保護 API を開始しません。
- runtime 起動直後は保存済み Community Node relay / seed を適用せず、明示的な session 成立後に再適用します。
- Settings の Refresh は同意が必要な場合、既存の対象 Node 同意ダイアログを開きます。
- session record のない status から Ready を合成しません。

## 検証

- cargo xtask doctor
- cargo xtask check
- cargo xtask oversized-files
- cargo xtask ipc-types --check
- cargo xtask rust-test（workspace 769件、harness 22件、doc test）
- cargo xtask test（frontend 1089件を含む）
- cargo xtask desktop-ui-check（Storybook、browser 58件、visual 14件を含む）
- cargo xtask tauri-check
- cargo xtask e2e-smoke
- cargo xtask scenario community_node_public_connectivity（15 step）
- git diff --check

## リスク

policy catalog は active local consent がある session / protected request ごとに確認するため、Node 障害時は従来より早く fail-closed になります。これは同意境界の意図した挙動です。保存設定と resolved URLs は保持するため、再同意後の復帰経路は維持します。

## 後続対応

#860 が所有する Community Node server 側 heartbeat、auth verify、trust pull、DB / API contract はこのPRの対象外です。親 #853 は #860 を含む既知 child 条件で別途判定します。