### PR TITLE
fix: Community Node server consent境界を固定する

### DIFF
--- a/crates/cn-core/src/auth.rs
+++ b/crates/cn-core/src/auth.rs
@@ -8,9 +8,6 @@ use sqlx::Row;
 use sqlx::postgres::PgPool;
 
 use crate::admission::{AdmissionMode, evaluate_admission};
-use crate::bootstrap::{
-    prune_expired_bootstrap_peer_registrations, upsert_bootstrap_peer_registration,
-};
 use crate::config::{
     AUTH_CHALLENGE_TTL_SECONDS, AUTH_EVENT_MAX_SKEW_SECONDS, JWT_CRYPTO_PROVIDER_INIT, JwtConfig,
 };
@@ -71,14 +68,12 @@ where
     Ok(())
 }
 
-#[allow(clippy::too_many_arguments)]
 pub async fn verify_auth_envelope_and_issue_token(
     pool: &PgPool,
     jwt_config: &JwtConfig,
     public_base_url: &str,
     auth_envelope_json: &Value,
     endpoint_id: Option<&str>,
-    addr_hint: Option<&str>,
     admission_mode: AdmissionMode,
     invite_code: Option<&str>,
 ) -> Result<AuthVerifyResponse> {
@@ -120,12 +115,12 @@ pub async fn verify_auth_envelope_and_issue_token(
     if normalized_pubkey != stored_pubkey {
         bail!("pubkey mismatch");
     }
-    let registered_endpoint = endpoint_id
-        .map(|value| CommunityNodeSeedPeer::new(value, addr_hint.map(str::to_string)))
-        .transpose()?;
+    let bound_endpoint_id = endpoint_id
+        .map(|value| CommunityNodeSeedPeer::new(value, None))
+        .transpose()?
+        .map(|seed_peer| seed_peer.endpoint_id);
 
     let mut tx = pool.begin().await?;
-    prune_expired_bootstrap_peer_registrations(&mut *tx).await?;
     // admission を challenge / invite 消費の前に評価する。拒否時は tx を rollback し、
     // challenge も invite も消費しない（無効な試行で消費させない）。invite redeem が成功した
     // 場合は subscriber 作成・challenge 消費と同一 tx でコミットされ原子性を保つ。
@@ -145,18 +140,12 @@ pub async fn verify_auth_envelope_and_issue_token(
     .execute(&mut *tx)
     .await?;
     ensure_active_subscriber(&mut *tx, normalized_pubkey.as_str()).await?;
-    if let Some(seed_peer) = registered_endpoint.as_ref() {
-        upsert_bootstrap_peer_registration(&mut *tx, normalized_pubkey.as_str(), seed_peer, now)
-            .await?;
-    }
     tx.commit().await?;
 
     let (access_token, expires_at) = issue_access_token(
         jwt_config,
         normalized_pubkey.as_str(),
-        registered_endpoint
-            .as_ref()
-            .map(|seed_peer| seed_peer.endpoint_id.as_str()),
+        bound_endpoint_id.as_deref(),
     )?;
     Ok(AuthVerifyResponse {
         access_token,

--- a/crates/cn-user-api/src/handlers/auth.rs
+++ b/crates/cn-user-api/src/handlers/auth.rs
@@ -47,7 +47,6 @@ pub(crate) async fn auth_verify(
         state.self_node.resolved_urls.public_base_url.as_str(),
         &request.auth_envelope_json,
         request.endpoint_id.as_deref(),
-        request.addr_hint.as_deref(),
         admission_config.mode,
         request.invite_code.as_deref(),
     )

--- a/crates/cn-user-api/src/handlers/bootstrap.rs
+++ b/crates/cn-user-api/src/handlers/bootstrap.rs
@@ -51,6 +51,7 @@ pub(crate) async fn bootstrap_heartbeat(
     Json(request): Json<BootstrapHeartbeatRequest>,
 ) -> ApiResult<Json<BootstrapHeartbeatResponse>> {
     let identity = require_bearer_identity(&state.pool, &state.jwt_config, &headers).await?;
+    let _ = require_consents(&state.pool, identity.pubkey.as_str()).await?;
     if let Some(bound_endpoint_id) = identity.endpoint_id.as_deref()
         && bound_endpoint_id != request.endpoint_id
     {

--- a/crates/cn-user-api/src/handlers/trust_relation.rs
+++ b/crates/cn-user-api/src/handlers/trust_relation.rs
@@ -153,9 +153,13 @@ pub(crate) async fn trust_pull(
             "this community node trust activation is not current",
         ));
     }
-    // bearer が有効な subscriber なら SubscribedNodes、無ければ匿名(Public visibility のみ)。
+    // bearer が有効なsubscriberはcurrent consent成立後だけSubscribedNodesへ昇格する。
+    // 認証できない要求は匿名としてPublic visibilityだけを維持する。
     let audience = match require_bearer_identity(&state.pool, &state.jwt_config, &headers).await {
-        Ok(_) => PullAudience::SubscribedNodes,
+        Ok(identity) => {
+            let _ = require_consents(&state.pool, identity.pubkey.as_str()).await?;
+            PullAudience::SubscribedNodes
+        }
         Err(_) => PullAudience::Public,
     };
     let target = parse_target_pubkey(pubkey.as_str())?;

--- a/crates/cn-user-api/tests/contract_auth.rs
+++ b/crates/cn-user-api/tests/contract_auth.rs
@@ -108,6 +108,97 @@ async fn auth_verify_rejects_capability_url_mismatch() -> Result<()> {
 }
 
 #[tokio::test]
+async fn auth_verify_defers_peer_registration_until_consented_heartbeat() -> Result<()> {
+    let Some(admin_database_url) = integration_test_admin_database_url() else {
+        eprintln!("skipping cn-user-api integration test; set KUKURI_CN_RUN_INTEGRATION_TESTS=1");
+        return Ok(());
+    };
+    let server = TestServer::spawn(
+        admin_database_url.as_str(),
+        "cn_auth_defers_peer_registration",
+    )
+    .await?;
+    let client = Client::new();
+    let pool = PgPool::connect(server.database.database_url.as_str()).await?;
+
+    let keys_a = generate_keys();
+    let (token_a, _) = authenticate(
+        &client,
+        &server.base_url,
+        &keys_a,
+        "peer-a",
+        Some("127.0.0.1:47001"),
+    )
+    .await?;
+    let registered_a: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM cn_bootstrap.peer_registrations
+         WHERE subscriber_pubkey = $1",
+    )
+    .bind(keys_a.public_key_hex())
+    .fetch_one(&pool)
+    .await?;
+    assert_eq!(registered_a, 0, "auth/verifyだけではpeerを登録しない");
+
+    let keys_b = generate_keys();
+    let (token_b, _) = authenticate(
+        &client,
+        &server.base_url,
+        &keys_b,
+        "peer-b",
+        Some("127.0.0.1:47002"),
+    )
+    .await?;
+    accept_required_consents(&client, &server.base_url, token_b.as_str()).await?;
+    send_bootstrap_heartbeat(
+        &client,
+        &server.base_url,
+        token_b.as_str(),
+        "peer-b",
+        Some("127.0.0.1:47002"),
+    )
+    .await?;
+    let before_a_heartbeat = client
+        .get(format!("{}/v1/bootstrap/nodes", server.base_url))
+        .bearer_auth(token_b.as_str())
+        .send()
+        .await?
+        .error_for_status()?
+        .json::<serde_json::Value>()
+        .await?;
+    assert_eq!(
+        before_a_heartbeat["nodes"][0]["resolved_urls"]["seed_peers"]
+            .as_array()
+            .map(Vec::len),
+        Some(0),
+        "auth/verify直後のpeerを他subscriberへ公開しない"
+    );
+
+    accept_required_consents(&client, &server.base_url, token_a.as_str()).await?;
+    send_bootstrap_heartbeat(
+        &client,
+        &server.base_url,
+        token_a.as_str(),
+        "peer-a",
+        Some("127.0.0.1:47001"),
+    )
+    .await?;
+    let after_a_heartbeat = client
+        .get(format!("{}/v1/bootstrap/nodes", server.base_url))
+        .bearer_auth(token_b.as_str())
+        .send()
+        .await?
+        .error_for_status()?
+        .json::<serde_json::Value>()
+        .await?;
+    assert_eq!(
+        after_a_heartbeat["nodes"][0]["resolved_urls"]["seed_peers"][0]["endpoint_id"],
+        "peer-a"
+    );
+
+    server.shutdown().await
+}
+
+#[tokio::test]
 async fn admission_open_mode_admits_new_subscriber() -> Result<()> {
     let Some(admin_database_url) = integration_test_admin_database_url() else {
         eprintln!("skipping cn-user-api integration test; set KUKURI_CN_RUN_INTEGRATION_TESTS=1");

--- a/crates/cn-user-api/tests/contract_bootstrap.rs
+++ b/crates/cn-user-api/tests/contract_bootstrap.rs
@@ -232,6 +232,92 @@ async fn bootstrap_requires_bearer_then_consents() -> Result<()> {
 }
 
 #[tokio::test]
+async fn bootstrap_heartbeat_requires_current_consents_before_mutation() -> Result<()> {
+    let Some(admin_database_url) = integration_test_admin_database_url() else {
+        eprintln!("skipping cn-user-api integration test; set KUKURI_CN_RUN_INTEGRATION_TESTS=1");
+        return Ok(());
+    };
+    let server = TestServer::spawn(
+        admin_database_url.as_str(),
+        "cn_bootstrap_heartbeat_consent",
+    )
+    .await?;
+    let client = Client::new();
+    let pool = PgPool::connect(server.database.database_url.as_str()).await?;
+    let keys = generate_keys();
+    let pubkey = keys.public_key_hex();
+    let (access_token, _) = authenticate(
+        &client,
+        &server.base_url,
+        &keys,
+        "peer-consent",
+        Some("127.0.0.1:47100"),
+    )
+    .await?;
+
+    let registration = || {
+        sqlx::query_as::<_, (Option<String>, chrono::DateTime<chrono::Utc>)>(
+            "SELECT addr_hint, expires_at FROM cn_bootstrap.peer_registrations
+             WHERE subscriber_pubkey = $1 AND endpoint_id = 'peer-consent'",
+        )
+        .bind(pubkey.clone())
+        .fetch_optional(&pool)
+    };
+    let before_no_consent = registration().await?;
+    let no_consent = client
+        .post(format!("{}/v1/bootstrap/heartbeat", server.base_url))
+        .bearer_auth(access_token.as_str())
+        .json(&serde_json::json!({
+            "endpoint_id": "peer-consent",
+            "addr_hint": "127.0.0.1:47101",
+        }))
+        .send()
+        .await?;
+    assert_eq!(no_consent.status(), StatusCode::FORBIDDEN);
+    assert_eq!(
+        no_consent.json::<serde_json::Value>().await?["code"],
+        "CONSENT_REQUIRED"
+    );
+    assert_eq!(registration().await?, before_no_consent, "拒否時はDB不変");
+
+    accept_required_consents(&client, &server.base_url, access_token.as_str()).await?;
+    send_bootstrap_heartbeat(
+        &client,
+        &server.base_url,
+        access_token.as_str(),
+        "peer-consent",
+        Some("127.0.0.1:47102"),
+    )
+    .await?;
+    let current_registration = registration().await?.context("peer registration missing")?;
+    assert_eq!(current_registration.0.as_deref(), Some("127.0.0.1:47102"));
+
+    advance_policy_snapshot(&pool, "issue-860-next-snapshot").await?;
+    let before_old_snapshot = registration().await?;
+    let old_snapshot = client
+        .post(format!("{}/v1/bootstrap/heartbeat", server.base_url))
+        .bearer_auth(access_token.as_str())
+        .json(&serde_json::json!({
+            "endpoint_id": "peer-consent",
+            "addr_hint": "127.0.0.1:47103",
+        }))
+        .send()
+        .await?;
+    assert_eq!(old_snapshot.status(), StatusCode::FORBIDDEN);
+    assert_eq!(
+        old_snapshot.json::<serde_json::Value>().await?["code"],
+        "CONSENT_REQUIRED"
+    );
+    assert_eq!(
+        registration().await?,
+        before_old_snapshot,
+        "旧snapshot拒否時はDB不変"
+    );
+
+    server.shutdown().await
+}
+
+#[tokio::test]
 async fn bootstrap_exposes_other_registered_seed_peers() -> Result<()> {
     let Some(admin_database_url) = integration_test_admin_database_url() else {
         eprintln!("skipping cn-user-api integration test; set KUKURI_CN_RUN_INTEGRATION_TESTS=1");
@@ -264,6 +350,22 @@ async fn bootstrap_exposes_other_registered_seed_peers() -> Result<()> {
             accept_required_consents(&client, &server.base_url, access_token.as_str()).await?;
         assert!(accepted.all_required_accepted);
     }
+    send_bootstrap_heartbeat(
+        &client,
+        &server.base_url,
+        access_token_a.as_str(),
+        "peer-a",
+        Some("127.0.0.1:44001"),
+    )
+    .await?;
+    send_bootstrap_heartbeat(
+        &client,
+        &server.base_url,
+        access_token_b.as_str(),
+        "peer-b",
+        Some("127.0.0.1:44002"),
+    )
+    .await?;
 
     let bootstrap_a = client
         .get(format!("{}/v1/bootstrap/nodes", server.base_url))
@@ -321,6 +423,22 @@ async fn bootstrap_exposes_other_endpoints_for_same_subscriber() -> Result<()> {
     let accepted =
         accept_required_consents(&client, &server.base_url, access_token_a1.as_str()).await?;
     assert!(accepted.all_required_accepted);
+    send_bootstrap_heartbeat(
+        &client,
+        &server.base_url,
+        access_token_a1.as_str(),
+        "peer-a-1",
+        None,
+    )
+    .await?;
+    send_bootstrap_heartbeat(
+        &client,
+        &server.base_url,
+        access_token_a2.as_str(),
+        "peer-a-2",
+        None,
+    )
+    .await?;
 
     let bootstrap_a1 = client
         .get(format!("{}/v1/bootstrap/nodes", server.base_url))
@@ -401,6 +519,30 @@ async fn bootstrap_filters_expired_peer_registrations_and_heartbeat_restores_the
             accept_required_consents(&client, &server.base_url, access_token.as_str()).await?;
         assert!(accepted.all_required_accepted);
     }
+    send_bootstrap_heartbeat(
+        &client,
+        &server.base_url,
+        token_a_initial.as_str(),
+        "peer-a-1",
+        Some("127.0.0.1:45001"),
+    )
+    .await?;
+    send_bootstrap_heartbeat(
+        &client,
+        &server.base_url,
+        token_a.as_str(),
+        "peer-a-2",
+        Some("127.0.0.1:45002"),
+    )
+    .await?;
+    send_bootstrap_heartbeat(
+        &client,
+        &server.base_url,
+        token_b.as_str(),
+        "peer-b",
+        Some("127.0.0.1:45003"),
+    )
+    .await?;
 
     sqlx::query(
         "UPDATE cn_bootstrap.peer_registrations

--- a/crates/cn-user-api/tests/support/mod.rs
+++ b/crates/cn-user-api/tests/support/mod.rs
@@ -13,6 +13,7 @@ use kukuri_cn_user_api::{UserApiConfig, app_router, build_state};
 use kukuri_core::KukuriKeys;
 use redis::AsyncCommands;
 use reqwest::{Client, StatusCode};
+use sqlx::postgres::PgPool;
 
 pub const DEFAULT_ADMIN_DATABASE_URL: &str = "postgres://cn:cn_password@127.0.0.1:15432/cn";
 pub const DEFAULT_RENDEZVOUS_REDIS_URL: &str = "redis://127.0.0.1:16379/";
@@ -137,6 +138,35 @@ pub async fn accept_required_consents(
     let accepted = serde_json::from_str::<kukuri_cn_protocol::CommunityNodeConsentStatus>(&body)?;
     assert!(accepted.all_required_accepted);
     Ok(accepted)
+}
+
+pub async fn send_bootstrap_heartbeat(
+    client: &Client,
+    base_url: &str,
+    access_token: &str,
+    endpoint_id: &str,
+    addr_hint: Option<&str>,
+) -> Result<kukuri_cn_protocol::BootstrapHeartbeatResponse> {
+    Ok(client
+        .post(format!("{base_url}/v1/bootstrap/heartbeat"))
+        .bearer_auth(access_token)
+        .json(&serde_json::json!({
+            "endpoint_id": endpoint_id,
+            "addr_hint": addr_hint,
+        }))
+        .send()
+        .await?
+        .error_for_status()?
+        .json::<kukuri_cn_protocol::BootstrapHeartbeatResponse>()
+        .await?)
+}
+
+pub async fn advance_policy_snapshot(pool: &PgPool, revision: &str) -> Result<()> {
+    let mut policies = kukuri_cn_core::list_policies(pool).await?;
+    for policy in &mut policies {
+        policy.policy_snapshot_revision = Some(revision.to_string());
+    }
+    kukuri_cn_core::sync_policies(pool, policies.as_slice()).await
 }
 
 pub async fn redis_keys(redis_url: &str, pattern: &str) -> Result<Vec<String>> {

--- a/crates/cn-user-api/tests/trust_relation.rs
+++ b/crates/cn-user-api/tests/trust_relation.rs
@@ -56,6 +56,12 @@ impl TestServer {
             .context("failed to bind test trust read listener")?;
         let addr = listener.local_addr()?;
         let base_url = format!("http://{addr}");
+        let operator_config_dir = tempfile::tempdir()?;
+        let operator_config_path = operator_config_dir.path().join("operator-config.yaml");
+        std::fs::write(
+            &operator_config_path,
+            kukuri_cn_operator::SAMPLE_CONFIG.as_bytes(),
+        )?;
         let mut state = build_state(&UserApiConfig {
             bind_addr: addr,
             database_url: database.database_url.clone(),
@@ -65,9 +71,9 @@ impl TestServer {
             public_base_url: base_url.clone(),
             connectivity_urls: vec!["http://127.0.0.1:13340".to_string()],
             jwt_config: JwtConfig::new("kukuri-cn-tests", "test-secret", 3600),
-            operator_config_path: None,
+            operator_config_path: Some(operator_config_path),
             channel_secret_key: None,
-            legal_data_key: None,
+            legal_data_key: Some("unit-test-legal-data-key-0123456789abcdef".to_string()),
             index_query_enabled: false,
             trust_read_enabled: false,
             relation_distance_optout_min_proximity: None,
@@ -105,12 +111,7 @@ impl TestServer {
     }
 }
 
-/// 認証 + consent を通し、bearer access token を返す。
-async fn authenticate_and_consent(
-    client: &Client,
-    base_url: &str,
-    keys: &KukuriKeys,
-) -> Result<String> {
+async fn authenticate_only(client: &Client, base_url: &str, keys: &KukuriKeys) -> Result<String> {
     let pubkey = keys.public_key_hex();
     let challenge = client
         .post(format!("{base_url}/v1/auth/challenge"))
@@ -133,8 +134,18 @@ async fn authenticate_and_consent(
         .error_for_status()?
         .json::<kukuri_cn_protocol::AuthVerifyResponse>()
         .await?;
-    accept_required_consents(client, base_url, verify.access_token.as_str()).await?;
     Ok(verify.access_token)
+}
+
+/// 認証 + consent を通し、bearer access token を返す。
+async fn authenticate_and_consent(
+    client: &Client,
+    base_url: &str,
+    keys: &KukuriKeys,
+) -> Result<String> {
+    let access_token = authenticate_only(client, base_url, keys).await?;
+    accept_required_consents(client, base_url, access_token.as_str()).await?;
+    Ok(access_token)
 }
 
 fn memory_trust_state() -> (Arc<TrustReadState>, Arc<MemoryRelationStore>) {
@@ -511,10 +522,22 @@ async fn cross_node_pull_discloses_only_confirmed_absolute_component() -> Result
     assert!(anonymous.get("relative").is_none(), "相対成分は返さない");
     assert!(anonymous.get("trust").is_none(), "合成値も返さない");
 
-    // subscriber 認証つき pull: SubscribedNodes visibility の confirmed も開示される。
+    // 有効なbearerでも同意前はSubscribedNodesへ昇格しない。
     let subscriber_keys = generate_keys();
-    let token =
-        authenticate_and_consent(&client, server.base_url.as_str(), &subscriber_keys).await?;
+    let token = authenticate_only(&client, server.base_url.as_str(), &subscriber_keys).await?;
+    let no_consent = client
+        .get(pull_url.as_str())
+        .bearer_auth(token.as_str())
+        .send()
+        .await?;
+    assert_eq!(no_consent.status(), StatusCode::FORBIDDEN);
+    assert_eq!(
+        no_consent.json::<serde_json::Value>().await?["code"],
+        "CONSENT_REQUIRED"
+    );
+
+    // current exact consent後だけSubscribedNodes visibilityのconfirmedも開示される。
+    accept_required_consents(&client, server.base_url.as_str(), token.as_str()).await?;
     let subscribed: serde_json::Value = client
         .get(pull_url.as_str())
         .bearer_auth(token.as_str())
@@ -525,9 +548,33 @@ async fn cross_node_pull_discloses_only_confirmed_absolute_component() -> Result
         .await?;
     let mut ids = signal_ids(&subscribed);
     ids.sort();
-    let mut expected = vec![public_confirmed.id, subscribed_confirmed.id];
+    let mut expected = vec![public_confirmed.id.clone(), subscribed_confirmed.id];
     expected.sort();
     assert_eq!(ids, expected);
+
+    // policy更新で同意が旧snapshotになったbearerは再び拒否する。
+    support::advance_policy_snapshot(&pool, "issue-860-trust-next-snapshot").await?;
+    let old_snapshot = client
+        .get(pull_url.as_str())
+        .bearer_auth(token.as_str())
+        .send()
+        .await?;
+    assert_eq!(old_snapshot.status(), StatusCode::FORBIDDEN);
+    assert_eq!(
+        old_snapshot.json::<serde_json::Value>().await?["code"],
+        "CONSENT_REQUIRED"
+    );
+    let anonymous_after_rotation: serde_json::Value = client
+        .get(pull_url.as_str())
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+    assert_eq!(
+        signal_ids(&anonymous_after_rotation),
+        vec![public_confirmed.id]
+    );
 
     server.shutdown().await
 }

--- a/docs/progress/2026-09-04-issue-860-community-node-consent-route-fixed-surface-rerun.md
+++ b/docs/progress/2026-09-04-issue-860-community-node-consent-route-fixed-surface-rerun.md
@@ -1,0 +1,55 @@
+# Issue #860 Community Node consent route fixed-surface rerun
+
+## 結論
+
+#860 の再監査で固定した server 側の残件 3 経路を、既存の current consent contract へ揃えた。bootstrap heartbeat は peer mutation 前、認証済み trust pull は subscriber audience 選択前に current consent を要求する。auth verify は認証と peer 広告を分離し、bootstrap peer の登録を同意後 heartbeat に一本化した。
+
+公開 listener 55 method-path と、別 bind の IAP 管理 listener 9 method-path を同じ分類基準で再集計した。今回の 3 経路以外に同種の未対処経路はなく、将来 route、既存 peer の即時 purge、匿名 Public trust pull、IAP 管理 listener を追加の Close 条件にはしていない。
+
+## 実装
+
+- `POST /v1/bootstrap/heartbeat` は bearer 認証後かつ endpoint 検証・peer row 更新前に既存 `require_consents` を実行する。未同意または旧 snapshot は `403 CONSENT_REQUIRED` となり、peer row を作成・更新しない。
+- `POST /v1/auth/verify` から bootstrap peer の prune / upsert を除去した。challenge 消費、admission、subscriber 有効化、`endpoint_id` の検証と JWT claim binding は維持し、wire 上の `addr_hint` も変更していない。
+- `GET /v1/trust/pull/{pubkey}` は匿名または bearer 認証不成立なら従来どおり `Public` audience を返す。有効な bearer で `SubscribedNodes` audience を要求する場合だけ current consent を検証する。
+- policy snapshot 更新 fixture と heartbeat helper を integration test support に追加し、通常の policy sync と公開 API を通じて旧 snapshot / current snapshot の境界を検証する。
+
+## テスト先行の再現
+
+実装前に追加した回帰 contract は、次の不足でそれぞれ失敗した。
+
+- auth verify 直後に bootstrap peer row が 1 件作成され、他 subscriber の seed 候補になった。
+- 未同意の bootstrap heartbeat が `200` となり、peer row を変更した。
+- 未同意の有効 bearer による trust pull が `200` となり、`SubscribedNodes` audience を返した。
+
+修正後は、auth verify 直後に peer row と seed 候補がないこと、current consent 後の最初の heartbeat で初めて登録されることを固定した。heartbeat は未同意・旧 snapshot で `403` かつ DB 不変、current consent で登録成功を検証した。trust pull は匿名 Public、未同意・旧 snapshot bearer の `403`、current consent bearer の `SubscribedNodes` を検証した。
+
+## 固定 route inventory
+
+- 公開 API router: 46 method-path。
+- manifest router: 9 method-path。
+- 公開 listener 合計: 55 method-path。
+- 別 bind の IAP 管理 listener: 9 method-path。
+- 今回変更した route 登録: 0 件。固定数は変更前後で同一。
+- 今回の対象: heartbeat mutation、auth verify peer side effect、認証済み trust pull subscriber audience の 3 件。
+- 上記固定面の未分類・未対処経路: 0 件。
+
+## 検証
+
+- 対象 integration test: `contract_auth` 18 件、`contract_bootstrap` 9 件、`trust_relation` 6 件、すべて成功。
+- `cargo xtask doctor`: 成功。
+- `cargo xtask oversized-files`: 成功（既存 baseline warning のみ）。
+- `cargo xtask cn-check`: 成功。
+- `cargo xtask cn-test`: Community Node 全 package / integration / doc test 成功。
+- `cargo xtask cn-e2e`: 成功。
+- `cargo xtask rust-test`: workspace 769 件、harness 22 件、doc test すべて成功（workspace 3 件 skip）。
+- `cargo xtask check`: format、clippy `-D warnings`、Tauri check、frontend lint / typecheck すべて成功。
+- `cargo xtask test`: Rust 769 件、harness 22 件、frontend 1089 件すべて成功（Rust 3 件 skip）。
+- `cargo xtask e2e-smoke`: `desktop_smoke_post_persist` 6 step 成功。
+- `cargo xtask scenario community_node_public_connectivity`: 15 step 成功。
+- `git diff --check`: 成功。
+
+## Scope boundary
+
+#857 が所有する desktop client の consent preflight、UI、report、runtime connectivity は変更していない。今回の固定条件は server 側 3 経路だけであり、90 秒 TTL で失効する既存 peer の即時削除や、将来の独自 client / route を再帰的な完了条件へ追加しない。本書の実装・contract・固定 inventory により #860 は Close 可能であり、#853 は既存の固定完了条件と child 状態だけで最終判定する。
+
+関連: #853、#857、#860


### PR DESCRIPTION
## 概要

- `POST /v1/bootstrap/heartbeat` の peer mutation 前に current consent guard を追加
- `POST /v1/auth/verify` から bootstrap peer 登録副作用を除去し、同意後 heartbeat に登録を一本化
- 認証済み `GET /v1/trust/pull/{pubkey}` の subscriber audience 前に current consent guard を追加
- 公開 listener 55 method-path / IAP 管理 listener 9 method-path の固定棚卸しを再確認し、監査記録を追加

## Contract

- heartbeat は未同意・旧 snapshot で `403 CONSENT_REQUIRED`、DB mutation なし
- auth verify 直後は peer row / seed 候補なし。current consent 後の heartbeat で初登録
- trust pull は匿名 Public を維持し、未同意・旧 snapshot bearer は `403`、current consent bearer は `SubscribedNodes`

## 検証

- `cargo xtask doctor`
- `cargo xtask oversized-files`
- `cargo xtask cn-check`
- `cargo xtask cn-test`
- `cargo xtask cn-e2e`
- `cargo xtask rust-test`（workspace 769件、harness 22件、doc test）
- `cargo xtask check`
- `cargo xtask test`（frontend 1089件を含む）
- `cargo xtask e2e-smoke`
- `cargo xtask scenario community_node_public_connectivity`
- `git diff --check`

Closes #860