### PR TITLE
[codex][fix] #857 Community Node同意transitionをfail-closedにする

### DIFF
--- a/crates/desktop-runtime/src/community_node/index_query_support.rs
+++ b/crates/desktop-runtime/src/community_node/index_query_support.rs
@@ -10,7 +10,7 @@ use kukuri_store::{ContentObservationRow, ContentObservationStore};
 use reqwest::{StatusCode, header::RETRY_AFTER};
 use serde::{Deserialize, Serialize};
 
-use super::{community_node_http_client, load_community_node_token};
+use super::{CommunityNodeSessionOutcome, community_node_http_client, load_community_node_token};
 use crate::runtime::DesktopRuntime;
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -143,7 +143,8 @@ impl DesktopRuntime {
             ));
         }
 
-        self.ensure_community_node_session(base_url.as_str())
+        let session_outcome = self
+            .ensure_community_node_session(base_url.as_str())
             .await
             .map_err(|error| {
                 CommunityNodeIndexQueryError::new(
@@ -151,15 +152,20 @@ impl DesktopRuntime {
                     error.to_string(),
                 )
             })?;
-        // 必須同意が未承認のノードへは検索語を送らない(#698)。
-        if self
-            .community_node_required_consent_is_pending(base_url.as_str())
-            .await
-        {
-            return Err(CommunityNodeIndexQueryError::new(
-                CONSENT_REQUIRED_CODE,
-                "community node required policies must be accepted before index queries",
-            ));
+        match session_outcome {
+            CommunityNodeSessionOutcome::Ready => {}
+            CommunityNodeSessionOutcome::ConsentRequired => {
+                return Err(CommunityNodeIndexQueryError::new(
+                    CONSENT_REQUIRED_CODE,
+                    "community node required policies must be accepted before index queries",
+                ));
+            }
+            CommunityNodeSessionOutcome::Deferred(phase) => {
+                return Err(CommunityNodeIndexQueryError::new(
+                    "COMMUNITY_NODE_SESSION_DEFERRED",
+                    format!("community node session is not ready ({phase:?})"),
+                ));
+            }
         }
         // 非公開チャンネルの範囲指定は所属証明(channel secret)を同伴する(#711)。
         // 参加中でない(capability が無い)チャンネルへは送信前に拒否する。

--- a/crates/desktop-runtime/src/community_node/indexing_request_support.rs
+++ b/crates/desktop-runtime/src/community_node/indexing_request_support.rs
@@ -8,7 +8,7 @@ use kukuri_cn_protocol::{
 use reqwest::{StatusCode, header::RETRY_AFTER};
 use serde::{Deserialize, Serialize};
 
-use super::{community_node_http_client, load_community_node_token};
+use super::{CommunityNodeSessionOutcome, community_node_http_client, load_community_node_token};
 use crate::runtime::DesktopRuntime;
 
 /// UI / IPC から受ける secret 非公開の indexing 申請。
@@ -104,7 +104,8 @@ impl DesktopRuntime {
         }
         // セッション確立と同意確認は秘密値を組み立てる前に行う。必須同意が未承認のノードへは
         // 非公開チャンネルの秘密値を含む申請を送らない(#698)。
-        self.ensure_community_node_session(base_url.as_str())
+        let session_outcome = self
+            .ensure_community_node_session(base_url.as_str())
             .await
             .map_err(|error| {
                 CommunityNodeIndexingRequestError::new(
@@ -112,14 +113,20 @@ impl DesktopRuntime {
                     error.to_string(),
                 )
             })?;
-        if self
-            .community_node_required_consent_is_pending(base_url.as_str())
-            .await
-        {
-            return Err(CommunityNodeIndexingRequestError::new(
-                CONSENT_REQUIRED_CODE,
-                "community node required policies must be accepted before indexing requests",
-            ));
+        match session_outcome {
+            CommunityNodeSessionOutcome::Ready => {}
+            CommunityNodeSessionOutcome::ConsentRequired => {
+                return Err(CommunityNodeIndexingRequestError::new(
+                    CONSENT_REQUIRED_CODE,
+                    "community node required policies must be accepted before indexing requests",
+                ));
+            }
+            CommunityNodeSessionOutcome::Deferred(phase) => {
+                return Err(CommunityNodeIndexingRequestError::new(
+                    "COMMUNITY_NODE_SESSION_DEFERRED",
+                    format!("community node session is not ready ({phase:?})"),
+                ));
+            }
         }
         let (target_id, channel_secret_hex) = match request.scope_kind {
             IndexScopeKind::PublicTopic => {

--- a/crates/desktop-runtime/src/community_node/mod.rs
+++ b/crates/desktop-runtime/src/community_node/mod.rs
@@ -281,6 +281,13 @@ pub enum CommunityNodeSessionPhase {
     AwaitingAdmission,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum CommunityNodeSessionOutcome {
+    Ready,
+    Deferred(CommunityNodeSessionPhase),
+    ConsentRequired,
+}
+
 #[derive(Clone, Debug, Default)]
 pub(crate) struct CommunityNodeSessionState {
     pub(crate) heartbeat_deadline: i64,
@@ -296,6 +303,9 @@ pub(crate) struct CommunityNodeSessionState {
     /// #857: 公開カタログ照合でローカル同意が現行版をカバーしないと判明した状態。
     /// 真の間は認証(JWT 発行)を開始せず、UI が再同意モーダルを提示する。
     pub(crate) local_consent_update_pending: bool,
+    /// 公開current policyとの厳密一致を確認して`Ready`へ到達した時点のlocal consent。
+    /// runtime内だけのevidenceとし、restart後は再度preflightする。
+    pub(crate) current_policy_verified_for: Option<CommunityNodeLocalConsentState>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/desktop-runtime/src/community_node/session_runtime_support.rs
+++ b/crates/desktop-runtime/src/community_node/session_runtime_support.rs
@@ -1,7 +1,10 @@
 use super::*;
 
 impl DesktopRuntime {
-    pub(crate) async fn ensure_community_node_session(&self, base_url: &str) -> Result<()> {
+    pub(crate) async fn ensure_community_node_session(
+        &self,
+        base_url: &str,
+    ) -> Result<CommunityNodeSessionOutcome> {
         self.ensure_community_node_session_with_mode(base_url, false)
             .await
     }
@@ -10,53 +13,9 @@ impl DesktopRuntime {
         &self,
         base_url: &str,
         force_refresh: bool,
-    ) -> Result<()> {
+    ) -> Result<CommunityNodeSessionOutcome> {
         let base_url = normalize_http_url(base_url)?;
-        let now = Utc::now().timestamp();
-        let session_gate = self
-            .community_node_sessions
-            .lock()
-            .await
-            .get(base_url.as_str())
-            .map(|s| (s.session_retry_deadline, s.session_phase));
-        if session_gate
-            .is_some_and(|(_, phase)| phase == CommunityNodeSessionPhase::AwaitingAdmission)
-        {
-            return Ok(());
-        }
-        let retry_after = session_gate.map(|(retry_after, _)| retry_after);
-        if !force_refresh && retry_after.is_some_and(|retry_after| retry_after > now) {
-            self.set_community_node_session_phase(
-                base_url.as_str(),
-                CommunityNodeSessionPhase::Retrying,
-            )
-            .await;
-            return Ok(());
-        }
-
         let _guard = self.community_node_session_guard.lock().await;
-        let now = Utc::now().timestamp();
-        let session_gate = self
-            .community_node_sessions
-            .lock()
-            .await
-            .get(base_url.as_str())
-            .map(|s| (s.session_retry_deadline, s.session_phase));
-        if session_gate
-            .is_some_and(|(_, phase)| phase == CommunityNodeSessionPhase::AwaitingAdmission)
-        {
-            return Ok(());
-        }
-        let retry_after = session_gate.map(|(retry_after, _)| retry_after);
-        if !force_refresh && retry_after.is_some_and(|retry_after| retry_after > now) {
-            self.set_community_node_session_phase(
-                base_url.as_str(),
-                CommunityNodeSessionPhase::Retrying,
-            )
-            .await;
-            return Ok(());
-        }
-
         let preflight = self
             .preflight_community_node_consent(base_url.as_str())
             .await?;
@@ -76,10 +35,36 @@ impl DesktopRuntime {
             .await;
             self.deactivate_community_node_connectivity(base_url.as_str())
                 .await?;
-            return Ok(());
+            return Ok(CommunityNodeSessionOutcome::ConsentRequired);
         }
         self.set_community_node_local_consent_update_pending(base_url.as_str(), false)
             .await;
+
+        let now = Utc::now().timestamp();
+        let session_gate = self
+            .community_node_sessions
+            .lock()
+            .await
+            .get(base_url.as_str())
+            .map(|s| (s.session_retry_deadline, s.session_phase));
+        if session_gate
+            .is_some_and(|(_, phase)| phase == CommunityNodeSessionPhase::AwaitingAdmission)
+        {
+            return Ok(CommunityNodeSessionOutcome::Deferred(
+                CommunityNodeSessionPhase::AwaitingAdmission,
+            ));
+        }
+        let retry_after = session_gate.map(|(retry_after, _)| retry_after);
+        if !force_refresh && retry_after.is_some_and(|retry_after| retry_after > now) {
+            self.set_community_node_session_phase(
+                base_url.as_str(),
+                CommunityNodeSessionPhase::Retrying,
+            )
+            .await;
+            return Ok(CommunityNodeSessionOutcome::Deferred(
+                CommunityNodeSessionPhase::Retrying,
+            ));
+        }
 
         let was_ready = self
             .community_node_session_was_ready(base_url.as_str())
@@ -128,7 +113,7 @@ impl DesktopRuntime {
                 .await;
                 self.deactivate_community_node_connectivity(base_url.as_str())
                     .await?;
-                return Ok(());
+                return Ok(CommunityNodeSessionOutcome::ConsentRequired);
             }
             // ローカル同意済みの内容をサーバ記録へ同期する(#857)。
             self.set_community_node_session_phase(
@@ -163,8 +148,32 @@ impl DesktopRuntime {
         .await?;
         self.clear_community_node_retry_state(base_url.as_str())
             .await;
-        self.set_community_node_session_ready(base_url.as_str(), !was_ready)
+        self.set_community_node_session_ready(base_url.as_str(), !was_ready, local_consent)
             .await;
+        self.apply_ready_community_node_connectivity(base_url.as_str())
+            .await?;
+        Ok(CommunityNodeSessionOutcome::Ready)
+    }
+
+    pub(crate) async fn apply_ready_community_node_connectivity(
+        &self,
+        base_url: &str,
+    ) -> Result<()> {
+        let local_seed_peer_before = self
+            .local_community_node_seed_peer("ready-connectivity-pre-apply")
+            .await
+            .ok();
+        self.apply_runtime_connectivity_assist().await?;
+        self.apply_effective_seed_peers().await?;
+        let local_seed_peer_after = self
+            .local_community_node_seed_peer("ready-connectivity-post-apply")
+            .await
+            .ok();
+        if local_seed_peer_before != local_seed_peer_after
+            && let Some(entry) = self.community_node_sessions.lock().await.get_mut(base_url)
+        {
+            entry.heartbeat_deadline = 0;
+        }
         Ok(())
     }
 
@@ -174,7 +183,7 @@ impl DesktopRuntime {
     ) -> Result<()> {
         let base_url = normalize_http_url(base_url)?;
         match self.ensure_community_node_session(base_url.as_str()).await {
-            Ok(()) => Ok(()),
+            Ok(_) => Ok(()),
             Err(error) => {
                 if let Some(rejection) = Self::community_node_admission_rejection(&error).cloned() {
                     self.set_community_node_admission_rejection(base_url.as_str(), rejection)
@@ -211,9 +220,17 @@ impl DesktopRuntime {
         );
         let sessions = self.community_node_sessions.lock().await;
         active.nodes.retain(|node| {
-            !sessions
-                .get(node.base_url.as_str())
-                .is_some_and(|session| session.local_consent_update_pending)
+            let Ok(local_consent) = load_community_node_local_consents(
+                &self.db_path,
+                self.identity_mode,
+                node.base_url.as_str(),
+            ) else {
+                return false;
+            };
+            sessions.get(node.base_url.as_str()).is_some_and(|session| {
+                !session.local_consent_update_pending
+                    && session.current_policy_verified_for.as_ref() == Some(&local_consent)
+            })
         });
         active
     }

--- a/crates/desktop-runtime/src/community_node/session_runtime_support.rs
+++ b/crates/desktop-runtime/src/community_node/session_runtime_support.rs
@@ -271,19 +271,6 @@ impl DesktopRuntime {
         last_error: Option<String>,
     ) -> Result<CommunityNodeNodeStatus> {
         let now = Utc::now().timestamp();
-        let token =
-            load_community_node_token(&self.db_path, self.identity_mode, node.base_url.as_str())?;
-        let auth_state = match token {
-            Some(token) if token.expires_at > now => CommunityNodeAuthState {
-                authenticated: true,
-                expires_at: Some(token.expires_at),
-            },
-            Some(token) => CommunityNodeAuthState {
-                authenticated: false,
-                expires_at: Some(token.expires_at),
-            },
-            None => CommunityNodeAuthState::default(),
-        };
         let local_consent = load_community_node_local_consents(
             &self.db_path,
             self.identity_mode,
@@ -304,7 +291,29 @@ impl DesktopRuntime {
         let session_phase = session
             .map(|s| s.session_phase)
             .unwrap_or(CommunityNodeSessionPhase::Idle);
+        let current_policy_verified = session.is_some_and(|session| {
+            !session.local_consent_update_pending
+                && session.current_policy_verified_for.as_ref() == Some(&local_consent)
+        });
         drop(sessions);
+        // status生成自体が、retry／参加承認待ちでpreflightを終えた後のtoken読込を
+        // 迂回させない。認証状態はcurrent policy照合済みevidenceがある場合だけ復元する。
+        let token = if current_policy_verified {
+            load_community_node_token(&self.db_path, self.identity_mode, node.base_url.as_str())?
+        } else {
+            None
+        };
+        let auth_state = match token {
+            Some(token) if token.expires_at > now => CommunityNodeAuthState {
+                authenticated: true,
+                expires_at: Some(token.expires_at),
+            },
+            Some(token) => CommunityNodeAuthState {
+                authenticated: false,
+                expires_at: Some(token.expires_at),
+            },
+            None => CommunityNodeAuthState::default(),
+        };
         let invite_code_saved = load_community_node_invite_code(
             &self.db_path,
             self.identity_mode,

--- a/crates/desktop-runtime/src/community_node/session_state_support.rs
+++ b/crates/desktop-runtime/src/community_node/session_state_support.rs
@@ -11,6 +11,14 @@ impl DesktopRuntime {
             .entry(base_url.to_string())
             .or_insert_with(CommunityNodeSessionState::default);
         entry.session_phase = phase;
+        if matches!(
+            phase,
+            CommunityNodeSessionPhase::Idle
+                | CommunityNodeSessionPhase::Retrying
+                | CommunityNodeSessionPhase::AwaitingAdmission
+        ) {
+            entry.current_policy_verified_for = None;
+        }
         if phase != CommunityNodeSessionPhase::Ready
             && matches!(
                 phase,
@@ -27,6 +35,7 @@ impl DesktopRuntime {
         &self,
         base_url: &str,
         schedule_immediate_refresh: bool,
+        verified_local_consent: CommunityNodeLocalConsentState,
     ) {
         let mut sessions = self.community_node_sessions.lock().await;
         let entry = sessions
@@ -34,6 +43,7 @@ impl DesktopRuntime {
             .or_insert_with(CommunityNodeSessionState::default);
         let previous = Some(entry.session_phase);
         entry.session_phase = CommunityNodeSessionPhase::Ready;
+        entry.current_policy_verified_for = Some(verified_local_consent);
         if schedule_immediate_refresh {
             entry.ready_refresh_pending = true;
             debug!(

--- a/crates/desktop-runtime/src/community_node/tester_feedback_support.rs
+++ b/crates/desktop-runtime/src/community_node/tester_feedback_support.rs
@@ -14,7 +14,7 @@ use kukuri_cn_protocol::{
 use reqwest::{StatusCode, header::RETRY_AFTER};
 use serde::{Deserialize, Serialize};
 
-use super::{community_node_http_client, load_community_node_token};
+use super::{CommunityNodeSessionOutcome, community_node_http_client, load_community_node_token};
 use crate::runtime::DesktopRuntime;
 
 /// UI / IPC から受けるテスターフィードバック送信。version / OS は含めない(自動付与)。
@@ -116,7 +116,8 @@ impl DesktopRuntime {
             }
         }
 
-        self.ensure_community_node_session(base_url.as_str())
+        let session_outcome = self
+            .ensure_community_node_session(base_url.as_str())
             .await
             .map_err(|error| {
                 CommunityNodeTesterFeedbackError::new(
@@ -124,14 +125,20 @@ impl DesktopRuntime {
                     error.to_string(),
                 )
             })?;
-        if self
-            .community_node_required_consent_is_pending(base_url.as_str())
-            .await
-        {
-            return Err(CommunityNodeTesterFeedbackError::new(
-                CONSENT_REQUIRED_CODE,
-                "community node required policies must be accepted before sending tester feedback",
-            ));
+        match session_outcome {
+            CommunityNodeSessionOutcome::Ready => {}
+            CommunityNodeSessionOutcome::ConsentRequired => {
+                return Err(CommunityNodeTesterFeedbackError::new(
+                    CONSENT_REQUIRED_CODE,
+                    "community node required policies must be accepted before sending tester feedback",
+                ));
+            }
+            CommunityNodeSessionOutcome::Deferred(phase) => {
+                return Err(CommunityNodeTesterFeedbackError::new(
+                    "COMMUNITY_NODE_SESSION_DEFERRED",
+                    format!("community node session is not ready ({phase:?})"),
+                ));
+            }
         }
 
         let token = load_community_node_token(&self.db_path, self.identity_mode, base_url.as_str())

--- a/crates/desktop-runtime/src/community_node/trust_relation_support.rs
+++ b/crates/desktop-runtime/src/community_node/trust_relation_support.rs
@@ -9,7 +9,7 @@ use kukuri_cn_protocol::{
 use reqwest::{Method, StatusCode};
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 
-use super::{community_node_http_client, load_community_node_token};
+use super::{CommunityNodeSessionOutcome, community_node_http_client, load_community_node_token};
 use crate::runtime::DesktopRuntime;
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -172,7 +172,8 @@ impl DesktopRuntime {
                     error.to_string(),
                 )
             })?;
-        self.ensure_community_node_session(base_url.as_str())
+        let session_outcome = self
+            .ensure_community_node_session(base_url.as_str())
             .await
             .map_err(|error| {
                 CommunityNodeTrustRelationError::new(
@@ -180,15 +181,20 @@ impl DesktopRuntime {
                     error.to_string(),
                 )
             })?;
-        // 必須同意が未承認のノードへは、対象利用者の公開鍵を含む要求も距離利用停止の操作も送らない(#705)。
-        if self
-            .community_node_required_consent_is_pending(base_url.as_str())
-            .await
-        {
-            return Err(CommunityNodeTrustRelationError::new(
-                CONSENT_REQUIRED_CODE,
-                "community node required policies must be accepted before trust and relation requests",
-            ));
+        match session_outcome {
+            CommunityNodeSessionOutcome::Ready => {}
+            CommunityNodeSessionOutcome::ConsentRequired => {
+                return Err(CommunityNodeTrustRelationError::new(
+                    CONSENT_REQUIRED_CODE,
+                    "community node required policies must be accepted before trust and relation requests",
+                ));
+            }
+            CommunityNodeSessionOutcome::Deferred(phase) => {
+                return Err(CommunityNodeTrustRelationError::new(
+                    "COMMUNITY_NODE_SESSION_DEFERRED",
+                    format!("community node session is not ready ({phase:?})"),
+                ));
+            }
         }
         let token = load_community_node_token(&self.db_path, self.identity_mode, base_url.as_str())
             .map_err(|error| {

--- a/crates/desktop-runtime/src/runtime/community_node_api.rs
+++ b/crates/desktop-runtime/src/runtime/community_node_api.rs
@@ -273,8 +273,10 @@ impl DesktopRuntime {
             .await?;
             self.clear_community_node_retry_state(base_url.as_str())
                 .await;
-            self.set_community_node_session_ready(base_url.as_str(), true)
+            self.set_community_node_session_ready(base_url.as_str(), true, local_consent)
                 .await;
+            self.apply_ready_community_node_connectivity(base_url.as_str())
+                .await?;
             let refreshed = self.require_community_node(base_url.as_str()).await?;
             return self
                 .community_node_status(refreshed, Some(consent_state), None)
@@ -445,7 +447,7 @@ impl DesktopRuntime {
             .ensure_community_node_session_with_mode(base_url.as_str(), true)
             .await
         {
-            Ok(()) => {}
+            Ok(_) => {}
             Err(error) => {
                 // 心拍 401 → 再認証 → 参加拒否(403)の経路は、定期処理と同じく AwaitingAdmission へ
                 // 落として利用者の操作待ちにする。それ以外の失敗は従来どおり呼び出し元へ返す(#708)。

--- a/crates/desktop-runtime/src/tests/community_node/config.rs
+++ b/crates/desktop-runtime/src/tests/community_node/config.rs
@@ -134,6 +134,116 @@ async fn startup_does_not_apply_persisted_community_node_connectivity_before_pre
 }
 
 #[tokio::test]
+async fn connectivity_apply_ignores_local_consent_without_verified_ready_session() {
+    let dir = tempdir().expect("tempdir");
+    let db_path = dir.path().join("community-node-unverified-connectivity.db");
+    let base_url = "https://community.example.com";
+    let relay_url = "https://127.0.0.1:9";
+    let community_seed = CommunityNodeSeedPeer::new(
+        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+        Some("127.0.0.1:9".to_string()),
+    )
+    .expect("community seed");
+    let runtime = DesktopRuntime::new_with_config_and_identity(
+        &db_path,
+        TransportNetworkConfig::loopback(),
+        IdentityStorageMode::FileOnly,
+    )
+    .await
+    .expect("runtime");
+    seed_local_community_node_consents(&runtime, base_url, 1);
+    *runtime.community_node_config.lock().await = CommunityNodeConfig {
+        nodes: vec![CommunityNodeNodeConfig {
+            base_url: base_url.to_string(),
+            resolved_urls: Some(
+                CommunityNodeResolvedUrls::new(
+                    base_url,
+                    vec![relay_url.to_string()],
+                    vec![community_seed],
+                )
+                .expect("resolved urls"),
+            ),
+        }],
+    };
+
+    runtime
+        .apply_runtime_connectivity_assist()
+        .await
+        .expect("apply runtime connectivity");
+    runtime
+        .apply_effective_seed_peers()
+        .await
+        .expect("apply effective seeds");
+
+    assert!(runtime.active_connectivity_urls.lock().await.is_empty());
+    let applied = runtime
+        .last_effective_seed_peer_apply_state
+        .lock()
+        .await
+        .clone()
+        .expect("effective seed state");
+    assert!(applied.bootstrap_seed_peers.is_empty());
+
+    runtime.shutdown().await;
+}
+
+#[tokio::test]
+async fn connectivity_apply_keeps_only_the_node_with_verified_ready_session() {
+    let dir = tempdir().expect("tempdir");
+    let db_path = dir.path().join("community-node-mixed-verification.db");
+    let runtime = DesktopRuntime::new_with_config_and_identity(
+        &db_path,
+        TransportNetworkConfig::loopback(),
+        IdentityStorageMode::FileOnly,
+    )
+    .await
+    .expect("runtime");
+    let verified_base_url = "https://verified.example.com";
+    let unverified_base_url = "https://unverified.example.com";
+    seed_local_community_node_consents(&runtime, verified_base_url, 1);
+    seed_local_community_node_consents(&runtime, unverified_base_url, 1);
+    mark_community_node_session_ready_for_test(&runtime, verified_base_url).await;
+    *runtime.community_node_config.lock().await = CommunityNodeConfig {
+        nodes: vec![
+            CommunityNodeNodeConfig {
+                base_url: verified_base_url.to_string(),
+                resolved_urls: Some(
+                    CommunityNodeResolvedUrls::new(
+                        verified_base_url,
+                        vec!["https://relay-verified.example.com".to_string()],
+                        Vec::new(),
+                    )
+                    .expect("verified urls"),
+                ),
+            },
+            CommunityNodeNodeConfig {
+                base_url: unverified_base_url.to_string(),
+                resolved_urls: Some(
+                    CommunityNodeResolvedUrls::new(
+                        unverified_base_url,
+                        vec!["https://relay-unverified.example.com".to_string()],
+                        Vec::new(),
+                    )
+                    .expect("unverified urls"),
+                ),
+            },
+        ],
+    };
+
+    runtime
+        .apply_runtime_connectivity_assist()
+        .await
+        .expect("apply runtime connectivity");
+
+    assert_eq!(
+        *runtime.active_connectivity_urls.lock().await,
+        vec!["https://relay-verified.example.com".to_string()]
+    );
+
+    runtime.shutdown().await;
+}
+
+#[tokio::test]
 async fn withdrawing_community_node_consent_removes_transport_assist() {
     let dir = tempdir().expect("tempdir");
     let db_path = dir.path().join("community-node-withdraw-connectivity.db");
@@ -178,6 +288,7 @@ async fn withdrawing_community_node_consent_removes_transport_assist() {
             ),
         }],
     };
+    mark_community_node_session_ready_for_test(&runtime, base_url).await;
     runtime
         .community_node_rendezvous_seed_peers
         .lock()

--- a/crates/desktop-runtime/src/tests/community_node/connectivity.rs
+++ b/crates/desktop-runtime/src/tests/community_node/connectivity.rs
@@ -194,6 +194,7 @@ async fn community_node_connectivity_assist_backfills_public_timeline_with_relay
         }],
     };
     seed_local_community_node_consents(&runtime_a, base_url, 1);
+    mark_community_node_session_ready_for_test(&runtime_a, base_url).await;
     *runtime_b.community_node_config.lock().await = CommunityNodeConfig {
         nodes: vec![CommunityNodeNodeConfig {
             base_url: base_url.to_string(),
@@ -210,7 +211,7 @@ async fn community_node_connectivity_assist_backfills_public_timeline_with_relay
         }],
     };
     seed_local_community_node_consents(&runtime_b, base_url, 1);
-
+    mark_community_node_session_ready_for_test(&runtime_b, base_url).await;
     timeout(
         Duration::from_secs(30),
         runtime_a.apply_runtime_connectivity_assist(),
@@ -733,9 +734,8 @@ async fn runtime_starts_with_unreachable_community_node_and_recovers_via_manual_
         kukuri_app_api::DeliveryState::Offline | kukuri_app_api::DeliveryState::DurableRecovering
     ));
 
-    // WP-Q2: 到達不能ノードへの registration refresh 試行(→ last_error 記録)は
-    // スケジューラ tick が駆動し、getter は読み取り専用。
-    // #857: 同意済みでなければそもそも通信しないため、同意記録をシードしてから tick を回す。
+    // WP-Q2: 到達不能ノードへのregistration refresh試行はscheduler tickが駆動し、getterは読み取り専用。
+    // #857: local consentだけでは保存済みrelayを有効化しない。到達不能Nodeはpreflightを完了できないためDirectOnlyを維持する。
     seed_local_community_node_consents(&runtime_a, community_base_url, 1);
     runtime_a
         .apply_runtime_connectivity_assist()
@@ -752,7 +752,7 @@ async fn runtime_starts_with_unreachable_community_node_and_recovers_via_manual_
             .expect("sync status after consent")
             .discovery
             .connect_mode,
-        ConnectMode::DirectOrRelay
+        ConnectMode::DirectOnly
     );
     runtime_a
         .run_community_node_session_maintenance_once()

--- a/crates/desktop-runtime/src/tests/community_node/index_query.rs
+++ b/crates/desktop-runtime/src/tests/community_node/index_query.rs
@@ -726,6 +726,14 @@ async fn awaiting_admission_manual_refresh_rechecks_policy_and_blocks_protected_
             CommunityNodeSessionPhase::AwaitingAdmission,
         )
         .await;
+    crate::identity::persist_optional_secret(
+        &runtime.db_path,
+        runtime.identity_mode,
+        crate::community_node::COMMUNITY_NODE_TOKEN_PURPOSE,
+        base_url.as_str(),
+        "invalid persisted token",
+    )
+    .expect("persist invalid token sentinel");
 
     let status = runtime
         .refresh_community_node_metadata(CommunityNodeTargetRequest {

--- a/crates/desktop-runtime/src/tests/community_node/index_query.rs
+++ b/crates/desktop-runtime/src/tests/community_node/index_query.rs
@@ -660,6 +660,97 @@ async fn community_node_private_indexing_stops_before_secret_when_consent_is_pen
 }
 
 #[tokio::test]
+async fn retrying_session_stops_indexing_request_before_http() {
+    let _resource = lock_test_resource(TestResource::CommunityNodeServer).await;
+    let (runtime, base_url, managed, state, server, _dir) = index_runtime(None).await;
+    runtime
+        .set_community_node_retry_state(
+            base_url.as_str(),
+            anyhow::anyhow!("temporary session failure"),
+        )
+        .await;
+
+    let error = runtime
+        .submit_community_node_indexing_request(CommunityNodeIndexingRequest {
+            base_url,
+            scope_kind: IndexScopeKind::PublicTopic,
+            topic_id: "kukuri:topic:indexing-request".to_string(),
+            channel_id: None,
+            confirm_private_channel_secret_disclosure: false,
+        })
+        .await
+        .expect_err("retrying session must defer the indexing request");
+
+    assert_eq!(error.code, "COMMUNITY_NODE_SESSION_DEFERRED");
+    assert_eq!(managed.policies_hits.load(Ordering::SeqCst), 1);
+    assert!(state.indexing_requests.lock().await.is_empty());
+    runtime.shutdown().await;
+    server.abort();
+}
+
+#[tokio::test]
+async fn retrying_session_preflights_and_stops_index_query_before_http() {
+    let _resource = lock_test_resource(TestResource::CommunityNodeServer).await;
+    let (runtime, base_url, managed, state, server, _dir) = index_runtime(None).await;
+    runtime
+        .set_community_node_retry_state(
+            base_url.as_str(),
+            anyhow::anyhow!("temporary session failure"),
+        )
+        .await;
+
+    runtime
+        .search_community_node_index(scoped_request(base_url.as_str()))
+        .await
+        .expect_err("retrying session must defer the protected query");
+
+    assert_eq!(managed.policies_hits.load(Ordering::SeqCst), 1);
+    assert_eq!(managed.challenge_hits.load(Ordering::SeqCst), 0);
+    assert_eq!(managed.verify_hits.load(Ordering::SeqCst), 0);
+    assert_eq!(managed.consent_status_hits.load(Ordering::SeqCst), 0);
+    assert!(state.requests.lock().await.is_empty());
+    runtime.shutdown().await;
+    server.abort();
+}
+
+#[tokio::test]
+async fn awaiting_admission_manual_refresh_rechecks_policy_and_blocks_protected_http() {
+    let _resource = lock_test_resource(TestResource::CommunityNodeServer).await;
+    let (runtime, base_url, managed, state, server, _dir) = index_runtime(None).await;
+    managed
+        .simulate_snapshot_update
+        .store(true, Ordering::SeqCst);
+    runtime
+        .set_community_node_session_phase(
+            base_url.as_str(),
+            CommunityNodeSessionPhase::AwaitingAdmission,
+        )
+        .await;
+
+    let status = runtime
+        .refresh_community_node_metadata(CommunityNodeTargetRequest {
+            base_url: base_url.clone(),
+        })
+        .await
+        .expect("manual refresh should return the consent-required status");
+    assert!(status.consent_update_pending);
+    assert_eq!(status.session_phase, CommunityNodeSessionPhase::Idle);
+
+    runtime
+        .search_community_node_index(scoped_request(base_url.as_str()))
+        .await
+        .expect_err("policy update must stop an awaiting-admission query");
+
+    assert_eq!(managed.policies_hits.load(Ordering::SeqCst), 2);
+    assert_eq!(managed.challenge_hits.load(Ordering::SeqCst), 0);
+    assert_eq!(managed.verify_hits.load(Ordering::SeqCst), 0);
+    assert_eq!(managed.consent_status_hits.load(Ordering::SeqCst), 0);
+    assert!(state.requests.lock().await.is_empty());
+    runtime.shutdown().await;
+    server.abort();
+}
+
+#[tokio::test]
 async fn community_node_private_scoped_query_attaches_membership_proof() {
     let _resource = lock_test_resource(TestResource::CommunityNodeServer).await;
     let (runtime, base_url, _managed, state, server, _dir) = index_runtime(None).await;

--- a/crates/desktop-runtime/src/tests/community_node/session.rs
+++ b/crates/desktop-runtime/src/tests/community_node/session.rs
@@ -456,7 +456,7 @@ async fn node_without_local_consent_is_never_contacted() {
 }
 
 #[tokio::test]
-async fn community_node_status_does_not_require_restart_when_connectivity_is_active() {
+async fn community_node_status_does_not_require_restart_when_verified_connectivity_is_active() {
     let _resource = lock_test_resource(TestResource::CommunityNodeServer).await;
     let dir = tempdir().expect("tempdir");
     let db_path = dir.path().join("community-status.db");
@@ -494,6 +494,7 @@ async fn community_node_status_does_not_require_restart_when_connectivity_is_act
     *runtime.community_node_config.lock().await = CommunityNodeConfig {
         nodes: vec![node.clone()],
     };
+    mark_community_node_session_ready_for_test(&runtime, base_url.as_str()).await;
     *runtime.active_connectivity_urls.lock().await = vec![connectivity_url.clone()];
 
     let status = timeout(
@@ -538,7 +539,10 @@ async fn community_node_status_does_not_require_restart_when_connectivity_is_act
             .connectivity_urls,
         vec![connectivity_url]
     );
-    assert_eq!(status.session_phase, crate::CommunityNodeSessionPhase::Idle);
+    assert_eq!(
+        status.session_phase,
+        crate::CommunityNodeSessionPhase::Ready
+    );
     assert!(!status.restart_required);
 
     timeout(test_timeout, runtime.shutdown())

--- a/crates/desktop-runtime/src/tests/community_node/tester_feedback_submission.rs
+++ b/crates/desktop-runtime/src/tests/community_node/tester_feedback_submission.rs
@@ -201,6 +201,28 @@ async fn tester_feedback_client_rejects_invalid_input_without_network() {
 }
 
 #[tokio::test]
+async fn retrying_session_stops_tester_feedback_before_http() {
+    let _resource = lock_test_resource(TestResource::CommunityNodeServer).await;
+    let (runtime, base_url, state, server, _dir) = tester_feedback_runtime(false).await;
+    runtime
+        .set_community_node_retry_state(
+            base_url.as_str(),
+            anyhow::anyhow!("temporary session failure"),
+        )
+        .await;
+
+    let error = runtime
+        .submit_community_node_tester_feedback(submission(base_url.as_str()))
+        .await
+        .expect_err("retrying session must defer tester feedback");
+
+    assert_eq!(error.code, "COMMUNITY_NODE_SESSION_DEFERRED");
+    assert!(state.received.lock().await.is_empty());
+    runtime.shutdown().await;
+    server.abort();
+}
+
+#[tokio::test]
 async fn tester_feedback_client_reauthenticates_once_on_unauthorized() {
     let _resource = lock_test_resource(TestResource::CommunityNodeServer).await;
     let (runtime, base_url, state, server, _dir) = tester_feedback_runtime(true).await;

--- a/crates/desktop-runtime/src/tests/community_node/trust_relation.rs
+++ b/crates/desktop-runtime/src/tests/community_node/trust_relation.rs
@@ -376,6 +376,32 @@ async fn community_node_trust_relation_client_stops_before_http_when_consent_is_
     server.abort();
 }
 
+#[tokio::test]
+async fn retrying_session_stops_trust_relation_request_before_http() {
+    let _resource = lock_test_resource(TestResource::CommunityNodeServer).await;
+    let (runtime, base_url, state, managed, server, _dir) = trust_relation_runtime(None).await;
+    runtime
+        .set_community_node_retry_state(
+            base_url.as_str(),
+            anyhow::anyhow!("temporary session failure"),
+        )
+        .await;
+
+    let error = runtime
+        .read_community_node_trust_user(CommunityNodeUserAdvisoryRequest {
+            base_url,
+            target_pubkey: "a".repeat(64),
+        })
+        .await
+        .expect_err("retrying session must defer the trust request");
+
+    assert_eq!(error.code, "COMMUNITY_NODE_SESSION_DEFERRED");
+    assert_eq!(managed.policies_hits.load(Ordering::SeqCst), 1);
+    assert!(state.requests.lock().await.is_empty());
+    runtime.shutdown().await;
+    server.abort();
+}
+
 // #699: 応答本文の対象識別子が要求対象と違う応答は採用しない。
 #[tokio::test]
 async fn community_node_trust_relation_client_rejects_responses_for_another_target() {

--- a/crates/desktop-runtime/src/tests/support/lock_contract.rs
+++ b/crates/desktop-runtime/src/tests/support/lock_contract.rs
@@ -18,7 +18,7 @@ const LOCK_CLASSIFICATION: &[(&str, &str, usize)] = &[
     ("community_node/config.rs", "ProcessEnvironment", 5),
     ("community_node/connectivity.rs", "IrohNetwork", 6),
     ("community_node/dome_hosting.rs", "CommunityNodeServer", 6),
-    ("community_node/index_query.rs", "CommunityNodeServer", 11),
+    ("community_node/index_query.rs", "CommunityNodeServer", 14),
     ("community_node/metadata.rs", "CommunityNodeServer", 10),
     (
         "community_node/report_submission.rs",
@@ -30,9 +30,9 @@ const LOCK_CLASSIFICATION: &[(&str, &str, usize)] = &[
     (
         "community_node/tester_feedback_submission.rs",
         "CommunityNodeServer",
-        3,
+        4,
     ),
-    ("community_node/trust_relation.rs", "CommunityNodeServer", 4),
+    ("community_node/trust_relation.rs", "CommunityNodeServer", 5),
     ("device_backup.rs", "IdentityStorage", 7),
     ("identity_restart.rs", "IdentityStorage", 2),
     ("media_blob_restore.rs", "IrohNetwork", 11),
@@ -107,10 +107,11 @@ fn lock_acquisitions_match_declared_classification() {
     );
     let total: usize = expected.values().sum();
     assert_eq!(
-        total, 105,
+        total, 110,
         "classification total drifted from the Q7 T6 baseline(#711 で index_query 試験を 1 件、\
          #802 で tester_feedback_submission 試験を 3 件、#862 で config 永続化試験を 2 件、\
          #855 で device_backup 試験を 7 件へ拡充、#857 で report consent gate 試験を 3 件、\
-         Dome hosting consent gate 試験を 6 件、固定面回帰で session・metadata・report を各 1 件追加)"
+         Dome hosting consent gate 試験を 6 件、固定面回帰で session・metadata・report を各 1 件追加、
+         transition rerun で index_query 試験を 3 件、tester feedback・trust relation 試験を各 1 件追加)"
     );
 }

--- a/crates/desktop-runtime/src/tests/support/mock_cn.rs
+++ b/crates/desktop-runtime/src/tests/support/mock_cn.rs
@@ -7,6 +7,7 @@ pub(crate) async fn apply_relay_backed_community_node_seed_peers(
     seed_peers: Vec<CommunityNodeSeedPeer>,
 ) {
     seed_local_community_node_consents(runtime, base_url, 1);
+    mark_community_node_session_ready_for_test(runtime, base_url).await;
     *runtime.community_node_config.lock().await = CommunityNodeConfig {
         nodes: vec![CommunityNodeNodeConfig {
             base_url: base_url.to_string(),
@@ -30,6 +31,21 @@ pub(crate) async fn apply_relay_backed_community_node_seed_peers(
     .await
     .expect("apply seed peers timeout")
     .expect("apply seed peers");
+}
+
+pub(crate) async fn mark_community_node_session_ready_for_test(
+    runtime: &DesktopRuntime,
+    base_url: &str,
+) {
+    let local_consent = crate::community_node::load_community_node_local_consents(
+        &runtime.db_path,
+        runtime.identity_mode,
+        base_url,
+    )
+    .expect("load local consent");
+    runtime
+        .set_community_node_session_ready(base_url, false, local_consent)
+        .await;
 }
 #[derive(Clone)]
 pub(crate) struct MockCommunityNodeState {

--- a/docs/progress/2026-09-04-issue-857-community-node-consent-transition-rerun-v2.md
+++ b/docs/progress/2026-09-04-issue-857-community-node-consent-transition-rerun-v2.md
@@ -1,0 +1,90 @@
+# #857 Community Node同意transition再実行 v2
+
+## 対象
+
+- Scope revision: `2026-09-04-issue-857-transition-rerun-v2`
+- 基準 commit: `db3585c5`
+- リスク区分: `C`
+- Goal: Community Node sessionが`Ready`でない状態から、保護対象HTTP通信またはNode由来relay／seed適用へ進めないようにする。
+- Non-goals: server側#860、report経路の直接preflight方式の変更、将来route、legacy互換、一般的なsecurity hardening、広範なrefactor。
+
+## failing-before
+
+基準 commit上で回帰testを先に追加し、次の3経路が失敗することを確認した。
+
+| transition | test | 修正前の観測 |
+| --- | --- | --- |
+| `TR-1` retry deadline内 | `retrying_session_preflights_and_stops_index_query_before_http` | index queryが保護対象HTTPまで到達した |
+| `TR-2` `AwaitingAdmission`中のpolicy変更 | `awaiting_admission_manual_refresh_rechecks_policy_and_blocks_protected_http` | manual refresh後もindex queryが保護対象HTTPまで到達した |
+| `TR-3` local consentのみ | `connectivity_apply_ignores_local_consent_without_verified_ready_session` | 保存済みrelayがruntimeへ適用された |
+
+いずれも修正前はexit code 101、修正後は成功した。
+
+## 実装と受入条件
+
+| 条件 | 実装 | 実行可能な根拠 |
+| --- | --- | --- |
+| `AC-1` | `ensure_community_node_session*`が`Ready`／`Deferred`／`ConsentRequired`を返す。保護対象callerは`Ready`だけでtoken読込とHTTP処理を続行する | retry中のindex query、indexing request、trust／relation、tester feedbackのnegative test |
+| `AC-2` | session guard取得後、retry deadlineと`AwaitingAdmission`のearly returnより前に公開current policy preflightを行う | `retrying_session_preflights_and_stops_index_query_before_http`、`awaiting_admission_manual_refresh_rechecks_policy_and_blocks_protected_http` |
+| `AC-3` | `Ready`到達時のlocal consentをruntime-only evidenceとしてNodeごとに保持し、現在のlocal consentとの完全一致を要求する | `connectivity_apply_ignores_local_consent_without_verified_ready_session` |
+| `AC-4` | `active_community_node_connectivity_config`が検証済みevidenceを持つNodeだけを残す。初回`Ready`後にrelay／seedを再適用する | `connectivity_apply_keeps_only_the_node_with_verified_ready_session`、既存startup／metadata／connectivity test |
+| `AC-5` | 拒否経路は保護対象HTTP hitを0件にし、未検証Nodeのrelay／seedを適用しない。正常経路とheartbeat再queueも維持する | 追加negative test 7件、既存Community Node test、実connectivity scenario |
+| `INVAR-1` | 公開manifest／policy取得以外は、active local consentとcurrent policy照合済みevidenceの成立後だけ開始する | caller別negative test、startup／mixed-node test、既存report／Dome test |
+
+## 固定surface inventoryの再構築
+
+### `INV-1`: manual refreshとmaintenance
+
+- `refresh_community_node_metadata`は`ensure_community_node_session_with_mode(..., true)`を呼ぶ。結果にかかわらずstatus生成以外の保護処理を続行しない。
+- `run_community_node_session_maintenance_once`から到達する`refresh_community_node_registration_if_due`は型付きoutcomeを受け取り、session helper外の保護処理を続行しない。
+- preflightはretry／`AwaitingAdmission`判定より前に実行される。
+
+### `INV-2`: 登録済みcommand 13件
+
+`apps/desktop/src-tauri/src/commands/community_node.rs`と`apps/desktop/src-tauri/src/lib.rs`の登録点から次を再列挙した。
+
+1. `refresh_community_node_metadata`
+2. `submit_community_node_report`
+3. `submit_community_node_tester_feedback`
+4. `submit_community_node_indexing_request`
+5. `search_community_node_index`
+6. `discover_community_node_index`
+7. `recommend_community_node_index`
+8. `read_community_node_trust_user`
+9. `read_community_node_relation_user`
+10. `list_community_node_relation_neighbors`
+11. `get_community_node_relation_optout`
+12. `set_community_node_relation_optout`
+13. `clear_community_node_relation_optout`
+
+reportは既存の直接preflightを維持する。残る12 commandはmanual refreshまたは4つのshared caller groupを通じて型付きsession outcomeへ到達する。未分類は0件。
+
+### `INV-3`: connectivityのglobal apply
+
+`apply_runtime_connectivity_assist*`、`apply_effective_seed_peers*`、`force_apply_effective_seed_peers`の全callerを逆引きした。config／seed変更、startup、reconnect、metadata／rendezvous更新、session `Ready` transitionは、いずれも`active_community_node_connectivity_config`のNode単位filterを経由する。未分類は0件。
+
+## 状態遷移の結果
+
+| transition | 結果 |
+| --- | --- |
+| `TR-1` | retry deadline中でも公開policyを取得し、`Deferred`または`ConsentRequired`で保護対象callerを停止する |
+| `TR-2` | `AwaitingAdmission`中のmanual refreshでもpolicy変更を検出し、sessionを`Idle`へ戻してconnectivityを無効化する |
+| `TR-3` | restart／config変更／mixed-node global applyでは、検証済みNodeだけのrelay／seedを反映する |
+| `TR-4` | 厳密一致同意と`Ready` evidenceがある正常経路、metadata refresh、heartbeat再queue、実peer接続を維持する |
+
+## validation
+
+- `cargo fmt --all -- --check`: 成功
+- `cargo xtask check`: 成功
+- `cargo xtask oversized-files`: 成功（追加testで一時的に1002行となった既存ファイルを999行へ収め、baselineは変更していない）
+- `cargo test -p kukuri-desktop-runtime`: 176件成功
+- `cargo xtask rust-test`: 本体776件、harness 22件、doc test成功
+- `cargo xtask test`: 本体776件、harness 22件、frontend 1089件、doc test成功
+- `cargo xtask tauri-check`: 成功
+- `cargo xtask e2e-smoke`: 6 step成功
+- `cargo xtask scenario community_node_public_connectivity`: 15 step成功
+- `git diff --check`: 成功（Windows checkoutのLF→CRLF警告のみ）
+
+## merge gate
+
+区分Cのため、この記録だけでは完了にしない。固定したPR headを別コンテキストで独立監査し、`PASS`かつ必須CI成功となった場合だけmergeする。監査結果とmerge後tree比較はIssue commentへ記録する。

--- a/docs/progress/2026-09-04-issue-857-community-node-consent-transition-rerun-v2.md
+++ b/docs/progress/2026-09-04-issue-857-community-node-consent-transition-rerun-v2.md
@@ -88,3 +88,9 @@ reportは既存の直接preflightを維持する。残る12 commandはmanual ref
 ## merge gate
 
 区分Cのため、この記録だけでは完了にしない。固定したPR headを別コンテキストで独立監査し、`PASS`かつ必須CI成功となった場合だけmergeする。監査結果とmerge後tree比較はIssue commentへ記録する。
+
+## 初回独立監査の指摘と修正
+
+PR #892の初回head `a713169d1d9ebb0b1c58bac87bf48e2f958d20fb` は、独立監査で`FAIL`となった。`refresh_community_node_metadata`とmaintenanceが非`Ready` outcomeの後も`community_node_status`へ進み、保存tokenを読み得るExisting-gapが1件残っていた。
+
+この経路は固定`AC-2`／`INV-1`／`TR-1`／`TR-2`に該当するため、壊れた保存tokenを置いた`AwaitingAdmission`状態のmanual refreshがdecode errorになることをfailing-beforeで確認した。その後、statusの認証状態復元を「同じNodeのcurrent-policy検証済みevidenceと現在のlocal consentが一致する場合」だけに限定した。修正後は同testとCommunity Node 111件が成功した。新しいPR headは、このdeltaを含めて再監査する。


### PR DESCRIPTION
## 概要

Community Node sessionのretry／参加承認待ちを含む全transitionで、公開current policyの照合前に保護対象HTTPやNode由来relay／seedへ進めないようにします。session結果を型で区別し、Nodeごとの検証済みevidenceをconnectivityのglobal applyまで保持します。

## Issue lifecycle

- 対象Issue: Refs #857
- リスク区分: C
- Scope revision / 基準commit: `2026-09-04-issue-857-transition-rerun-v2` / `db3585c5`
- Fixed surface inventory: Tauri登録点とruntime APIから13 commandを再列挙し、session helperの全callerとconnectivity apply sinkの全callerを`rg`とCodeGraphで双方向確認。変更前後とも登録入口13件、追加・削除0件、分類変更0件、未分類0件
- Sensitive sink と shared helper の全caller確認: `ensure_community_node_session*`のcaller 6箇所と、`apply_runtime_connectivity_assist*`／`apply_effective_seed_peers*`／`force_apply_effective_seed_peers`のcallerを逆引き。reportは既存の直接preflight、残る12 commandはmanual refreshまたは4 shared caller groupへ分類
- 対象状態遷移: retry deadline、`AwaitingAdmission`、restart／未検証local consent、検証済み／未検証Node混在、`Ready`正常系

## AC / invariant traceability

| AC / INVAR ID | 実装箇所 | test / contract / scenario | 結果 |
| --- | --- | --- | --- |
| AC-1 | `session_runtime_support.rs`とindex／indexing／trust／feedback caller | `retrying_session_preflights_and_stops_index_query_before_http`ほかcaller別negative test | 成功 |
| AC-2 | retry／`AwaitingAdmission`判定前の`preflight_community_node_consent` | `awaiting_admission_manual_refresh_rechecks_policy_and_blocks_protected_http` | 成功 |
| AC-3 | `CommunityNodeSessionState::current_policy_verified_for` | `connectivity_apply_ignores_local_consent_without_verified_ready_session` | 成功 |
| AC-4 | `active_community_node_connectivity_config`と`apply_ready_community_node_connectivity` | `connectivity_apply_keeps_only_the_node_with_verified_ready_session`、既存startup／metadata／connectivity test | 成功 |
| AC-5 | 拒否時のtyped stopとNode単位filter | 追加negative test 7件、既存Community Node test、実connectivity scenario | 成功 |
| INVAR-1 | public preflight、typed outcome、per-node evidenceの組合せ | caller別negative、startup／mixed-node、既存report／Dome test | 成功 |

詳細な対応表は `docs/progress/2026-09-04-issue-857-community-node-consent-transition-rerun-v2.md` に記録しています。

## テスト先行証跡

- failing-before: 基準commitで`retrying_session_preflights_and_stops_index_query_before_http`、`awaiting_admission_manual_refresh_rechecks_policy_and_blocks_protected_http`、`connectivity_apply_ignores_local_consent_without_verified_ready_session`がexit code 101。保護対象HTTPまたは保存済みrelay適用への到達を観測
- passing-after: 上記3件と、indexing／trust／tester feedback／mixed-nodeの追加testがすべて成功

## 種別

- [x] fix
- [ ] feature
- [ ] refactor
- [ ] contract／scenario
- [ ] docs
- [ ] deps

## 挙動変更

変更あり。session未準備時は保護対象callerを`CONSENT_REQUIRED`または`COMMUNITY_NODE_SESSION_DEFERRED`で停止し、local consentだけでは保存済みrelay／seedを有効化しません。厳密一致同意と`Ready` evidenceがある正常系、reportの直接preflight、Dome同意境界、heartbeat再queue、Direct P2P復旧は維持します。

## UI変更

対象外: runtimeの同意境界修正であり、画面・導線・IPC形状は変更しません。

## 検証

- targeted: `cargo test -p kukuri-desktop-runtime`（176件成功）
- path別必須validation: `cargo xtask check`、`cargo xtask oversized-files`、`cargo xtask rust-test`（本体776件＋harness 22件）、`cargo xtask test`（同Rust test＋frontend 1089件）、`cargo xtask tauri-check`、`cargo xtask e2e-smoke`（6 step）、`cargo xtask scenario community_node_public_connectivity`（15 step）、`git diff --check`が成功
- 未実行と理由: なし
- CI: final head `0478a95a45e75a6ca161bb78804f05e2f24a4b34`でGitGuardian、Linux 8 job、Windowsの全required checkが成功

## 独立監査

- 要否と理由: 必須。リスク区分C、shared session guard、外部送信、token、relay／seedを含むため
- 初回監査対象commit: `a713169d1d9ebb0b1c58bac87bf48e2f958d20fb`
- 初回判定: `FAIL`。`refresh_community_node_metadata`とmaintenanceが非`Ready` outcome後もstatus生成から保存tokenを読むExisting-gap 1件
- 修正: statusのtoken読込を同じNodeのcurrent-policy検証済みevidenceと現在のlocal consentが一致する場合だけに限定。壊れた保存tokenを置いた`AwaitingAdmission` manual refreshでfailing-before／passing-afterを固定
- 再監査対象commit: `0478a95a45e75a6ca161bb78804f05e2f24a4b34`
- inventory（合計 / 適合 / 不適合 / 未分類）: group `3 / 3 / 0 / 0`、登録command `13 / 13 / 0 / 0`。別枠setter 2件も適合
- AC / INVAR evidence: AC-1〜AC-5／INVAR-1の支配関係、manual refresh／maintenance、正常Ready auth statusを再確認
- blocker: 0件
- non-blocker: Existing-gap 0、Regression 0、New-requirement 0、Optional-hardening 0
- 判定: `PASS`
- 監査後delta: なし
## リスク

- Existing-gap / Regression: retry／`AwaitingAdmission`のearly returnと、local consentだけでglobal connectivityが有効になる既存gapを修正。既存heartbeat再queueの回帰を全test前に検出して同PR内で修正済み
- New-requirement / Optional-hardening: 将来route、未登録機能、一般的な悪意client、server側#860、広範なrefactorは固定Non-goalでありClose blockerにしていません