### PR TITLE
docs: Issue #885のLinux CLI境界とデータ分類を定義

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -55,6 +55,7 @@
 ## Architecture
 - P2P-first community node の責任境界: `docs/architecture/p2p-first-community-node-responsibility-boundary.md`（operator docs / safety / report routing の共通前提）
 - desktop UI のCSS / state / data配置: `docs/architecture/desktop-ui-implementation.md`（製品・視覚契約はroot `DESIGN.md`、開発フローはADR 0014）
+- Linux GUI配布とCLIのローカル制御経路: `docs/adr/0049-linux-gui-cli-control-plane.md`（#885。CLI専用profile、常駐プロセス／IPC、command登録簿、冪等性、配布成果物のデータ分類）
 - moderation event / safety advisory の trust semantics + deterministic (CSAM / known-hash) critical safety: `docs/adr/0027-deterministic-moderation-critical-safety.md`（optional trust input であり network-wide command ではないことを固定。旧 `community-node-critical-safety.md` / `moderation-event-trust-semantics.md` を集約）
 - community node trust / relation foundation: `docs/adr/0026-community-node-trust-relation-foundation.md`
 - default community node 依存低減ロードマップ: `docs/architecture/default-community-node-dependency-reduction.md`（default node は onboarding infrastructure であり network-wide authority ではない）

