### PR TITLE
refactor: extract shared client host for #886

### DIFF
--- a/apps/desktop/src-tauri/src/commands/device_backup.rs
+++ b/apps/desktop/src-tauri/src/commands/device_backup.rs
@@ -23,18 +23,14 @@ use crate::state::{
 const PROGRESS_EVENT: &str = "kukuri://device-backup-progress";
 
 async fn rebuild_runtime(
-    app_handle: &tauri::AppHandle,
     state: &DesktopState,
     db_path: PathBuf,
 ) -> Result<(), CommandError> {
-    let runtime = build_runtime(app_handle, db_path).await.map_err(|error| {
+    let runtime = build_runtime(db_path).await.map_err(|error| {
         CommandError::from(format!("failed to restart desktop runtime: {error}"))
     })?;
-    let previous = state.replace_runtime(runtime);
+    let previous = state.host().replace_runtime(runtime).await;
     drop(previous);
-    app_handle
-        .state::<OsNotificationBackground>()
-        .reset_for_account_switch();
     Ok(())
 }
 
@@ -46,8 +42,11 @@ async fn restore_previous_runtime(
     operation_error: CommandError,
 ) -> CommandError {
     let failed_db_path = db_path.clone();
-    match rebuild_runtime(app_handle, state, db_path).await {
+    match rebuild_runtime(state, db_path).await {
         Ok(()) => {
+            app_handle
+                .state::<OsNotificationBackground>()
+                .reset_for_account_switch();
             startup.set_status(DesktopStartupStatus::Ready);
             operation_error
         }
@@ -169,8 +168,11 @@ pub async fn create_device_backup_command(
     };
 
     match operation.map_err(map_error) {
-        Ok(summary) => match rebuild_runtime(&app_handle, &state, restart_path.clone()).await {
+        Ok(summary) => match rebuild_runtime(&state, restart_path.clone()).await {
             Ok(()) => {
+                app_handle
+                    .state::<OsNotificationBackground>()
+                    .reset_for_account_switch();
                 startup.set_status(DesktopStartupStatus::Ready);
                 Ok(summary)
             }

--- a/apps/desktop/src-tauri/src/commands/identity.rs
+++ b/apps/desktop/src-tauri/src/commands/identity.rs
@@ -6,14 +6,14 @@
 use kukuri_desktop_runtime::{
     AccountKeyExport, AccountKeyImportPreview, AccountRecord, AccountsSnapshot,
     ExportAccountKeyRequest, ImportAccountKeyRequest, PreviewAccountKeyImportRequest,
-    SwitchAccountRequest, account_db_path,
+    SwitchAccountRequest,
 };
 use tauri::Manager;
 
 use crate::commands::background_notifications::OsNotificationBackground;
 use crate::restore_lifecycle::{DesktopOperationState, require_runtime_operation_ready};
 use crate::state::{
-    CommandError, DesktopStartupState, DesktopStartupStatus, DesktopState, build_runtime, map_error,
+    CommandError, DesktopStartupState, DesktopStartupStatus, DesktopState, map_error,
 };
 
 #[tauri::command]
@@ -89,32 +89,15 @@ pub async fn switch_account(
 
     startup.set_status(DesktopStartupStatus::Initializing);
 
-    let db_path = account_db_path(&state.app_data_dir, request.account_id.as_str());
-    let new_runtime = match build_runtime(&app_handle, db_path).await {
-        Ok(runtime) => runtime,
-        Err(error) => {
-            // 旧 runtime は無傷のまま残っている。
-            startup.set_status(DesktopStartupStatus::Ready);
-            return Err(CommandError::from(format!(
-                "failed to start the account runtime: {error}"
-            )));
-        }
-    };
-
-    let record = match kukuri_desktop_runtime::set_active_account(
-        &state.app_data_dir,
-        request.account_id.as_str(),
-    ) {
+    let host = state.host();
+    let record = match host.switch_account(request.account_id.as_str()).await {
         Ok(record) => record,
         Err(error) => {
-            new_runtime.shutdown().await;
+            // 旧 runtime は無傷のまま残っている。
             startup.set_status(DesktopStartupStatus::Ready);
             return Err(map_error(error));
         }
     };
-
-    let previous = state.replace_runtime(new_runtime);
-    previous.shutdown().await;
     app_handle
         .state::<OsNotificationBackground>()
         .reset_for_account_switch();

--- a/apps/desktop/src-tauri/src/restore_lifecycle.rs
+++ b/apps/desktop/src-tauri/src/restore_lifecycle.rs
@@ -1,4 +1,4 @@
-use std::{io::Write, path::Path};
+use std::path::Path;
 
 use kukuri_desktop_runtime::{
     DeviceBackupCancellation, DeviceRestorePhase, finalize_pending_device_restore,
@@ -223,18 +223,18 @@ pub(crate) async fn publish_desktop_state(
     next: DesktopState,
 ) -> Result<(), String> {
     if let Some(existing) = app_handle.try_state::<DesktopState>() {
-        let previous = existing.replace_runtime(next.runtime());
+        let previous = existing.replace_host(next.host());
         drop(existing);
         drop(next);
         previous.shutdown().await;
         return Ok(());
     }
 
-    let runtime = next.runtime();
+    let host = next.host();
     if app_handle.manage(next) {
         Ok(())
     } else {
-        runtime.shutdown().await;
+        host.shutdown().await;
         Err("desktop runtime state was initialized concurrently".to_string())
     }
 }
@@ -253,13 +253,13 @@ pub(crate) async fn activate_pending_restore(
     app_data_dir: &Path,
     restored: DesktopState,
 ) -> Result<(), RestoreActivationFailure> {
-    let runtime = restored.runtime();
+    let host = restored.host();
     if let Err(failure) = persist_restore_activation_phase(app_data_dir) {
-        runtime.shutdown().await;
+        host.shutdown().await;
         return Err(failure);
     }
     if let Err(error) = finalize_pending_device_restore(app_data_dir) {
-        runtime.shutdown().await;
+        host.shutdown().await;
         return Err(RestoreActivationFailure::FinishForward(format!(
             "failed to finalize restored runtime activation: {error:#}"
         )));
@@ -291,34 +291,6 @@ pub(crate) async fn rollback_pending_restore_and_rebuild(
         .state::<OsNotificationBackground>()
         .reset_for_account_switch();
     Ok(())
-}
-
-/// 同意fileは破損時も未同意へfail-closedするため、同一fileへの同期writeで十分。
-/// journal phaseはこのfsyncが成功した後にだけ進める。
-pub(crate) fn write_file_durably(path: &Path, bytes: &[u8]) -> Result<(), String> {
-    let mut file = std::fs::OpenOptions::new()
-        .create(true)
-        .truncate(true)
-        .write(true)
-        .open(path)
-        .map_err(|error| {
-            format!(
-                "failed to open consent record `{}`: {error}",
-                path.display()
-            )
-        })?;
-    file.write_all(bytes).map_err(|error| {
-        format!(
-            "failed to write consent record `{}`: {error}",
-            path.display()
-        )
-    })?;
-    file.sync_all().map_err(|error| {
-        format!(
-            "failed to sync consent record `{}`: {error}",
-            path.display()
-        )
-    })
 }
 
 #[cfg(test)]

--- a/apps/desktop/src-tauri/src/state.rs
+++ b/apps/desktop/src-tauri/src/state.rs
@@ -1,221 +1,49 @@
 use std::{
-    path::{Path, PathBuf},
+    path::PathBuf,
     sync::Arc,
-    time::{SystemTime, UNIX_EPOCH},
 };
 
 use kukuri_desktop_runtime::{
-    CommunityNodeConfig, DesktopRuntime, StoreStartupError, ensure_accounts_initialized_from_env,
-    resolve_app_data_dir_from_env, resolve_db_path_from_env,
+    ClientHost, DesktopRuntime, resolve_app_data_dir_from_env, resolve_db_path_from_env,
 };
-use serde::{Deserialize, Serialize};
+pub(crate) use kukuri_desktop_runtime::{
+    AGE_ATTESTATION_VERSION, APP_LEGAL_DOCUMENTS, AgeAttestationRecord, AgeAttestationStatus,
+    AppConsentDocumentRecord, AppConsentDocumentStatus, ClientStartupError as StartupError,
+    ClientStartupState as DesktopStartupState, ClientStartupStatus as DesktopStartupStatus,
+    age_attestation_satisfied, age_attestation_status, app_consent_documents_status,
+    app_consent_satisfied, consent_required_status, current_unix_seconds,
+    failed_startup_status as failed_status, load_app_consent_store, reset_app_consent_at_path,
+    save_app_consent_store,
+};
+#[cfg(test)]
+pub(crate) use kukuri_desktop_runtime::{
+    APP_LEGAL_AUTHORITATIVE_LANGUAGE, APP_LEGAL_EFFECTIVE_DATE, AppConsentStore,
+    ClientStartupErrorKind as DesktopStartupErrorKind, LEGAL_BUNDLE_VERSION,
+    app_consent_documents_satisfied, app_consent_path,
+};
+use serde::Serialize;
 use tauri::{Emitter, Manager};
-use tokio::sync::watch;
 
-/// #859: アカウント切替で runtime を入れ替えられるよう、`manage` 済みの state の
-/// 中で `Arc<DesktopRuntime>` を差し替え可能にする。lock は Arc の clone / 差し替え
-/// だけの短い臨界区間に限定する(runtime の await を跨いで保持しない)。
+/// `manage` 済みのTauri stateでは共有hostの参照だけを保持する。
+/// account runtimeの所有・差し替え・停止は`ClientHost`へ集約し、このlockは
+/// hostのclone / 差し替えだけの短い臨界区間に限定する(awaitを跨がない)。
 pub(crate) struct DesktopState {
-    runtime: std::sync::RwLock<Arc<DesktopRuntime>>,
+    host: std::sync::RwLock<Arc<ClientHost>>,
     pub(crate) app_data_dir: PathBuf,
 }
 
 impl DesktopState {
     pub(crate) fn runtime(&self) -> Arc<DesktopRuntime> {
-        self.runtime.read().expect("runtime lock poisoned").clone()
+        self.host()
+            .runtime()
     }
 
-    pub(crate) fn replace_runtime(&self, next: Arc<DesktopRuntime>) -> Arc<DesktopRuntime> {
-        std::mem::replace(
-            &mut *self.runtime.write().expect("runtime lock poisoned"),
-            next,
-        )
-    }
-}
-
-pub(crate) const LEGAL_BUNDLE_VERSION: i32 = 5;
-pub(crate) const APP_LEGAL_EFFECTIVE_DATE: &str = "2026-09-03";
-pub(crate) const APP_LEGAL_AUTHORITATIVE_LANGUAGE: &str = "ja";
-
-/// 18歳以上の自己申告(#858、ADR 0046)の現行版。文書同意とは独立に管理し、
-/// 申告文言の重要変更時のみ上げて再申告を求める。
-pub(crate) const AGE_ATTESTATION_VERSION: i32 = 1;
-
-/// アプリ同意の対象文書と現行版。同意は bundle 単一フラグではなく文書単位で
-/// 記録する(#857)。現状は全文書が legal bundle 版と同じ版番号を共有しているが、
-/// 記録・判定は slug ごとに独立している。
-pub(crate) const APP_LEGAL_DOCUMENTS: &[(&str, i32)] = &[
-    ("terms", LEGAL_BUNDLE_VERSION),
-    ("privacy", LEGAL_BUNDLE_VERSION),
-];
-
-const APP_CONSENT_FILE_EXTENSION: &str = "app-consent.json";
-
-/// 文書単位のアプリ同意記録(#857)。対象文書 slug・版・日時・同意時の表示言語・
-/// アプリ版を保存する。旧形式(`accepted_bundle_version` の単一フラグ)は
-/// 意図的に読み替えず、未同意として再同意を求める。
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub(crate) struct AppConsentDocumentRecord {
-    pub(crate) slug: String,
-    pub(crate) version: i32,
-    pub(crate) accepted_at: i64,
-    pub(crate) language: String,
-    pub(crate) app_version: String,
-}
-
-/// 18歳以上の自己申告記録(#858)。文書同意とは別の行為として記録する。
-/// 生年月日等は収集せず、申告の事実・版・日時・表示言語・アプリ版のみ保存する。
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub(crate) struct AgeAttestationRecord {
-    pub(crate) version: i32,
-    pub(crate) attested_at: i64,
-    pub(crate) language: String,
-    pub(crate) app_version: String,
-}
-
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
-pub(crate) struct AppConsentStore {
-    #[serde(default)]
-    pub(crate) records: Vec<AppConsentDocumentRecord>,
-    #[serde(default)]
-    pub(crate) age_attestations: Vec<AgeAttestationRecord>,
-}
-
-/// 文書単位の同意状態ビュー。startup gate と `get_app_consent_status` の両方で使う。
-#[derive(Clone, Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub(crate) struct AppConsentDocumentStatus {
-    pub(crate) slug: String,
-    pub(crate) current_version: i32,
-    pub(crate) effective_date: String,
-    pub(crate) authoritative_language: String,
-    pub(crate) material_change: bool,
-    pub(crate) controller_name: String,
-    pub(crate) contact: String,
-    pub(crate) accepted_version: Option<i32>,
-    pub(crate) accepted_at: Option<i64>,
-    pub(crate) accepted_language: Option<String>,
-    pub(crate) accepted_app_version: Option<String>,
-}
-
-#[derive(Clone, Debug, Deserialize)]
-struct DistributionLegalMetadata {
-    controller_name: String,
-    contact: String,
-}
-
-/// 年齢自己申告の状態ビュー。文書同意とは別枠で startup gate と
-/// `get_app_consent_status` に載せる。
-#[derive(Clone, Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub(crate) struct AgeAttestationStatus {
-    pub(crate) current_version: i32,
-    pub(crate) attested_version: Option<i32>,
-    pub(crate) attested_at: Option<i64>,
-}
-
-#[derive(Clone, Debug, Serialize)]
-#[serde(tag = "status", rename_all = "snake_case")]
-pub(crate) enum DesktopStartupStatus {
-    Initializing,
-    Ready,
-    ConsentRequired {
-        documents: Vec<AppConsentDocumentStatus>,
-        age_attestation: AgeAttestationStatus,
-    },
-    Failed {
-        error: DesktopStartupErrorView,
-    },
-}
-
-#[derive(Clone, Debug, Serialize)]
-pub(crate) struct DesktopStartupErrorView {
-    pub(crate) kind: DesktopStartupErrorKind,
-    pub(crate) message: String,
-    pub(crate) detail: String,
-    pub(crate) db_path: Option<String>,
-}
-
-#[derive(Clone, Debug, Serialize)]
-#[serde(rename_all = "snake_case")]
-pub(crate) enum DesktopStartupErrorKind {
-    DatabaseOpen,
-    DatabaseMigration,
-    Unknown,
-}
-
-/// 起動失敗の内部表現。分類済みの `kind` と表示用 `message` を持ち、`build_desktop_state`
-/// の Err として src-tauri 内を流れる。`kind` は anyhow エラーの typed downcast で
-/// 決まる(WP-Q2、従来の文字列 contains 判定を置換)。
-#[derive(Debug)]
-pub(crate) struct StartupError {
-    pub(crate) kind: DesktopStartupErrorKind,
-    pub(crate) message: String,
-}
-
-impl StartupError {
-    /// 分類できない起動失敗(db パス解決失敗など)。
-    pub(crate) fn unknown(message: String) -> Self {
-        Self {
-            kind: DesktopStartupErrorKind::Unknown,
-            message,
-        }
+    pub(crate) fn host(&self) -> Arc<ClientHost> {
+        self.host.read().expect("host lock poisoned").clone()
     }
 
-    fn unknown_from(error: anyhow::Error) -> Self {
-        Self::unknown(error_message(error))
-    }
-
-    /// runtime 構築時の anyhow エラーを typed 分類して包む。
-    fn from_runtime_error(error: anyhow::Error) -> Self {
-        Self {
-            kind: classify_startup_error(&error),
-            message: error_message(error),
-        }
-    }
-}
-
-impl std::fmt::Display for StartupError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(&self.message)
-    }
-}
-
-pub(crate) struct DesktopStartupState {
-    status: watch::Sender<DesktopStartupStatus>,
-}
-
-impl DesktopStartupState {
-    pub(crate) fn initializing() -> Self {
-        Self::new(DesktopStartupStatus::Initializing)
-    }
-
-    fn new(status: DesktopStartupStatus) -> Self {
-        let (status, _) = watch::channel(status);
-        Self { status }
-    }
-
-    pub(crate) fn status(&self) -> DesktopStartupStatus {
-        self.status.borrow().clone()
-    }
-
-    pub(crate) fn set_status(&self, next: DesktopStartupStatus) {
-        self.status.send_replace(next);
-    }
-
-    pub(crate) fn subscribe(&self) -> watch::Receiver<DesktopStartupStatus> {
-        self.status.subscribe()
-    }
-}
-
-pub(crate) fn failed_status(error: StartupError, db_path: Option<PathBuf>) -> DesktopStartupStatus {
-    DesktopStartupStatus::Failed {
-        error: DesktopStartupErrorView {
-            kind: error.kind,
-            message: "kukuri could not open the local app database.".to_string(),
-            detail: error.message,
-            db_path: db_path.map(|path| path.display().to_string()),
-        },
+    pub(crate) fn replace_host(&self, next: Arc<ClientHost>) -> Arc<ClientHost> {
+        std::mem::replace(&mut *self.host.write().expect("host lock poisoned"), next)
     }
 }
 
@@ -367,49 +195,45 @@ pub(crate) async fn build_desktop_state(
     app_handle: &tauri::AppHandle,
 ) -> Result<DesktopState, StartupError> {
     let app_data_dir = resolve_app_data_dir(app_handle).map_err(StartupError::unknown)?;
-    let db_path =
-        ensure_accounts_initialized_from_env(&app_data_dir).map_err(StartupError::unknown_from)?;
-    let runtime = build_runtime(app_handle, db_path).await?;
+    let host = ClientHost::start(app_data_dir.clone())
+        .await?;
+    spawn_runtime_event_bridge(app_handle, &host);
 
     Ok(DesktopState {
-        runtime: std::sync::RwLock::new(runtime),
+        host: std::sync::RwLock::new(host),
         app_data_dir,
     })
 }
 
-/// runtime をひとつ構築し、常駐タスク(CN セッション維持・イベントブリッジ・
-/// sync 監視)まで起動して返す。初回起動とアカウント切替の両方で使う。
+/// backup／restore中に一時停止したruntimeの後継を構築する。
+/// 常駐タスクは`ClientHost::replace_runtime`がevent購読順序を保って開始する。
 pub(crate) async fn build_runtime(
-    app_handle: &tauri::AppHandle,
     db_path: PathBuf,
 ) -> Result<Arc<DesktopRuntime>, StartupError> {
-    // 配布 Node はアカウントごとの runtime 初回構築時だけ候補として渡す。
-    // 保存済み設定(空・置換済みを含む)の優先判定は DesktopRuntime が担う。
-    let initial_community_node_config = distribution_community_node_config()
-        .map_err(|error| StartupError::unknown(error.to_string()))?;
-    let runtime = DesktopRuntime::from_env(db_path, initial_community_node_config)
+    ClientHost::build_detached_runtime(db_path)
         .await
-        .map_err(StartupError::from_runtime_error)?;
-    let runtime = Arc::new(runtime);
-    // トレイ常駐中はフロントのポーリング(hidden で停止)が CN セッションを維持できないため、
-    // runtime 常駐のセッション維持スケジューラをここで起動する(停止は shutdown / プロセス終了)。
-    runtime.start_community_node_session_scheduler().await;
-
-    spawn_runtime_event_bridge(app_handle, &runtime);
-    runtime.start_sync_status_observer().await;
-    Ok(runtime)
 }
 
-fn distribution_community_node_config() -> Result<CommunityNodeConfig, serde_json::Error> {
-    serde_json::from_str(include_str!("../distribution/community-nodes.json"))
+#[cfg(test)]
+fn distribution_community_node_config(
+) -> Result<kukuri_desktop_runtime::CommunityNodeConfig, serde_json::Error> {
+    kukuri_desktop_runtime::distribution_community_node_config()
 }
 
+#[cfg(test)]
+#[derive(serde::Deserialize)]
+struct DistributionLegalMetadata {
+    controller_name: String,
+    contact: String,
+}
+
+#[cfg(test)]
 fn distribution_legal_metadata() -> Result<DistributionLegalMetadata, serde_json::Error> {
     serde_json::from_str(include_str!("../distribution/legal.json"))
 }
 
-fn spawn_runtime_event_bridge(app_handle: &tauri::AppHandle, runtime: &Arc<DesktopRuntime>) {
-    let mut rx = runtime.subscribe_events();
+fn spawn_runtime_event_bridge(app_handle: &tauri::AppHandle, host: &Arc<ClientHost>) {
+    let mut rx = host.subscribe_events();
     let app = app_handle.clone();
     tauri::async_runtime::spawn(async move {
         while let Ok(event) = rx.recv().await {
@@ -418,144 +242,11 @@ fn spawn_runtime_event_bridge(app_handle: &tauri::AppHandle, runtime: &Arc<Deskt
     });
 }
 
-fn app_consent_path(db_path: &Path) -> PathBuf {
-    db_path.with_extension(APP_CONSENT_FILE_EXTENSION)
-}
-
-/// 同意記録ファイルを読む。ファイル欠落・破損・旧形式(bundle 単一フラグ)は
-/// いずれも空の store(= 全文書未同意)として扱う。
-pub(crate) fn load_app_consent_store(db_path: &Path) -> AppConsentStore {
-    let Ok(bytes) = std::fs::read(app_consent_path(db_path)) else {
-        return AppConsentStore::default();
-    };
-    serde_json::from_slice(&bytes).unwrap_or_default()
-}
-
-pub(crate) fn save_app_consent_store(
-    db_path: &Path,
-    store: &AppConsentStore,
-) -> Result<(), String> {
-    let path = app_consent_path(db_path);
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)
-            .map_err(|error| format!("failed to create consent dir: {error}"))?;
-    }
-    let bytes = serde_json::to_vec_pretty(store)
-        .map_err(|error| format!("failed to encode consent record: {error}"))?;
-    crate::restore_lifecycle::write_file_durably(&path, &bytes)
-}
-
 pub(crate) fn reset_app_consent_after_device_restore(
     app_handle: &tauri::AppHandle,
 ) -> Result<DesktopStartupStatus, String> {
     let db_path = resolve_db_path(app_handle)?;
     reset_app_consent_at_path(&db_path)
-}
-
-pub(crate) fn reset_app_consent_at_path(db_path: &Path) -> Result<DesktopStartupStatus, String> {
-    let store = AppConsentStore::default();
-    save_app_consent_store(db_path, &store)?;
-    Ok(consent_required_status(&store))
-}
-
-pub(crate) fn consent_required_status(store: &AppConsentStore) -> DesktopStartupStatus {
-    DesktopStartupStatus::ConsentRequired {
-        documents: app_consent_documents_status(store),
-        age_attestation: age_attestation_status(store),
-    }
-}
-
-/// slug ごとの最新同意記録(版が最大のもの。同版なら日時が新しいもの)。
-fn latest_app_consent_record<'a>(
-    store: &'a AppConsentStore,
-    slug: &str,
-) -> Option<&'a AppConsentDocumentRecord> {
-    store
-        .records
-        .iter()
-        .filter(|record| record.slug == slug)
-        .max_by_key(|record| (record.version, record.accepted_at))
-}
-
-pub(crate) fn app_consent_documents_status(
-    store: &AppConsentStore,
-) -> Vec<AppConsentDocumentStatus> {
-    let legal = distribution_legal_metadata().expect("distribution legal metadata must be valid");
-    APP_LEGAL_DOCUMENTS
-        .iter()
-        .map(|(slug, current_version)| {
-            let latest = latest_app_consent_record(store, slug);
-            AppConsentDocumentStatus {
-                slug: (*slug).to_string(),
-                current_version: *current_version,
-                effective_date: APP_LEGAL_EFFECTIVE_DATE.to_string(),
-                authoritative_language: APP_LEGAL_AUTHORITATIVE_LANGUAGE.to_string(),
-                material_change: true,
-                controller_name: legal.controller_name.clone(),
-                contact: legal.contact.clone(),
-                accepted_version: latest.map(|record| record.version),
-                accepted_at: latest.map(|record| record.accepted_at),
-                accepted_language: latest.map(|record| record.language.clone()),
-                accepted_app_version: latest.map(|record| record.app_version.clone()),
-            }
-        })
-        .collect()
-}
-
-/// 全対象文書について現行版以上の同意記録があるか。
-pub(crate) fn app_consent_documents_satisfied(store: &AppConsentStore) -> bool {
-    APP_LEGAL_DOCUMENTS.iter().all(|(slug, current_version)| {
-        latest_app_consent_record(store, slug)
-            .map(|record| record.version >= *current_version)
-            .unwrap_or(false)
-    })
-}
-
-/// 現行版以上の年齢自己申告記録があるか(#858)。文書同意とは独立に判定する。
-pub(crate) fn age_attestation_satisfied(store: &AppConsentStore) -> bool {
-    latest_age_attestation_record(store)
-        .map(|record| record.version >= AGE_ATTESTATION_VERSION)
-        .unwrap_or(false)
-}
-
-fn latest_age_attestation_record(store: &AppConsentStore) -> Option<&AgeAttestationRecord> {
-    store
-        .age_attestations
-        .iter()
-        .max_by_key(|record| (record.version, record.attested_at))
-}
-
-pub(crate) fn age_attestation_status(store: &AppConsentStore) -> AgeAttestationStatus {
-    let latest = latest_age_attestation_record(store);
-    AgeAttestationStatus {
-        current_version: AGE_ATTESTATION_VERSION,
-        attested_version: latest.map(|record| record.version),
-        attested_at: latest.map(|record| record.attested_at),
-    }
-}
-
-/// 起動 gate の総合判定: 全文書同意 + 年齢自己申告が揃っているか。
-pub(crate) fn app_consent_satisfied(store: &AppConsentStore) -> bool {
-    app_consent_documents_satisfied(store) && age_attestation_satisfied(store)
-}
-
-pub(crate) fn current_unix_seconds() -> i64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|duration| duration.as_secs() as i64)
-        .unwrap_or(0)
-}
-
-/// 起動時の anyhow エラーを typed に分類する(WP-Q2)。store が返す
-/// `StoreStartupError`(接続 / migration を区別)を downcast で判定する。
-/// anyhow の downcast は `.context()` を跨いでチェーンを辿るため、途中で文脈が
-/// 付与されても root の typed variant に到達する。store 由来でないエラーは Unknown。
-fn classify_startup_error(error: &anyhow::Error) -> DesktopStartupErrorKind {
-    match error.downcast_ref::<StoreStartupError>() {
-        Some(StoreStartupError::Migration(_)) => DesktopStartupErrorKind::DatabaseMigration,
-        Some(StoreStartupError::Open { .. }) => DesktopStartupErrorKind::DatabaseOpen,
-        None => DesktopStartupErrorKind::Unknown,
-    }
 }
 
 #[cfg(test)]
@@ -772,7 +463,7 @@ mod tests {
         std::fs::create_dir_all(&dir).expect("create temp dir");
         let db_path = dir.join("kukuri.db");
         std::fs::write(
-            db_path.with_extension(APP_CONSENT_FILE_EXTENSION),
+            app_consent_path(&db_path),
             r#"{"accepted_bundle_version":2,"accepted_at":1700000000}"#,
         )
         .expect("write legacy consent file");
@@ -966,12 +657,9 @@ mod tests {
             "migration-like wording in an unrelated failure",
             "failed to connect sqlite database (but not a StoreStartupError)",
         ] {
-            let error = anyhow::anyhow!(message);
+            let error = StartupError::from_error(anyhow::anyhow!(message));
             assert!(
-                matches!(
-                    classify_startup_error(&error),
-                    DesktopStartupErrorKind::Unknown
-                ),
+                matches!(error.kind, DesktopStartupErrorKind::Unknown),
                 "non-store error must classify as Unknown regardless of message: {message}"
             );
         }

--- a/crates/desktop-runtime/src/host/consent.rs
+++ b/crates/desktop-runtime/src/host/consent.rs
@@ -1,0 +1,258 @@
+use std::{
+    io::Write,
+    path::{Path, PathBuf},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use serde::{Deserialize, Serialize};
+
+pub const LEGAL_BUNDLE_VERSION: i32 = 5;
+pub const APP_LEGAL_EFFECTIVE_DATE: &str = "2026-09-03";
+pub const APP_LEGAL_AUTHORITATIVE_LANGUAGE: &str = "ja";
+pub const AGE_ATTESTATION_VERSION: i32 = 1;
+pub const APP_LEGAL_DOCUMENTS: &[(&str, i32)] = &[
+    ("terms", LEGAL_BUNDLE_VERSION),
+    ("privacy", LEGAL_BUNDLE_VERSION),
+];
+
+const APP_CONSENT_FILE_EXTENSION: &str = "app-consent.json";
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AppConsentDocumentRecord {
+    pub slug: String,
+    pub version: i32,
+    pub accepted_at: i64,
+    pub language: String,
+    pub app_version: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgeAttestationRecord {
+    pub version: i32,
+    pub attested_at: i64,
+    pub language: String,
+    pub app_version: String,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AppConsentStore {
+    #[serde(default)]
+    pub records: Vec<AppConsentDocumentRecord>,
+    #[serde(default)]
+    pub age_attestations: Vec<AgeAttestationRecord>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AppConsentDocumentStatus {
+    pub slug: String,
+    pub current_version: i32,
+    pub effective_date: String,
+    pub authoritative_language: String,
+    pub material_change: bool,
+    pub controller_name: String,
+    pub contact: String,
+    pub accepted_version: Option<i32>,
+    pub accepted_at: Option<i64>,
+    pub accepted_language: Option<String>,
+    pub accepted_app_version: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct DistributionLegalMetadata {
+    controller_name: String,
+    contact: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgeAttestationStatus {
+    pub current_version: i32,
+    pub attested_version: Option<i32>,
+    pub attested_at: Option<i64>,
+}
+
+pub fn app_consent_path(db_path: &Path) -> PathBuf {
+    db_path.with_extension(APP_CONSENT_FILE_EXTENSION)
+}
+
+/// ファイル欠落・破損・旧形式はいずれも未同意へ倒す。
+pub fn load_app_consent_store(db_path: &Path) -> AppConsentStore {
+    let Ok(bytes) = std::fs::read(app_consent_path(db_path)) else {
+        return AppConsentStore::default();
+    };
+    serde_json::from_slice(&bytes).unwrap_or_default()
+}
+
+pub fn save_app_consent_store(db_path: &Path, store: &AppConsentStore) -> Result<(), String> {
+    let path = app_consent_path(db_path);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|error| format!("failed to create consent dir: {error}"))?;
+    }
+    let bytes = serde_json::to_vec_pretty(store)
+        .map_err(|error| format!("failed to encode consent record: {error}"))?;
+    write_file_durably(&path, &bytes)
+}
+
+pub fn reset_app_consent_at_path(db_path: &Path) -> Result<ClientStartupStatus, String> {
+    let store = AppConsentStore::default();
+    save_app_consent_store(db_path, &store)?;
+    Ok(consent_required_status(&store))
+}
+
+pub fn consent_required_status(store: &AppConsentStore) -> ClientStartupStatus {
+    ClientStartupStatus::ConsentRequired {
+        documents: app_consent_documents_status(store),
+        age_attestation: age_attestation_status(store),
+    }
+}
+
+fn latest_app_consent_record<'a>(
+    store: &'a AppConsentStore,
+    slug: &str,
+) -> Option<&'a AppConsentDocumentRecord> {
+    store
+        .records
+        .iter()
+        .filter(|record| record.slug == slug)
+        .max_by_key(|record| (record.version, record.accepted_at))
+}
+
+pub fn app_consent_documents_status(store: &AppConsentStore) -> Vec<AppConsentDocumentStatus> {
+    let legal: DistributionLegalMetadata = serde_json::from_str(include_str!(
+        "../../../../apps/desktop/src-tauri/distribution/legal.json"
+    ))
+    .expect("distribution legal metadata must be valid");
+    APP_LEGAL_DOCUMENTS
+        .iter()
+        .map(|(slug, current_version)| {
+            let latest = latest_app_consent_record(store, slug);
+            AppConsentDocumentStatus {
+                slug: (*slug).to_string(),
+                current_version: *current_version,
+                effective_date: APP_LEGAL_EFFECTIVE_DATE.to_string(),
+                authoritative_language: APP_LEGAL_AUTHORITATIVE_LANGUAGE.to_string(),
+                material_change: true,
+                controller_name: legal.controller_name.clone(),
+                contact: legal.contact.clone(),
+                accepted_version: latest.map(|record| record.version),
+                accepted_at: latest.map(|record| record.accepted_at),
+                accepted_language: latest.map(|record| record.language.clone()),
+                accepted_app_version: latest.map(|record| record.app_version.clone()),
+            }
+        })
+        .collect()
+}
+
+pub fn app_consent_documents_satisfied(store: &AppConsentStore) -> bool {
+    APP_LEGAL_DOCUMENTS.iter().all(|(slug, current_version)| {
+        latest_app_consent_record(store, slug)
+            .map(|record| record.version >= *current_version)
+            .unwrap_or(false)
+    })
+}
+
+pub fn age_attestation_satisfied(store: &AppConsentStore) -> bool {
+    latest_age_attestation_record(store)
+        .map(|record| record.version >= AGE_ATTESTATION_VERSION)
+        .unwrap_or(false)
+}
+
+fn latest_age_attestation_record(store: &AppConsentStore) -> Option<&AgeAttestationRecord> {
+    store
+        .age_attestations
+        .iter()
+        .max_by_key(|record| (record.version, record.attested_at))
+}
+
+pub fn age_attestation_status(store: &AppConsentStore) -> AgeAttestationStatus {
+    let latest = latest_age_attestation_record(store);
+    AgeAttestationStatus {
+        current_version: AGE_ATTESTATION_VERSION,
+        attested_version: latest.map(|record| record.version),
+        attested_at: latest.map(|record| record.attested_at),
+    }
+}
+
+pub fn app_consent_satisfied(store: &AppConsentStore) -> bool {
+    app_consent_documents_satisfied(store) && age_attestation_satisfied(store)
+}
+
+pub fn current_unix_seconds() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum ClientStartupStatus {
+    Initializing,
+    Ready,
+    ConsentRequired {
+        documents: Vec<AppConsentDocumentStatus>,
+        age_attestation: AgeAttestationStatus,
+    },
+    Failed {
+        error: ClientStartupErrorView,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct ClientStartupErrorView {
+    pub kind: ClientStartupErrorKind,
+    pub message: String,
+    pub detail: String,
+    pub db_path: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ClientStartupErrorKind {
+    DatabaseOpen,
+    DatabaseMigration,
+    Unknown,
+}
+
+fn write_file_durably(path: &Path, bytes: &[u8]) -> Result<(), String> {
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .truncate(true)
+        .write(true)
+        .open(path)
+        .map_err(|error| {
+            format!(
+                "failed to open consent record `{}`: {error}",
+                path.display()
+            )
+        })?;
+    file.write_all(bytes).map_err(|error| {
+        format!(
+            "failed to write consent record `{}`: {error}",
+            path.display()
+        )
+    })?;
+    file.sync_all().map_err(|error| {
+        format!(
+            "failed to sync consent record `{}`: {error}",
+            path.display()
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_or_invalid_consent_is_fail_closed() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = dir.path().join("kukuri.db");
+        assert!(!app_consent_satisfied(&load_app_consent_store(&db_path)));
+
+        std::fs::write(app_consent_path(&db_path), b"not-json").expect("write invalid consent");
+        assert!(!app_consent_satisfied(&load_app_consent_store(&db_path)));
+    }
+}

--- a/crates/desktop-runtime/src/host/mod.rs
+++ b/crates/desktop-runtime/src/host/mod.rs
@@ -1,0 +1,321 @@
+mod consent;
+
+use std::{
+    path::{Path, PathBuf},
+    sync::{
+        Arc, RwLock,
+        atomic::{AtomicBool, Ordering},
+    },
+};
+
+use tokio::{sync::broadcast, task::JoinHandle};
+
+use crate::{
+    AccountRecord, CommunityNodeConfig, DesktopRuntime, RuntimeEvent, StoreStartupError,
+    account_db_path, ensure_accounts_initialized_from_env, list_accounts, set_active_account,
+};
+
+pub use consent::{
+    AGE_ATTESTATION_VERSION, APP_LEGAL_AUTHORITATIVE_LANGUAGE, APP_LEGAL_DOCUMENTS,
+    APP_LEGAL_EFFECTIVE_DATE, AgeAttestationRecord, AgeAttestationStatus, AppConsentDocumentRecord,
+    AppConsentDocumentStatus, AppConsentStore, ClientStartupErrorKind, ClientStartupErrorView,
+    ClientStartupStatus, LEGAL_BUNDLE_VERSION, age_attestation_satisfied, age_attestation_status,
+    app_consent_documents_satisfied, app_consent_documents_status, app_consent_path,
+    app_consent_satisfied, consent_required_status, current_unix_seconds, load_app_consent_store,
+    reset_app_consent_at_path, save_app_consent_store,
+};
+
+#[derive(Debug)]
+pub struct ClientStartupError {
+    pub kind: ClientStartupErrorKind,
+    pub message: String,
+}
+
+impl ClientStartupError {
+    pub fn unknown(message: String) -> Self {
+        Self {
+            kind: ClientStartupErrorKind::Unknown,
+            message,
+        }
+    }
+
+    pub fn from_error(error: anyhow::Error) -> Self {
+        let kind = match error.downcast_ref::<StoreStartupError>() {
+            Some(StoreStartupError::Migration(_)) => ClientStartupErrorKind::DatabaseMigration,
+            Some(StoreStartupError::Open { .. }) => ClientStartupErrorKind::DatabaseOpen,
+            None => ClientStartupErrorKind::Unknown,
+        };
+        Self {
+            kind,
+            message: format!("{error:#}"),
+        }
+    }
+}
+
+impl std::fmt::Display for ClientStartupError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+pub fn failed_startup_status(
+    error: ClientStartupError,
+    db_path: Option<PathBuf>,
+) -> ClientStartupStatus {
+    ClientStartupStatus::Failed {
+        error: ClientStartupErrorView {
+            kind: error.kind,
+            message: "kukuri could not open the local app database.".to_string(),
+            detail: error.message,
+            db_path: db_path.map(|path| path.display().to_string()),
+        },
+    }
+}
+
+pub struct ClientStartupState {
+    status: tokio::sync::watch::Sender<ClientStartupStatus>,
+}
+
+impl ClientStartupState {
+    pub fn initializing() -> Self {
+        Self::new(ClientStartupStatus::Initializing)
+    }
+
+    pub fn new(status: ClientStartupStatus) -> Self {
+        let (status, _) = tokio::sync::watch::channel(status);
+        Self { status }
+    }
+
+    pub fn status(&self) -> ClientStartupStatus {
+        self.status.borrow().clone()
+    }
+
+    pub fn set_status(&self, next: ClientStartupStatus) {
+        self.status.send_replace(next);
+    }
+
+    pub fn subscribe(&self) -> tokio::sync::watch::Receiver<ClientStartupStatus> {
+        self.status.subscribe()
+    }
+}
+
+/// UI adapterに依存せず、一つのactive account runtimeとevent転送を所有する。
+pub struct ClientHost {
+    runtime: RwLock<Arc<DesktopRuntime>>,
+    app_data_dir: PathBuf,
+    events: broadcast::Sender<RuntimeEvent>,
+    event_state: Arc<std::sync::Mutex<ClientEventState>>,
+    event_task: tokio::sync::Mutex<Option<JoinHandle<()>>>,
+    switch_guard: tokio::sync::Mutex<()>,
+    shutdown_started: AtomicBool,
+}
+
+#[derive(Default)]
+struct ClientEventState {
+    latest_sync_status: Option<RuntimeEvent>,
+}
+
+/// 新規購読者には直近のsync状態を一度再送し、その後のeventをbroadcastで配信する。
+pub struct ClientEventReceiver {
+    initial: Option<RuntimeEvent>,
+    receiver: broadcast::Receiver<RuntimeEvent>,
+}
+
+impl ClientEventReceiver {
+    pub async fn recv(&mut self) -> Result<RuntimeEvent, broadcast::error::RecvError> {
+        if let Some(initial) = self.initial.take() {
+            return Ok(initial);
+        }
+        self.receiver.recv().await
+    }
+}
+
+impl ClientHost {
+    pub async fn start(app_data_dir: PathBuf) -> Result<Arc<Self>, ClientStartupError> {
+        let db_path = ensure_accounts_initialized_from_env(&app_data_dir)
+            .map_err(ClientStartupError::from_error)?;
+        let runtime = Self::build_detached_runtime(db_path).await?;
+        Ok(Self::from_runtime(app_data_dir, runtime).await)
+    }
+
+    pub async fn from_runtime(app_data_dir: PathBuf, runtime: Arc<DesktopRuntime>) -> Arc<Self> {
+        let (events, _) = broadcast::channel(64);
+        let host = Arc::new(Self {
+            runtime: RwLock::new(runtime.clone()),
+            app_data_dir,
+            events,
+            event_state: Arc::new(std::sync::Mutex::new(ClientEventState::default())),
+            event_task: tokio::sync::Mutex::new(None),
+            switch_guard: tokio::sync::Mutex::new(()),
+            shutdown_started: AtomicBool::new(false),
+        });
+        runtime.start_community_node_session_scheduler().await;
+        host.replace_event_task(runtime).await;
+        host.runtime().start_sync_status_observer().await;
+        host
+    }
+
+    /// runtimeを構築するが、schedulerとobserverはまだ開始しない。
+    /// `from_runtime`または`replace_runtime`へ渡してhostのevent購読後に有効化する。
+    pub async fn build_detached_runtime(
+        db_path: impl AsRef<Path>,
+    ) -> Result<Arc<DesktopRuntime>, ClientStartupError> {
+        let initial_community_node_config = distribution_community_node_config()
+            .map_err(|error| ClientStartupError::unknown(error.to_string()))?;
+        let runtime = DesktopRuntime::from_env(db_path, initial_community_node_config)
+            .await
+            .map_err(ClientStartupError::from_error)?;
+        Ok(Arc::new(runtime))
+    }
+
+    pub fn app_data_dir(&self) -> &Path {
+        &self.app_data_dir
+    }
+
+    pub fn runtime(&self) -> Arc<DesktopRuntime> {
+        self.runtime.read().expect("runtime lock poisoned").clone()
+    }
+
+    pub fn subscribe_events(&self) -> ClientEventReceiver {
+        subscribe_host_events(&self.events, &self.event_state)
+    }
+
+    pub async fn replace_runtime(&self, next: Arc<DesktopRuntime>) -> Arc<DesktopRuntime> {
+        next.start_community_node_session_scheduler().await;
+        let previous = std::mem::replace(
+            &mut *self.runtime.write().expect("runtime lock poisoned"),
+            next.clone(),
+        );
+        self.replace_event_task(next.clone()).await;
+        next.start_sync_status_observer().await;
+        previous
+    }
+
+    pub async fn restart_runtime(
+        &self,
+        db_path: impl AsRef<Path>,
+    ) -> Result<(), ClientStartupError> {
+        let next = Self::build_detached_runtime(db_path).await?;
+        let previous = self.replace_runtime(next).await;
+        previous.shutdown().await;
+        Ok(())
+    }
+
+    pub async fn switch_account(&self, account_id: &str) -> anyhow::Result<AccountRecord> {
+        let _guard = self.switch_guard.lock().await;
+        let snapshot = list_accounts(&self.app_data_dir)?;
+        let record = snapshot
+            .accounts
+            .iter()
+            .find(|record| record.id == account_id)
+            .cloned()
+            .ok_or_else(|| anyhow::anyhow!("unknown account `{account_id}`"))?;
+        if snapshot.active_account_id == account_id {
+            return Ok(record);
+        }
+
+        let db_path = account_db_path(&self.app_data_dir, account_id);
+        let next = Self::build_detached_runtime(db_path)
+            .await
+            .map_err(|error| anyhow::anyhow!("failed to start the account runtime: {error}"))?;
+        let record = match set_active_account(&self.app_data_dir, account_id) {
+            Ok(record) => record,
+            Err(error) => {
+                next.shutdown().await;
+                return Err(error);
+            }
+        };
+        let previous = self.replace_runtime(next).await;
+        previous.shutdown().await;
+        Ok(record)
+    }
+
+    pub async fn shutdown(&self) {
+        if self.shutdown_started.swap(true, Ordering::AcqRel) {
+            return;
+        }
+        if let Some(task) = self.event_task.lock().await.take() {
+            task.abort();
+            let _ = task.await;
+        }
+        self.runtime().shutdown().await;
+    }
+
+    async fn replace_event_task(&self, runtime: Arc<DesktopRuntime>) {
+        let mut task = self.event_task.lock().await;
+        if let Some(previous) = task.take() {
+            previous.abort();
+            let _ = previous.await;
+        }
+        let mut events = runtime.subscribe_events();
+        let sender = self.events.clone();
+        let event_state = self.event_state.clone();
+        *task = Some(tokio::spawn(async move {
+            while let Ok(event) = events.recv().await {
+                forward_host_event(&sender, &event_state, event);
+            }
+        }));
+    }
+}
+
+fn subscribe_host_events(
+    sender: &broadcast::Sender<RuntimeEvent>,
+    event_state: &std::sync::Mutex<ClientEventState>,
+) -> ClientEventReceiver {
+    let state = event_state
+        .lock()
+        .expect("client event state lock poisoned");
+    let receiver = sender.subscribe();
+    let initial = state.latest_sync_status.clone();
+    ClientEventReceiver { initial, receiver }
+}
+
+fn forward_host_event(
+    sender: &broadcast::Sender<RuntimeEvent>,
+    event_state: &std::sync::Mutex<ClientEventState>,
+    event: RuntimeEvent,
+) {
+    let mut state = event_state
+        .lock()
+        .expect("client event state lock poisoned");
+    if matches!(event, RuntimeEvent::SyncStatusChanged { .. }) {
+        state.latest_sync_status = Some(event.clone());
+    }
+    let _ = sender.send(event);
+}
+
+pub fn distribution_community_node_config() -> Result<CommunityNodeConfig, serde_json::Error> {
+    serde_json::from_str(include_str!(
+        "../../../../apps/desktop/src-tauri/distribution/community-nodes.json"
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn late_subscriber_receives_latest_sync_status_once() {
+        let (sender, _) = broadcast::channel(4);
+        let event_state = std::sync::Mutex::new(ClientEventState::default());
+        forward_host_event(
+            &sender,
+            &event_state,
+            RuntimeEvent::SyncStatusChanged {
+                sync_status: None,
+                community_node_statuses: None,
+            },
+        );
+
+        let mut receiver = subscribe_host_events(&sender, &event_state);
+        assert!(matches!(
+            receiver.recv().await,
+            Ok(RuntimeEvent::SyncStatusChanged { .. })
+        ));
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(10), receiver.recv())
+                .await
+                .is_err()
+        );
+    }
+}

--- a/crates/desktop-runtime/src/lib.rs
+++ b/crates/desktop-runtime/src/lib.rs
@@ -3,6 +3,7 @@ mod attachments;
 mod backup;
 mod community_node;
 mod discovery;
+mod host;
 mod identity;
 #[cfg(feature = "ts")]
 mod ipc_ts_export;
@@ -51,6 +52,17 @@ pub use community_node::{
     SubmitCommunityNodeReportStatus, SubmitIndexingRequestResponse, TrustUserReadResponse,
 };
 pub use discovery::{DiscoveryConfig, SetDiscoverySeedsRequest};
+pub use host::{
+    AGE_ATTESTATION_VERSION, APP_LEGAL_AUTHORITATIVE_LANGUAGE, APP_LEGAL_DOCUMENTS,
+    APP_LEGAL_EFFECTIVE_DATE, AgeAttestationRecord, AgeAttestationStatus, AppConsentDocumentRecord,
+    AppConsentDocumentStatus, AppConsentStore, ClientEventReceiver, ClientHost, ClientStartupError,
+    ClientStartupErrorKind, ClientStartupErrorView, ClientStartupState, ClientStartupStatus,
+    LEGAL_BUNDLE_VERSION, age_attestation_satisfied, age_attestation_status,
+    app_consent_documents_satisfied, app_consent_documents_status, app_consent_path,
+    app_consent_satisfied, consent_required_status, current_unix_seconds,
+    distribution_community_node_config, failed_startup_status, load_app_consent_store,
+    reset_app_consent_at_path, save_app_consent_store,
+};
 // 起動エラーの typed 分類(WP-Q2)。src-tauri は downcast で DatabaseOpen/Migration を判定する。
 pub use kukuri_store::StoreStartupError;
 pub use paths::{resolve_app_data_dir_from_env, resolve_db_path_from_env};


### PR DESCRIPTION
## 概要

Issue #886 の第2段階として、Tauri側にあったクライアントruntimeの構築・account切替・event転送・停止と、app consent／age・型付きstartup状態を `kukuri-desktop-runtime::ClientHost` へ抽出しました。

このPRは責務分離専用です。profile lock、daemon、Unix socket、購読永続化などの新機能は後続PRで扱います。

## Issue lifecycle

- 対象Issue: Refs #886
- リスク区分: C
- Scope revision / 基準commit: `2026-09-04-issue-886-shared-host-daemon-v1` / `4cafd6704a239fec84cd0d2922913824a9b2cb51`
- Fixed surface inventory: `build_desktop_state`、app consent acceptance、account switch、backup runtime再構築、restore activation／rollbackからruntime・scheduler・observer・event・shutdown sinkまでをCodeGraphで順方向／逆方向確認。変更前はTauri stateがruntimeを直接所有、変更後は`ClientHost`が単一所有し、Tauriはadapter。未分類0件。
- Sensitive sink と shared helper の全caller確認: `build_desktop_state`、`build_runtime`、`DesktopState::runtime`、`DesktopRuntime::shutdown`、scheduler／observer開始、account registry更新、restore publishをCodeGraphで再生成し、Tauri startup／consent／switch／backup／restoreの全callerを確認。
- 対象状態遷移: 通常startup、同意待ち、account switch成功／失敗、backup後の再構築、restore activation成功／失敗／rollback、runtime shutdown。

## AC / invariant traceability

| AC / INVAR ID | 実装箇所 | test / contract / scenario | 結果 |
| --- | --- | --- | --- |
| AC-1（共通host抽出部分） | `crates/desktop-runtime/src/host/`、Tauri `state.rs` | desktop-runtime host test、Tauri state tests | PASS |
| INVAR-1 | Tauri `state.rs`、`commands/identity.rs`、`commands/device_backup.rs`、`restore_lifecycle.rs` | Tauri lib 36 tests、`e2e-smoke`、device backup/restore scenario | PASS |
| INVAR-2 | consent状態の共有実装、既存Tauri startup gate | consent fail-closed tests、Tauri invoke gate／restore tests | PASS |
| INVAR-3（既存GUI profile部分） | `ClientHost`の単一runtime所有と直列account switch | workspace Rust tests、account／restore tests | PASS |

## テスト先行証跡

- failing-before: 対象外。挙動変更を伴わない責務抽出であり、既存characterization testsをpassing-before契約として使用。
- passing-after: 下記のtargeted／path別validationが成功。

## 種別

- [ ] fix
- [ ] feature
- [x] refactor
- [ ] contract／scenario
- [ ] docs
- [ ] deps

## 挙動変更

なし。GUIのstartup status／DTO／profile、account switch失敗時の旧runtime維持、backup／restore、runtime event、scheduler／observerの既存挙動を維持します。

## UI変更

対象外: UIの表示・操作・DTOを変更していません。

## 検証

- targeted: `cargo test -p kukuri-desktop-runtime host:: -- --test-threads=1`（2件）、Tauri state tests、Tauri lib 36 tests、restore lifecycle 6 testsがPASS。
- path別必須validation: `cargo xtask rust-test`（workspace 794件、harness 22件、doc tests PASS）、`cargo xtask tauri-check`、`cargo xtask e2e-smoke`、`cargo xtask scenario desktop_device_backup_restore`、`cargo xtask scenario community_node_public_connectivity`がPR headでPASS。
- 追加検査: `cargo xtask oversized-files`は既存baseline内（新規超過0件）、`cargo fmt --all -- --check`、`git diff --check`がPASS。
- 未実行と理由: なし。
- CI: GitGuardian、Linux 8ジョブ、Windows 1ジョブの全10 checksがPASS。

## 独立監査

- 要否と理由: 必須。shared guard、同意、network、identity、永続化、restore境界を変更する区分Cのため。
- 監査対象commit: `0b450cd7923f7c2ad99f2d5292c198f577f35835`
- inventory（合計 / 適合 / 不適合 / 未分類）: 今回適用3 / 3 / 0 / 0。固定5件中、daemon／socketを所有する`INV-2`／`INV-3`は後続featureのため対象外。
- AC / INVAR evidence: GUI登録点、同意／restore gate、account switch／backup／restoreのruntime・event task所有、DTO／profile、typed startup errorを順逆call pathとtestで確認。
- blocker: 0件。
- non-blocker: daemon、profile lock、Unix socket、signal shutdown、購読永続化、および共通host自身のconsent orchestrationは後続feature scope。
- 判定: PASS。
- 監査後delta: なし。最終監査対象commitで全validationを実行。

## リスク

- Existing-gap / Regression: 現時点で0件。switch先runtime構築失敗では旧runtimeを維持し、restore公開前の失敗では新host全体を停止する。
- New-requirement / Optional-hardening: profile lease、daemon lifecycle、Unix socket、継続subscriptionは承認済み後続taskで実装し、この責務分離PRのmerge条件には含めない。