--- a/docs/adr/0049-linux-gui-cli-control-plane.md
+++ b/docs/adr/0049-linux-gui-cli-control-plane.md
@@ -1,0 +1,124 @@
+# ADR 0049: Linux GUI配布とCLIのローカル制御経路
+
+## Status
+
+Accepted
+
+## Context
+
+Issue #885は、Linux x86_64 GUIをAppImageとして配布し、GUIとは別profileを所有する
+単一所有の常駐プロセスと薄いCLIを介してKukuriクライアントを操作できるようにする。
+
+この追加は既存の投稿、DM、private channel、Live、Game、Metaverse／Dome、Community Nodeの
+canonical sourceを変更しない。一方で、CLI profileの購読期待状態、ローカルIPC、command登録簿、
+冪等性台帳、複数platformの配布成果物という新しいデータ境界を持つため、ADR 0002に
+従って実装前に分類する。
+
+## Feature Data Classification
+
+### Linux GUI／CLI配布成果物
+
+- Feature 名: Linux GUI／CLI Preview Release成果物
+- Durable / Transient: Durable。公開したPreview Release単位で保持する
+- Canonical Source: 配布対象tag／source commitと、そのcommitから検証・署名・集約した同一実行のGitHub Preview Release成果物一式。`latest-preview.json`は公開した成果物のversion、target、URL、signatureを参照する
+- Replicated?: Kukuri protocol上はNo。GitHub Release／CDN上の配布copyはapplication replicaとして扱わない
+- Rebuildable From: 固定source commit、固定したtoolchain／runner、成果物一覧、署名鍵から論理的に再生成可能。ただしtimestampや署名を含むbyte単位の再現性は完了条件にしない
+- Public Replica / Private Replica / Local Only: 公開配布物。Kukuriのpublic／private replicaは増やさない
+- Gossip Hint 必要有無: 不要
+- Blob 必要有無: 不要
+- SQLite projection 必要有無: 不要
+- 必須 contract: x86_64 AppImage、x86_64／aarch64 CLI archive、checksum、必要な署名、Windows成果物、platform manifestを同一sourceから完全に生成し、一部欠落時はmanifest／Releaseを公開しない。署名用secretを成果物、cache、log、untrusted eventへ渡さない
+- 必須 scenario: Ubuntu 22.04／Debian 12における配布済みAppImageの実環境smoke test、x86_64／aarch64 CLI smoke test、Windows回帰、不正なupdater署名、成果物欠落、取得失敗を含む検証環境での更新
+
+### CLI専用profileと購読期待状態
+
+- Feature 名: CLI専用クライアントprofile
+- Durable / Transient: Durable。所有lock、process／session、socketはTransient
+- Canonical Source: GUIと分離したprofile directory内のaccount registry、identity backend、既存featureごとのcanonical store、およびprofile内の購読期待状態
+- Replicated?: 既存製品データだけが各featureの既存契約に従ってreplicateされる。profile管理情報と所有状態はNo
+- Rebuildable From: 既存製品データは各featureのcanonical sourceから復元可能。identityと購読期待状態はそれぞれのローカル永続状態がなければ再構築しない
+- Public Replica / Private Replica / Local Only: 制御情報はLocal Only。製品データの区分は既存featureの分類を維持する
+- Gossip Hint 必要有無: 制御情報には不要。購読後の製品データは既存契約を維持する
+- Blob 必要有無: 制御情報には不要。製品データは既存契約を維持する
+- SQLite projection 必要有無: 既存profile DBを維持する。購読期待状態の具体的な保存形式は子Issueで固定するが、別profileやglobal設定へ暗黙適用しない
+- 必須 contract: GUI profileとのpath／identity非共有、一profile一所有者、同profileの二重起動拒否、別profile同時起動、restart後のidentity／購読期待状態復元、同意前network I/O 0件
+- 必須 scenario: 新規profile、同意待ち、通常起動、restart、signal、同一profileの競合、別profileの同時実行、Secret Service不在
+
+### ローカルsocketの要求／event stream
+
+- Feature 名: 常駐プロセスのローカル制御protocol
+- Durable / Transient: Transient。request／response／NDJSON event stream自体は保存しない
+- Canonical Source: 常駐プロセスの版管理されたcommand登録簿、schema、dispatcher metadata。CLI parserや表示文言を正本にしない
+- Replicated?: No
+- Rebuildable From: command登録簿とruntime eventから再生成する
+- Public Replica / Private Replica / Local Only: Local Only
+- Gossip Hint 必要有無: 不要
+- Blob 必要有無: 不要。大容量mediaはprotocolへbase64で埋め込まず、明示したローカルfile／blob参照を返す
+- SQLite projection 必要有無: 不要
+- 必須 contract: Unix socketのみ、runtime directory 0700、socket 0600、接続元UID一致、TCP listen 0件、版管理されたJSON／NDJSON、stdout／stderr分離、型付きerror、容量／timeout／backpressure上限、remote contentと制御情報の分離
+- 必須 scenario: 正常／不正なenvelope、protocol不一致、常駐プロセス不在、timeout／SIGINT、低速な購読側、上限超過入力、接続元UID不一致、secret／untrusted contentの漏えい検査
+
+### command登録簿と操作安全情報
+
+- Feature 名: CLI command登録簿と操作安全情報
+- Durable / Transient: 実行ファイルに含まれる再生成可能な定義。要求単位の検証結果はTransient
+- Canonical Source: 常駐プロセスのcommand登録簿とdispatcher metadata。CLI parserや呼び出し元の状態を正本にしない
+- Replicated?: No
+- Rebuildable From: sourceとschema生成処理から再生成する
+- Public Replica / Private Replica / Local Only: Local Only
+- Gossip Hint 必要有無: 不要
+- Blob 必要有無: 不要
+- SQLite projection 必要有無: 不要
+- 必須 contract: read／write／destructive／secret-bearing／idempotency-required metadataをdispatcherと同じ定義から生成する。操作可否は既存のaccount、同意、audience、credential、domain authorizationで判定する
+- 必須 scenario: command登録簿とdispatcherの不一致、既存domain authorizationによる許可／拒否、argv／payload／remote contentを制御情報として誤解釈しないこと
+
+### 永続的な冪等性台帳
+
+- Feature 名: CLI変更操作の冪等性台帳
+- Durable / Transient: Durable。ただし件数／期間の上限を持つ
+- Canonical Source: CLI profile内のローカル台帳。domain object自体のcanonical sourceにはしない
+- Replicated?: No
+- Rebuildable From: No。期限内entryはrestartとprofile backup／restoreで維持し、失われた場合に変更操作を自動再実行しない
+- Public Replica / Private Replica / Local Only: Local Only
+- Gossip Hint 必要有無: 不要
+- Blob 必要有無: 不要
+- SQLite projection 必要有無: 必要。profile内のSQLite台帳をcanonicalなlocal stateとして使い、domain SQLite projectionや共有replicaへ混ぜない
+- 必須 contract: command、profile、request idempotency key、canonical payload digestを結び、同一payloadの再実行／異なるpayloadとの競合／実行中停止による結果不明／保持期限切れを区別する。secret-bearing request／resultの平文copyは保存せず、既存domain resultへの参照または秘密情報を含まないresultだけを保持する
+- 必須 scenario: 初回実行、同一payloadの再実行、異なるpayloadとの競合、commit前後の停止、restart、backup／restore、保持期限切れ、同時重複、secret-bearing mutation
+
+## Decision
+
+- GUIとCLIはprofile／identityを共有しない。GUI processと常駐processが同じprofileを同時所有する方式は採用しない。
+- 常駐プロセスだけがprofile内のDesktopRuntimeを所有し、薄いCLIはローカルUnix socket越しにrequestを送る。公開TCP制御APIは提供しない。
+- app／Community Node同意、age gate、restore gateを共通hostで共有し、成立前はruntime、scheduler、remote取得、background通知を開始しない。
+- protocolの正本は常駐プロセスのcommand登録簿／dispatcherとし、schema／command metadataを同じ定義から生成する。
+- account、同意、private audience、credentialなど既存の製品側guardは、GUIと同じ意味で常駐プロセス側にも適用する。
+- Tauri updater署名は必須とする。AppImage埋込みGPG署名は別の配布契約として扱い、採否を#889の計画承認前に固定する。
+- Ubuntu 22.04をLinux GUI build基盤とし、Ubuntu 22.04／Debian 12のX11／XWaylandを実環境smoke test対象にする。
+
+## バックアップ／復元境界
+
+- CLI profileのidentity、既存製品データ、購読期待状態、期限内の冪等性entryはprofile backup対象に含める。
+- 所有lock、socket、PID、実行中session、bearer token、endpoint secretは移行しない。
+- app／Community Node同意とage attestationは既存のbackup／restore契約どおり移行せず、restore後に再設定を要求する。
+- restore後に冪等性resultを復元できないkeyは`operation_outcome_unknown`とし、domainの変更操作を自動再実行しない。
+
+## セキュリティ境界
+
+- runtime directory 0700、socket 0600、接続元UID検証は、別OS userからの接続と偶発的なprofile間接続を防ぐ。
+- 同じOS userで動くprocessは同じローカル権限を持つ。分離が必要な運用では別OS userと別profileを使用する。
+
+## Consequences
+
+- CLI追加のために既存featureのdocs／blobs／gossip／SQLite、署名canonical、private audience、P2P三経路を変更してはならない。
+- 常駐プロセス、protocol、command登録簿、台帳はLocal Onlyの制御経路であり、Community Nodeやpeerへ制御指示を送信しない。
+- untrustedなpost／DM本文をcommand、profile、file path、log指示として解釈しない。
+- E2Eで使う一時profileはtest harnessが作成・破棄する。
+- 共通host抽出では、#855／#857後のrestore／consent／background actionを含む全callerを現行基準から再生成する。
+
+## 参照
+
+- [Tauri AppImage](https://v2.tauri.app/distribute/appimage/)
+- [Tauri Updater](https://v2.tauri.app/plugin/updater/)
+- [Tauri Linux signing](https://v2.tauri.app/distribute/sign/linux/)
+- Issue #885、#886、#887、#888、#889、#890

--- a/docs/progress/2026-04-16-mvp-builder-preview-plan.md
+++ b/docs/progress/2026-04-16-mvp-builder-preview-plan.md
@@ -4,6 +4,7 @@
 
 - このマイルストーンは general launch ではなく `builder preview` の切り出しです。
 - capability baseline は [2026-03-10-foundation.md](./2026-03-10-foundation.md) を維持し、その上に `初回体験 / 配布 / 説明 / feedback loop` を載せます。
+- Issue #885を現行マイルストーンへ組み込み、Windows NSISに加えてLinux x86_64 AppImageとx86_64／aarch64利用者向けCLIをPreview Releaseへ載せます。実装順と境界は#886〜#890、データ分類はADR 0049を正本とします。
 - Community Node は最後まで単一の概念として扱います。配布候補と利用者追加 Node はどちらも、Node 固有文書への明示同意後にセッションを自動確立・維持します。
 - current preview surface は `launch -> default product Columns -> profile setup -> community node consent -> node ready -> starter topic -> post/reply -> private channel -> feedback` です。
 
@@ -19,7 +20,8 @@
 ## Preview Surface
 
 - packaged distribution: Windows NSIS installer via GitHub Releases
-- source-run fallback: Linux
+- 配布予定: Linux x86_64 AppImage、x86_64／aarch64 `kukuri-cli`をGitHub Preview Releaseで配布（#885）
+- source実行による代替導線: Linux（#885完了までは現行導線として維持）
 - docs: root README, `docs/runbooks/mvp-user-quickstart.md`, `docs/runbooks/mvp-troubleshooting.md`
 - feedback home: GitHub を canonical とし、preview announcement 前に Discussions か同等の feedback surface を有効化する
 
@@ -37,6 +39,8 @@
 | Preview docs refresh | landed | repo change | README, docs index, user quickstart, troubleshooting を追加 |
 | Device backup / restore | landed | repo change | 使用中の1アカウントを1暗号化ファイルへ保存し、staging検証・rollback・再同意付きで復元 |
 | Windows release workflow | landed | repo change | tag / manual dispatch で NSIS asset を Release に載せる |
+| Linux共通基盤／常駐プロセス／CLI通信規約 | planned | repo change | #886〜#888。GUIと分離したprofileを単一の常駐プロセスが所有し、版管理されたローカルprotocolで非OS固有backendとの同等性を提供する |
+| Linux AppImage／リリース統合 | planned | repo change | #889〜#890。Ubuntu 22.04でのbuild、Ubuntu 22.04／Debian 12での実環境smoke test、複数platform成果物の全件成功を要求するリリースを追加する |
 | Seed content on hosted preview node | planned | launch op | project-owned author で preview topics を事前投入する |
 | GitHub feedback surface | planned | launch op | Discussions category か同等の GitHub feedback home を整備する |
 
@@ -60,9 +64,10 @@
 - [ ] hosted preview node 上で starter topic seed content を確認
 - [ ] GitHub feedback surface を preview copy から辿れるようにする
 - [ ] packaged Windows app で `launch -> ready -> post -> reply -> private channel` を手動確認
+- [ ] #885の全親AC／INVARを満たし、Linux AppImageとx86_64／aarch64 CLIをWindows成果物と同じPreview Releaseへ完全に公開
 
 ## Assumptions
 
 - 配布候補と利用者追加 Node は同じ同意・セッション契約を使い、Node の種別差を作りません。
 - community-node server endpoint contract 自体は変更しません。
-- Linux binary packaging、hosted Storybook、general-public launch、moderation tooling はこの milestone の exit criteria に含めません。
+- Linuxのバイナリ配布と利用者向けCLIは#885としてこのマイルストーンの完了条件に含めます。hosted Storybook、一般公開、モデレーションツールは引き続き含めません。

--- a/docs/progress/2026-06-11-release-readiness-execution-plan.md
+++ b/docs/progress/2026-06-11-release-readiness-execution-plan.md
@@ -1,5 +1,7 @@
 # 2026-06-11 リリース準備 実行計画
 
+> 適用範囲の更新（2026-09-04）: 本文にあるWindows限定／Linux source実行限定の記述は、初回Preview Releaseを成立させた当時の実行基準である。現行のbuilder previewマイルストーンはIssue #885によりLinux x86_64 AppImageとx86_64／aarch64利用者向けCLIを追加する。現行計画は`docs/progress/2026-04-16-mvp-builder-preview-plan.md`、データ分類はADR 0049、実装は#886〜#890を正本とする。#890完了までは`docs/runbooks/release.md`のWindows限定手順が実行可能な現行runbookである。
+
 ## 概要
 
 - この計画は、ビルダープレビューを「配布できる」「更新できる」「問題報告を回収できる」状態にするためのリリース準備計画です。


### PR DESCRIPTION
## 概要

Issue #885の基準commitを再固定し、Linux GUI／CLI対応を現行builder previewマイルストーンへ組み込みました。実装前に必要なデータ分類と、CLI専用profile、常駐プロセス、ローカルIPC、command登録簿、冪等性台帳、配布成果物の責務境界をADR 0049として定義します。

## Issue lifecycle

- 対象Issue（`Refs #...` / `Closes #...`）: Refs #885
- リスク区分: A（実装挙動を変更しない計画・文書変更）
- Scope revision / 基準commit: `2026-09-04-issue-885-linux-cli-epic-v1` / `f933a286bfdef4c2325036af93139746a17f6f3e`
- Fixed surface inventory（探索方法、変更前後、未分類件数）: 対象は文書4件。実装入口、shared helper、sensitive sinkの変更なし。未分類0件
- Sensitive sink と shared helper の全caller確認: 対象外。コード変更なし
- 対象状態遷移（通常、失敗、retry、restart、複数対象など）: 対象外。実装変更なし。将来実装の状態遷移はADR 0049とIssue #885〜#890へ固定

## AC / invariant traceability

| AC / INVAR ID | 実装箇所 | test / contract / scenario | 結果 |
| --- | --- | --- | --- |
| #885 Definition of Ready | `docs/adr/0049-linux-gui-cli-control-plane.md` | データ分類、責務境界、必須contract／scenario | 記載済み |
| #885 現行マイルストーン組み込み | `docs/progress/2026-04-16-mvp-builder-preview-plan.md` | 配布対象、作業項目、完了条件 | 記載済み |
| 既存リリース計画との整合 | `docs/progress/2026-06-11-release-readiness-execution-plan.md` | 過去基準と現行計画の区別 | 記載済み |

## テスト先行証跡

- failing-before: 対象外。機能修正ではなく計画・文書変更
- passing-after: `git diff --check` 成功

## 種別

- [ ] fix
- [ ] feature
- [ ] refactor
- [ ] contract／scenario
- [x] docs
- [ ] deps

## 挙動変更

なし。実装、保存形式、通信形式、配布処理は変更していません。

## UI変更

対象外: UI変更なし。

## 検証

- targeted: `git diff --check` 成功
- path別必須validation: 文書のみのため追加対象なし
- 未実行と理由: コード・設定変更がないためローカルのbuild／testは未実行
- CI: PR作成後に確認

## 独立監査

- 要否と理由: 不要。区分Aの文書変更であり、実装surfaceを変更しない
- 監査対象commit: 対象外
- inventory（合計 / 適合 / 不適合 / 未分類）: 4 / 4 / 0 / 0
- AC / INVAR evidence: 上記対応表
- blocker: 0件
- non-blocker: #886〜#890の実装判断は各子Issueの計画で固定する
- 判定: 対象外
- 監査後delta: 対象外

## リスク

- Existing-gap / Regression: コード変更がないためなし
- New-requirement / Optional-hardening（Close blockerにしていない事項）: AppImage埋込みGPG署名など、ADRで子Issueの計画承認前に決める事項