### PR TITLE
feat: Linux client daemonを追加する

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3185,6 +3185,7 @@ name = "kukuri-cli"
 version = "0.1.8"
 dependencies = [
  "anyhow",
+ "blake3",
  "clap",
  "kukuri-desktop-runtime",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3181,6 +3181,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "kukuri-cli"
+version = "0.1.8"
+dependencies = [
+ "anyhow",
+ "clap",
+ "kukuri-desktop-runtime",
+ "libc",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+]
+
+[[package]]
 name = "kukuri-cn-cli"
 version = "0.1.8"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "crates/harness",
     "crates/app-api",
     "crates/desktop-runtime",
+    "crates/kukuri-cli",
     "crates/test-support",
     "crates/cn-core",
     "crates/cn-user-api",
@@ -60,6 +61,7 @@ iroh-mainline-address-lookup = "0.4.0"
 iroh-relay = { version = "1.0.3", features = ["server"] }
 jsonwebtoken = { version = "11.0.0", features = ["aws_lc_rs"] }
 keyring = { version = "4.1.6", default-features = false }
+libc = "0.2.183"
 chacha20poly1305 = "0.11.0"
 n0-mainline = "0.5.0"
 reqwest = { version = "0.13.4", default-features = false, features = ["json", "query", "rustls"] }

--- a/apps/desktop/src-tauri/src/commands/device_backup.rs
+++ b/apps/desktop/src-tauri/src/commands/device_backup.rs
@@ -29,7 +29,13 @@ async fn rebuild_runtime(
     let runtime = build_runtime(db_path).await.map_err(|error| {
         CommandError::from(format!("failed to restart desktop runtime: {error}"))
     })?;
-    let previous = state.host().replace_runtime(runtime).await;
+    let previous = state
+        .host()
+        .replace_runtime(runtime)
+        .await
+        .map_err(|error| {
+            CommandError::from(format!("failed to activate desktop runtime: {error}"))
+        })?;
     drop(previous);
     Ok(())
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -5,7 +5,9 @@ mod state;
 mod tracing;
 
 use ::tracing::{error, info};
-use kukuri_desktop_runtime::{DeviceRestorePhase, pending_device_restore_phase};
+use kukuri_desktop_runtime::{
+    DeviceRestorePhase, ProfileLease, gui_profile, pending_device_restore_phase,
+};
 use tauri::{
     AppHandle, Manager, WindowEvent,
     menu::{Menu, MenuItem},
@@ -23,7 +25,8 @@ use crate::{
         rollback_pending_restore_and_rebuild,
     },
     state::{
-        DesktopStartupState, DesktopStartupStatus, StartupError, app_consent_satisfied,
+        DesktopStartupState, DesktopStartupStatus, DesktopState, StartupError,
+        app_consent_satisfied,
         build_desktop_state, consent_required_status, failed_status, load_app_consent_store,
         resolve_app_data_dir, resolve_db_path,
     },
@@ -138,6 +141,16 @@ fn show_main_window(app: &AppHandle) {
     }
 }
 
+fn shutdown_and_exit(app: &AppHandle) {
+    let app = app.clone();
+    tauri::async_runtime::spawn(async move {
+        if let Some(state) = app.try_state::<DesktopState>() {
+            state.host().shutdown().await;
+        }
+        app.exit(0);
+    });
+}
+
 /// Build the system tray so kukuri stays resident after the window is closed
 /// (issue #304). Closing the window hides it; the app keeps syncing in the
 /// background and only exits via the tray "Quit" entry.
@@ -152,7 +165,7 @@ fn build_tray(app: &AppHandle) -> tauri::Result<()> {
         .show_menu_on_left_click(false)
         .on_menu_event(|app, event| match event.id.as_ref() {
             "open" => show_main_window(app),
-            "quit" => app.exit(0),
+            "quit" => shutdown_and_exit(app),
             _ => {}
         })
         .on_tray_icon_event(|tray, event| {
@@ -207,18 +220,26 @@ pub fn run() {
 
             // Restore journal recoveryは、同意fileの読取やruntime構築より必ず先に行う。
             // 回復不能ならruntimeを開始せずFailedへ閉じる。
-            let startup = match resolve_app_data_dir(app.handle()) {
+            let resolved_profile = resolve_app_data_dir(app.handle())
+                .map_err(StartupError::unknown)
+                .and_then(|app_data_dir| {
+                    ProfileLease::acquire(gui_profile("desktop", app_data_dir.clone()))
+                        .map(|lease| (app_data_dir, lease))
+                        .map_err(StartupError::from_profile_error)
+                });
+            let startup = match resolved_profile {
                 Err(error) => {
-                    let error = StartupError::unknown(error);
-                    error!(%error, "failed to resolve app data before restore recovery");
+                    error!(%error, "failed to acquire desktop profile before restore recovery");
                     (failed_status(error, None), false)
                 }
-                Ok(app_data_dir) => match recover_device_restore_before_startup(&app_data_dir) {
-                    Err(error) => {
-                        error!(%error, "failed to recover pending device restore");
-                        (failed_status(error, None), false)
-                    }
-                    Ok(pending_phase) => match resolve_db_path(app.handle()) {
+                Ok((app_data_dir, profile_lease)) => {
+                    app.manage(profile_lease);
+                    match recover_device_restore_before_startup(&app_data_dir) {
+                        Err(error) => {
+                            error!(%error, "failed to recover pending device restore");
+                            (failed_status(error, None), false)
+                        }
+                        Ok(pending_phase) => match resolve_db_path(app.handle()) {
                         Err(error) => {
                             let error = StartupError::unknown(error);
                             error!(%error, "failed to resolve consent path after restore recovery");
@@ -277,7 +298,8 @@ pub fn run() {
                             };
                             (status, initialize_runtime)
                         }
-                    },
+                        },
+                    }
                 }
             };
             let (initial_status, initialize_runtime) = startup;

--- a/apps/desktop/src-tauri/src/state.rs
+++ b/apps/desktop/src-tauri/src/state.rs
@@ -195,8 +195,14 @@ pub(crate) async fn build_desktop_state(
     app_handle: &tauri::AppHandle,
 ) -> Result<DesktopState, StartupError> {
     let app_data_dir = resolve_app_data_dir(app_handle).map_err(StartupError::unknown)?;
-    let host = ClientHost::start(app_data_dir.clone())
-        .await?;
+    let host = match ClientHost::start_if_consented(app_data_dir.clone()).await? {
+        kukuri_desktop_runtime::ClientHostStart::Ready(host) => host,
+        kukuri_desktop_runtime::ClientHostStart::ConsentRequired(_) => {
+            return Err(StartupError::unknown(
+                "app consent is required before starting the runtime".to_string(),
+            ));
+        }
+    };
     spawn_runtime_event_bridge(app_handle, &host);
 
     Ok(DesktopState {

--- a/apps/desktop/src/lib/api/types.ts
+++ b/apps/desktop/src/lib/api/types.ts
@@ -99,7 +99,13 @@ export type CommandError = {
   retry_after_seconds?: number | null;
 };
 
-export type DesktopStartupErrorKind = 'database_open' | 'database_migration' | 'unknown';
+export type DesktopStartupErrorKind =
+  | 'database_open'
+  | 'database_migration'
+  | 'profile_in_use'
+  | 'profile_invalid'
+  | 'subscription_state'
+  | 'unknown';
 
 export type DesktopStartupErrorView = {
   kind: DesktopStartupErrorKind;

--- a/crates/app-api/src/service/gossip_subscription_support.rs
+++ b/crates/app-api/src/service/gossip_subscription_support.rs
@@ -67,7 +67,7 @@ impl AppService {
     /// Tear down the gossip subscription for a single private channel without
     /// leaving the channel. Mirrors the abort path of
     /// [`restart_private_channel_subscription`].
-    pub(crate) async fn unsubscribe_private_channel(
+    pub async fn unsubscribe_private_channel(
         &self,
         topic_id: &str,
         channel_id: &str,

--- a/crates/app-api/src/service/timeline_subscription_support.rs
+++ b/crates/app-api/src/service/timeline_subscription_support.rs
@@ -235,7 +235,7 @@ impl AppService {
         Ok(Some(envelope))
     }
 
-    pub(crate) async fn ensure_scope_subscriptions(
+    pub async fn ensure_scope_subscriptions(
         &self,
         topic_id: &str,
         scope: &TimelineScope,

--- a/crates/desktop-runtime/src/accounts.rs
+++ b/crates/desktop-runtime/src/accounts.rs
@@ -41,12 +41,13 @@ const ACCOUNT_ID_HEX_CHARS: usize = 16;
 // 移行時に flat レイアウトからアカウントディレクトリへ移す db 兄弟ファイル。
 // harness の cleanup_runtime_artifacts と同じ per-account state の一覧に基づく。
 // `app-consent.json` は端末レベルの状態のため意図的に含めない。
-const FLAT_SIBLING_EXTENSIONS: [&str; 5] = [
+const FLAT_SIBLING_EXTENSIONS: [&str; 6] = [
     "db-shm",
     "db-wal",
     "discovery.json",
     "community-node.json",
     "content-display.json",
+    "subscriptions.json",
 ];
 const FLAT_SIBLING_DIR_EXTENSIONS: [&str; 1] = ["iroh-data"];
 // optional secret の file fallback(`kukuri.<purpose>-<hash>`)の prefix 一覧。

--- a/crates/desktop-runtime/src/backup.rs
+++ b/crates/desktop-runtime/src/backup.rs
@@ -486,6 +486,8 @@ where
         if !staging_db.is_file() {
             bail!("device backup does not contain its SQLite database");
         }
+        crate::host::load_desired_subscriptions(&staging_db)
+            .context("device backup desired subscription state is invalid")?;
         persist_keys(&staging_db, IdentityStorageMode::FileOnly, &keys)?;
         persist_restored_secrets(&staging_db, &secret_bundle)
     })();

--- a/crates/desktop-runtime/src/backup/create.rs
+++ b/crates/desktop-runtime/src/backup/create.rs
@@ -116,6 +116,7 @@ where
             "private_channel_state".to_string(),
             "drafts_and_preferences".to_string(),
             "community_node_configuration".to_string(),
+            "desired_subscriptions".to_string(),
         ],
         requires_reconsent: vec![
             "app_legal_documents".to_string(),
@@ -201,7 +202,11 @@ fn account_file_sources(db_path: &Path) -> Result<Vec<(String, EntrySource)>> {
             add_file_source(&mut sources, &path, Path::new(name))?;
         }
     }
-    for extension in ["discovery.json", "community-node.json"] {
+    for extension in [
+        "discovery.json",
+        "community-node.json",
+        "subscriptions.json",
+    ] {
         let path = db_path.with_extension(extension);
         if path.is_file() {
             let name = path

--- a/crates/desktop-runtime/src/host/consent.rs
+++ b/crates/desktop-runtime/src/host/consent.rs
@@ -213,6 +213,9 @@ pub struct ClientStartupErrorView {
 pub enum ClientStartupErrorKind {
     DatabaseOpen,
     DatabaseMigration,
+    ProfileInUse,
+    ProfileInvalid,
+    SubscriptionState,
     Unknown,
 }
 

--- a/crates/desktop-runtime/src/host/mod.rs
+++ b/crates/desktop-runtime/src/host/mod.rs
@@ -1,4 +1,6 @@
 mod consent;
+mod profile;
+mod subscriptions;
 
 use std::{
     path::{Path, PathBuf},
@@ -24,6 +26,17 @@ pub use consent::{
     app_consent_satisfied, consent_required_status, current_unix_seconds, load_app_consent_store,
     reset_app_consent_at_path, save_app_consent_store,
 };
+pub use profile::{
+    ClientProfile, ClientProfileKind, ProfileError, ProfileErrorKind, ProfileLease, gui_profile,
+    resolve_cli_profile,
+};
+pub(crate) use subscriptions::load_desired_subscriptions;
+#[cfg(test)]
+pub(crate) use subscriptions::save_desired_subscriptions;
+pub use subscriptions::{
+    DesiredSubscription, DesiredSubscriptionScope, SubscriptionStateError,
+    SubscriptionStateErrorKind, desired_subscriptions_path,
+};
 
 #[derive(Debug)]
 pub struct ClientStartupError {
@@ -48,6 +61,24 @@ impl ClientStartupError {
         Self {
             kind,
             message: format!("{error:#}"),
+        }
+    }
+
+    pub fn from_profile_error(error: ProfileError) -> Self {
+        let kind = match error.kind {
+            ProfileErrorKind::ProfileInUse => ClientStartupErrorKind::ProfileInUse,
+            _ => ClientStartupErrorKind::ProfileInvalid,
+        };
+        Self {
+            kind,
+            message: format!("{}: {}", error.code(), error),
+        }
+    }
+
+    pub fn from_subscription_error(error: SubscriptionStateError) -> Self {
+        Self {
+            kind: ClientStartupErrorKind::SubscriptionState,
+            message: format!("{}: {}", error.code(), error),
         }
     }
 }
@@ -106,8 +137,14 @@ pub struct ClientHost {
     events: broadcast::Sender<RuntimeEvent>,
     event_state: Arc<std::sync::Mutex<ClientEventState>>,
     event_task: tokio::sync::Mutex<Option<JoinHandle<()>>>,
-    switch_guard: tokio::sync::Mutex<()>,
+    operation_guard: tokio::sync::Mutex<()>,
+    shutdown_guard: tokio::sync::Mutex<()>,
     shutdown_started: AtomicBool,
+}
+
+pub enum ClientHostStart {
+    Ready(Arc<ClientHost>),
+    ConsentRequired(ClientStartupStatus),
 }
 
 #[derive(Default)]
@@ -131,14 +168,36 @@ impl ClientEventReceiver {
 }
 
 impl ClientHost {
-    pub async fn start(app_data_dir: PathBuf) -> Result<Arc<Self>, ClientStartupError> {
+    pub async fn start_if_consented(
+        app_data_dir: PathBuf,
+    ) -> Result<ClientHostStart, ClientStartupError> {
+        let consent = load_app_consent_store(&app_data_dir.join(crate::paths::DB_FILE_NAME));
+        if !app_consent_satisfied(&consent) {
+            return Ok(ClientHostStart::ConsentRequired(consent_required_status(
+                &consent,
+            )));
+        }
+        Self::start(app_data_dir).await.map(ClientHostStart::Ready)
+    }
+
+    async fn start(app_data_dir: PathBuf) -> Result<Arc<Self>, ClientStartupError> {
         let db_path = ensure_accounts_initialized_from_env(&app_data_dir)
             .map_err(ClientStartupError::from_error)?;
         let runtime = Self::build_detached_runtime(db_path).await?;
-        Ok(Self::from_runtime(app_data_dir, runtime).await)
+        Self::from_runtime(app_data_dir, runtime).await
     }
 
-    pub async fn from_runtime(app_data_dir: PathBuf, runtime: Arc<DesktopRuntime>) -> Arc<Self> {
+    pub async fn from_runtime(
+        app_data_dir: PathBuf,
+        runtime: Arc<DesktopRuntime>,
+    ) -> Result<Arc<Self>, ClientStartupError> {
+        let desired = match subscriptions::load_desired_subscriptions(runtime.db_path()) {
+            Ok(desired) => desired,
+            Err(error) => {
+                runtime.shutdown().await;
+                return Err(ClientStartupError::from_subscription_error(error));
+            }
+        };
         let (events, _) = broadcast::channel(64);
         let host = Arc::new(Self {
             runtime: RwLock::new(runtime.clone()),
@@ -146,13 +205,18 @@ impl ClientHost {
             events,
             event_state: Arc::new(std::sync::Mutex::new(ClientEventState::default())),
             event_task: tokio::sync::Mutex::new(None),
-            switch_guard: tokio::sync::Mutex::new(()),
+            operation_guard: tokio::sync::Mutex::new(()),
+            shutdown_guard: tokio::sync::Mutex::new(()),
             shutdown_started: AtomicBool::new(false),
         });
         runtime.start_community_node_session_scheduler().await;
         host.replace_event_task(runtime).await;
+        if let Err(error) = host.restore_desired_subscriptions(&desired).await {
+            host.shutdown().await;
+            return Err(ClientStartupError::from_subscription_error(error));
+        }
         host.runtime().start_sync_status_observer().await;
-        host
+        Ok(host)
     }
 
     /// runtimeを構築するが、schedulerとobserverはまだ開始しない。
@@ -180,29 +244,70 @@ impl ClientHost {
         subscribe_host_events(&self.events, &self.event_state)
     }
 
-    pub async fn replace_runtime(&self, next: Arc<DesktopRuntime>) -> Arc<DesktopRuntime> {
+    pub async fn replace_runtime(
+        &self,
+        next: Arc<DesktopRuntime>,
+    ) -> Result<Arc<DesktopRuntime>, ClientStartupError> {
+        let _guard = self.operation_guard.lock().await;
+        if self.shutdown_started.load(Ordering::Acquire) {
+            return Err(ClientStartupError::unknown(
+                "client host is shutting down".to_string(),
+            ));
+        }
+        self.replace_runtime_locked(next).await
+    }
+
+    async fn replace_runtime_locked(
+        &self,
+        next: Arc<DesktopRuntime>,
+    ) -> Result<Arc<DesktopRuntime>, ClientStartupError> {
+        let desired = match subscriptions::load_desired_subscriptions(next.db_path()) {
+            Ok(desired) => desired,
+            Err(error) => {
+                next.shutdown().await;
+                return Err(ClientStartupError::from_subscription_error(error));
+            }
+        };
         next.start_community_node_session_scheduler().await;
         let previous = std::mem::replace(
             &mut *self.runtime.write().expect("runtime lock poisoned"),
             next.clone(),
         );
         self.replace_event_task(next.clone()).await;
+        if let Err(error) = self.restore_desired_subscriptions(&desired).await {
+            let failed = std::mem::replace(
+                &mut *self.runtime.write().expect("runtime lock poisoned"),
+                previous.clone(),
+            );
+            self.replace_event_task(previous).await;
+            failed.shutdown().await;
+            return Err(ClientStartupError::from_subscription_error(error));
+        }
         next.start_sync_status_observer().await;
-        previous
+        Ok(previous)
     }
 
     pub async fn restart_runtime(
         &self,
         db_path: impl AsRef<Path>,
     ) -> Result<(), ClientStartupError> {
+        let _guard = self.operation_guard.lock().await;
+        if self.shutdown_started.load(Ordering::Acquire) {
+            return Err(ClientStartupError::unknown(
+                "client host is shutting down".to_string(),
+            ));
+        }
         let next = Self::build_detached_runtime(db_path).await?;
-        let previous = self.replace_runtime(next).await;
+        let previous = self.replace_runtime_locked(next).await?;
         previous.shutdown().await;
         Ok(())
     }
 
     pub async fn switch_account(&self, account_id: &str) -> anyhow::Result<AccountRecord> {
-        let _guard = self.switch_guard.lock().await;
+        let _guard = self.operation_guard.lock().await;
+        if self.shutdown_started.load(Ordering::Acquire) {
+            anyhow::bail!("client host is shutting down");
+        }
         let snapshot = list_accounts(&self.app_data_dir)?;
         let record = snapshot
             .accounts
@@ -218,6 +323,7 @@ impl ClientHost {
         let next = Self::build_detached_runtime(db_path)
             .await
             .map_err(|error| anyhow::anyhow!("failed to start the account runtime: {error}"))?;
+        let previous_account_id = snapshot.active_account_id.clone();
         let record = match set_active_account(&self.app_data_dir, account_id) {
             Ok(record) => record,
             Err(error) => {
@@ -225,15 +331,116 @@ impl ClientHost {
                 return Err(error);
             }
         };
-        let previous = self.replace_runtime(next).await;
+        let previous = match self.replace_runtime_locked(next).await {
+            Ok(previous) => previous,
+            Err(error) => {
+                let rollback = set_active_account(&self.app_data_dir, &previous_account_id);
+                return match rollback {
+                    Ok(_) => Err(anyhow::anyhow!(
+                        "failed to activate account runtime: {error}"
+                    )),
+                    Err(rollback_error) => Err(anyhow::anyhow!(
+                        "failed to activate account runtime: {error}; failed to restore active account: {rollback_error:#}"
+                    )),
+                };
+            }
+        };
         previous.shutdown().await;
         Ok(record)
     }
 
+    pub fn desired_subscriptions(
+        &self,
+    ) -> Result<Vec<DesiredSubscription>, SubscriptionStateError> {
+        subscriptions::load_desired_subscriptions(self.runtime().db_path())
+    }
+
+    pub async fn add_desired_subscription(
+        &self,
+        subscription: DesiredSubscription,
+    ) -> Result<(), SubscriptionStateError> {
+        subscription.validate()?;
+        let _guard = self.operation_guard.lock().await;
+        if self.shutdown_started.load(Ordering::Acquire) {
+            return Err(SubscriptionStateError::new(
+                SubscriptionStateErrorKind::ActivationFailed,
+                "client host is shutting down",
+            ));
+        }
+        let runtime = self.runtime();
+        let mut desired = subscriptions::load_desired_subscriptions(runtime.db_path())?;
+        if desired.contains(&subscription) {
+            return runtime
+                .ensure_desired_subscription(&subscription)
+                .await
+                .map_err(|error| {
+                    SubscriptionStateError::new(
+                        SubscriptionStateErrorKind::ActivationFailed,
+                        format!("failed to activate desired subscription: {error:#}"),
+                    )
+                });
+        }
+        runtime
+            .ensure_desired_subscription(&subscription)
+            .await
+            .map_err(|error| {
+                SubscriptionStateError::new(
+                    SubscriptionStateErrorKind::ActivationFailed,
+                    format!("failed to activate desired subscription: {error:#}"),
+                )
+            })?;
+        let topic_was_desired = desired
+            .iter()
+            .any(|current| current.topic == subscription.topic);
+        desired.push(subscription.clone());
+        if let Err(error) = subscriptions::save_desired_subscriptions(runtime.db_path(), &desired) {
+            let _ = runtime
+                .remove_desired_subscription(&subscription, topic_was_desired)
+                .await;
+            return Err(error);
+        }
+        Ok(())
+    }
+
+    pub async fn remove_desired_subscription(
+        &self,
+        subscription: &DesiredSubscription,
+    ) -> Result<(), SubscriptionStateError> {
+        subscription.validate()?;
+        let _guard = self.operation_guard.lock().await;
+        if self.shutdown_started.load(Ordering::Acquire) {
+            return Err(SubscriptionStateError::new(
+                SubscriptionStateErrorKind::ActivationFailed,
+                "client host is shutting down",
+            ));
+        }
+        let runtime = self.runtime();
+        let mut desired = subscriptions::load_desired_subscriptions(runtime.db_path())?;
+        if !desired.iter().any(|current| current == subscription) {
+            return Ok(());
+        }
+        desired.retain(|current| current != subscription);
+        subscriptions::save_desired_subscriptions(runtime.db_path(), &desired)?;
+        let topic_still_desired = desired
+            .iter()
+            .any(|current| current.topic == subscription.topic);
+        runtime
+            .remove_desired_subscription(subscription, topic_still_desired)
+            .await
+            .map_err(|error| {
+                SubscriptionStateError::new(
+                    SubscriptionStateErrorKind::ActivationFailed,
+                    format!("failed to remove active subscription: {error:#}"),
+                )
+            })
+    }
+
     pub async fn shutdown(&self) {
+        let _shutdown_guard = self.shutdown_guard.lock().await;
         if self.shutdown_started.swap(true, Ordering::AcqRel) {
             return;
         }
+        let _guard = self.operation_guard.lock().await;
         if let Some(task) = self.event_task.lock().await.take() {
             task.abort();
             let _ = task.await;
@@ -255,6 +462,25 @@ impl ClientHost {
                 forward_host_event(&sender, &event_state, event);
             }
         }));
+    }
+
+    async fn restore_desired_subscriptions(
+        &self,
+        desired: &[DesiredSubscription],
+    ) -> Result<(), SubscriptionStateError> {
+        let runtime = self.runtime();
+        for subscription in desired {
+            runtime
+                .ensure_desired_subscription(subscription)
+                .await
+                .map_err(|error| {
+                    SubscriptionStateError::new(
+                        SubscriptionStateErrorKind::ActivationFailed,
+                        format!("failed to restore desired subscription: {error:#}"),
+                    )
+                })?;
+        }
+        Ok(())
     }
 }
 
@@ -317,5 +543,81 @@ mod tests {
                 .await
                 .is_err()
         );
+    }
+
+    #[tokio::test]
+    async fn consent_gate_does_not_initialize_account_or_runtime() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let app_data_dir = root.path().join("profile");
+        let result = ClientHost::start_if_consented(app_data_dir.clone())
+            .await
+            .expect("consent gate");
+        assert!(matches!(result, ClientHostStart::ConsentRequired(_)));
+        assert!(!app_data_dir.join("accounts.json").exists());
+    }
+
+    #[tokio::test]
+    async fn desired_subscription_and_identity_survive_host_restart() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let db_path = root.path().join("kukuri.db");
+        let desired = DesiredSubscription {
+            topic: "kukuri:topic:host-restart".to_string(),
+            scope: DesiredSubscriptionScope::Public,
+        };
+        let runtime = Arc::new(DesktopRuntime::new(&db_path).await.expect("first runtime"));
+        let first = ClientHost::from_runtime(root.path().to_path_buf(), runtime)
+            .await
+            .expect("first host");
+        first
+            .add_desired_subscription(desired.clone())
+            .await
+            .expect("add desired subscription");
+        assert_eq!(
+            first.desired_subscriptions().expect("list desired"),
+            vec![desired.clone()]
+        );
+        let first_status = first
+            .runtime()
+            .get_sync_status()
+            .await
+            .expect("first status");
+        assert!(first_status.subscribed_topics.contains(&desired.topic));
+        first.shutdown().await;
+        first.shutdown().await;
+
+        let runtime = Arc::new(DesktopRuntime::new(&db_path).await.expect("second runtime"));
+        let second = ClientHost::from_runtime(root.path().to_path_buf(), runtime)
+            .await
+            .expect("second host");
+        let second_status = second
+            .runtime()
+            .get_sync_status()
+            .await
+            .expect("second status");
+        assert_eq!(
+            second_status.local_author_pubkey,
+            first_status.local_author_pubkey
+        );
+        assert!(second_status.subscribed_topics.contains(&desired.topic));
+        second
+            .remove_desired_subscription(&desired)
+            .await
+            .expect("remove desired subscription");
+        assert!(
+            second
+                .desired_subscriptions()
+                .expect("list desired")
+                .is_empty()
+        );
+        assert!(
+            !second
+                .runtime()
+                .get_sync_status()
+                .await
+                .expect("status after removal")
+                .subscribed_topics
+                .contains(&desired.topic)
+        );
+        second.shutdown().await;
     }
 }

--- a/crates/desktop-runtime/src/host/profile.rs
+++ b/crates/desktop-runtime/src/host/profile.rs
@@ -1,0 +1,449 @@
+use std::{
+    fs::{File, OpenOptions},
+    path::{Path, PathBuf},
+};
+
+use serde::{Deserialize, Serialize};
+
+const PROFILE_MARKER_FILE: &str = ".kukuri-profile.json";
+const PROFILE_MARKER_TEMP_FILE: &str = ".kukuri-profile.json.tmp";
+const PROFILE_LOCK_FILE: &str = ".kukuri-profile.lock";
+const PROFILE_MARKER_VERSION: u32 = 1;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ClientProfileKind {
+    Gui,
+    Cli,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ClientProfile {
+    pub name: String,
+    pub app_data_dir: PathBuf,
+    pub kind: ClientProfileKind,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ProfileErrorKind {
+    InvalidProfile,
+    ProfileSelectorConflict,
+    ProfileInUse,
+    ProfileKindMismatch,
+    LegacyProfileUnclassified,
+    ProfilePathUnavailable,
+}
+
+impl ProfileErrorKind {
+    pub fn code(self) -> &'static str {
+        match self {
+            Self::InvalidProfile => "invalid_profile",
+            Self::ProfileSelectorConflict => "profile_selector_conflict",
+            Self::ProfileInUse => "profile_in_use",
+            Self::ProfileKindMismatch => "profile_kind_mismatch",
+            Self::LegacyProfileUnclassified => "legacy_profile_unclassified",
+            Self::ProfilePathUnavailable => "profile_path_unavailable",
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct ProfileError {
+    pub kind: ProfileErrorKind,
+    pub message: String,
+}
+
+impl ProfileError {
+    fn new(kind: ProfileErrorKind, message: impl Into<String>) -> Self {
+        Self {
+            kind,
+            message: message.into(),
+        }
+    }
+
+    pub fn code(&self) -> &'static str {
+        self.kind.code()
+    }
+}
+
+impl std::fmt::Display for ProfileError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for ProfileError {}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct ProfileMarker {
+    version: u32,
+    kind: ClientProfileKind,
+}
+
+/// profile内の永続stateより先に取得し、所有期間中はfile handleを保持する。
+#[derive(Debug)]
+pub struct ProfileLease {
+    profile: ClientProfile,
+    _lock: File,
+}
+
+impl ProfileLease {
+    pub fn acquire(profile: ClientProfile) -> Result<Self, ProfileError> {
+        std::fs::create_dir_all(&profile.app_data_dir).map_err(|error| {
+            ProfileError::new(
+                ProfileErrorKind::ProfilePathUnavailable,
+                format!(
+                    "failed to create profile directory `{}`: {error}",
+                    profile.app_data_dir.display()
+                ),
+            )
+        })?;
+        set_private_directory_permissions(&profile.app_data_dir)?;
+
+        let lock_path = profile.app_data_dir.join(PROFILE_LOCK_FILE);
+        let lock = open_private_lock_file(&lock_path)?;
+        if let Err(error) = lock.try_lock() {
+            let (kind, message) = match error {
+                std::fs::TryLockError::WouldBlock => (
+                    ProfileErrorKind::ProfileInUse,
+                    format!(
+                        "profile `{}` is already owned by another process",
+                        profile.name
+                    ),
+                ),
+                std::fs::TryLockError::Error(error) => (
+                    ProfileErrorKind::ProfilePathUnavailable,
+                    format!(
+                        "failed to lock profile `{}` at `{}`: {error}",
+                        profile.name,
+                        lock_path.display()
+                    ),
+                ),
+            };
+            return Err(ProfileError::new(kind, message));
+        }
+
+        validate_or_create_marker(&profile)?;
+        Ok(Self {
+            profile,
+            _lock: lock,
+        })
+    }
+
+    pub fn profile(&self) -> &ClientProfile {
+        &self.profile
+    }
+}
+
+pub fn resolve_cli_profile(
+    argument_profile: Option<&str>,
+    environment_instance: Option<&str>,
+    environment_app_data_dir: Option<&str>,
+    xdg_data_home: Option<&Path>,
+    home: Option<&Path>,
+) -> Result<ClientProfile, ProfileError> {
+    let argument_profile = normalized_selector(argument_profile);
+    let environment_instance = normalized_selector(environment_instance);
+    let environment_app_data_dir = normalized_selector(environment_app_data_dir);
+
+    if argument_profile.is_some()
+        && environment_instance.is_some()
+        && argument_profile != environment_instance
+    {
+        return Err(ProfileError::new(
+            ProfileErrorKind::ProfileSelectorConflict,
+            "--profile and KUKURI_INSTANCE select different profiles",
+        ));
+    }
+    if environment_app_data_dir.is_some()
+        && (argument_profile.is_some() || environment_instance.is_some())
+    {
+        return Err(ProfileError::new(
+            ProfileErrorKind::ProfileSelectorConflict,
+            "KUKURI_APP_DATA_DIR cannot be combined with --profile or KUKURI_INSTANCE",
+        ));
+    }
+
+    let name = argument_profile
+        .or(environment_instance)
+        .unwrap_or("default");
+    validate_profile_name(name)?;
+    let app_data_dir = match environment_app_data_dir {
+        Some(path) => PathBuf::from(path),
+        None => {
+            let base = match xdg_data_home {
+                Some(path) => path.to_path_buf(),
+                None => home
+                    .map(|path| path.join(".local").join("share"))
+                    .ok_or_else(|| {
+                        ProfileError::new(
+                            ProfileErrorKind::ProfilePathUnavailable,
+                            "HOME is required when XDG_DATA_HOME is not set",
+                        )
+                    })?,
+            };
+            base.join("kukuri").join("cli").join("profiles").join(name)
+        }
+    };
+
+    Ok(ClientProfile {
+        name: name.to_string(),
+        app_data_dir,
+        kind: ClientProfileKind::Cli,
+    })
+}
+
+pub fn gui_profile(name: impl Into<String>, app_data_dir: PathBuf) -> ClientProfile {
+    ClientProfile {
+        name: name.into(),
+        app_data_dir,
+        kind: ClientProfileKind::Gui,
+    }
+}
+
+fn normalized_selector(value: Option<&str>) -> Option<&str> {
+    value.map(str::trim).filter(|value| !value.is_empty())
+}
+
+fn validate_profile_name(name: &str) -> Result<(), ProfileError> {
+    let valid = !matches!(name, "." | "..")
+        && !name.is_empty()
+        && name.len() <= 64
+        && name
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-'));
+    if valid {
+        Ok(())
+    } else {
+        Err(ProfileError::new(
+            ProfileErrorKind::InvalidProfile,
+            format!("invalid profile name `{name}`"),
+        ))
+    }
+}
+
+fn open_private_lock_file(path: &Path) -> Result<File, ProfileError> {
+    let file = OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .read(true)
+        .write(true)
+        .open(path)
+        .map_err(|error| {
+            ProfileError::new(
+                ProfileErrorKind::ProfilePathUnavailable,
+                format!("failed to open profile lock `{}`: {error}", path.display()),
+            )
+        })?;
+    set_private_file_permissions(path)?;
+    Ok(file)
+}
+
+fn validate_or_create_marker(profile: &ClientProfile) -> Result<(), ProfileError> {
+    let marker_path = profile.app_data_dir.join(PROFILE_MARKER_FILE);
+    if marker_path.exists() {
+        let bytes = std::fs::read(&marker_path).map_err(|error| {
+            ProfileError::new(
+                ProfileErrorKind::ProfilePathUnavailable,
+                format!(
+                    "failed to read profile marker `{}`: {error}",
+                    marker_path.display()
+                ),
+            )
+        })?;
+        let marker: ProfileMarker = serde_json::from_slice(&bytes).map_err(|error| {
+            ProfileError::new(
+                ProfileErrorKind::ProfileKindMismatch,
+                format!(
+                    "invalid profile marker `{}`: {error}",
+                    marker_path.display()
+                ),
+            )
+        })?;
+        if marker.version != PROFILE_MARKER_VERSION || marker.kind != profile.kind {
+            return Err(ProfileError::new(
+                ProfileErrorKind::ProfileKindMismatch,
+                format!(
+                    "profile `{}` is marked for {:?}, not {:?}",
+                    profile.name, marker.kind, profile.kind
+                ),
+            ));
+        }
+        return Ok(());
+    }
+
+    let has_existing_state = std::fs::read_dir(&profile.app_data_dir)
+        .map_err(|error| {
+            ProfileError::new(
+                ProfileErrorKind::ProfilePathUnavailable,
+                format!(
+                    "failed to inspect profile directory `{}`: {error}",
+                    profile.app_data_dir.display()
+                ),
+            )
+        })?
+        .filter_map(Result::ok)
+        .any(|entry| {
+            entry.file_name() != PROFILE_LOCK_FILE && entry.file_name() != PROFILE_MARKER_TEMP_FILE
+        });
+    if has_existing_state && profile.kind == ClientProfileKind::Cli {
+        return Err(ProfileError::new(
+            ProfileErrorKind::LegacyProfileUnclassified,
+            format!(
+                "unmarked existing profile `{}` cannot be adopted by the CLI",
+                profile.app_data_dir.display()
+            ),
+        ));
+    }
+
+    let marker = ProfileMarker {
+        version: PROFILE_MARKER_VERSION,
+        kind: profile.kind,
+    };
+    let bytes = serde_json::to_vec_pretty(&marker).map_err(|error| {
+        ProfileError::new(
+            ProfileErrorKind::ProfilePathUnavailable,
+            format!("failed to encode profile marker: {error}"),
+        )
+    })?;
+    crate::identity::write_private_file_atomically(&marker_path, &bytes).map_err(|error| {
+        ProfileError::new(
+            ProfileErrorKind::ProfilePathUnavailable,
+            format!(
+                "failed to persist profile marker `{}`: {error}",
+                marker_path.display()
+            ),
+        )
+    })
+}
+
+#[cfg(unix)]
+fn set_private_file_permissions(path: &Path) -> Result<(), ProfileError> {
+    use std::os::unix::fs::PermissionsExt;
+
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600)).map_err(|error| {
+        ProfileError::new(
+            ProfileErrorKind::ProfilePathUnavailable,
+            format!(
+                "failed to set private permissions on `{}`: {error}",
+                path.display()
+            ),
+        )
+    })
+}
+
+#[cfg(not(unix))]
+fn set_private_file_permissions(_path: &Path) -> Result<(), ProfileError> {
+    Ok(())
+}
+
+#[cfg(unix)]
+fn set_private_directory_permissions(path: &Path) -> Result<(), ProfileError> {
+    use std::os::unix::fs::PermissionsExt;
+
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700)).map_err(|error| {
+        ProfileError::new(
+            ProfileErrorKind::ProfilePathUnavailable,
+            format!(
+                "failed to set private permissions on profile directory `{}`: {error}",
+                path.display()
+            ),
+        )
+    })
+}
+
+#[cfg(not(unix))]
+fn set_private_directory_permissions(_path: &Path) -> Result<(), ProfileError> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cli_profile_uses_xdg_path_and_rejects_conflicting_selectors() {
+        let root = Path::new("/data");
+        let profile = resolve_cli_profile(Some("alpha"), Some("alpha"), None, Some(root), None)
+            .expect("matching selectors");
+        assert_eq!(profile.app_data_dir, root.join("kukuri/cli/profiles/alpha"));
+
+        let error = resolve_cli_profile(Some("alpha"), Some("beta"), None, Some(root), None)
+            .expect_err("conflicting selectors");
+        assert_eq!(error.kind, ProfileErrorKind::ProfileSelectorConflict);
+
+        let error = resolve_cli_profile(Some("alpha"), None, Some("/custom"), Some(root), None)
+            .expect_err("explicit directory and selector conflict");
+        assert_eq!(error.kind, ProfileErrorKind::ProfileSelectorConflict);
+    }
+
+    #[test]
+    fn cli_profile_rejects_path_traversal() {
+        let error = resolve_cli_profile(Some("../gui"), None, None, Some(Path::new("/data")), None)
+            .expect_err("path traversal");
+        assert_eq!(error.kind, ProfileErrorKind::InvalidProfile);
+    }
+
+    #[test]
+    fn same_profile_has_one_owner_and_different_profiles_can_coexist() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let first_profile = ClientProfile {
+            name: "first".to_string(),
+            app_data_dir: root.path().join("first"),
+            kind: ClientProfileKind::Cli,
+        };
+        let second_profile = ClientProfile {
+            name: "second".to_string(),
+            app_data_dir: root.path().join("second"),
+            kind: ClientProfileKind::Cli,
+        };
+        let first = ProfileLease::acquire(first_profile.clone()).expect("first owner");
+        let error = ProfileLease::acquire(first_profile).expect_err("duplicate owner");
+        assert_eq!(error.kind, ProfileErrorKind::ProfileInUse);
+        let second = ProfileLease::acquire(second_profile).expect("different profile owner");
+        drop((first, second));
+    }
+
+    #[test]
+    fn profile_kind_is_fail_closed_and_gui_can_adopt_legacy_directory() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let legacy = root.path().join("legacy");
+        std::fs::create_dir_all(&legacy).expect("legacy dir");
+        std::fs::write(legacy.join("accounts.json"), b"legacy").expect("legacy state");
+
+        let cli_error = ProfileLease::acquire(ClientProfile {
+            name: "legacy".to_string(),
+            app_data_dir: legacy.clone(),
+            kind: ClientProfileKind::Cli,
+        })
+        .expect_err("CLI must not adopt an unmarked existing profile");
+        assert_eq!(cli_error.kind, ProfileErrorKind::LegacyProfileUnclassified);
+
+        let gui = ProfileLease::acquire(gui_profile("default", legacy.clone()))
+            .expect("GUI adopts its legacy directory");
+        drop(gui);
+        let cli_error = ProfileLease::acquire(ClientProfile {
+            name: "legacy".to_string(),
+            app_data_dir: legacy,
+            kind: ClientProfileKind::Cli,
+        })
+        .expect_err("marked GUI profile");
+        assert_eq!(cli_error.kind, ProfileErrorKind::ProfileKindMismatch);
+    }
+
+    #[test]
+    fn interrupted_marker_write_does_not_make_a_fresh_cli_profile_unusable() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let profile_dir = root.path().join("interrupted");
+        std::fs::create_dir_all(&profile_dir).expect("profile dir");
+        std::fs::write(profile_dir.join(PROFILE_MARKER_TEMP_FILE), b"partial")
+            .expect("partial marker");
+
+        ProfileLease::acquire(ClientProfile {
+            name: "interrupted".to_string(),
+            app_data_dir: profile_dir,
+            kind: ClientProfileKind::Cli,
+        })
+        .expect("recover marker write");
+    }
+}

--- a/crates/desktop-runtime/src/host/profile.rs
+++ b/crates/desktop-runtime/src/host/profile.rs
@@ -164,12 +164,12 @@ pub fn resolve_cli_profile(
         ));
     }
 
-    let name = argument_profile
+    let selected_name = argument_profile
         .or(environment_instance)
         .unwrap_or("default");
-    validate_profile_name(name)?;
-    let app_data_dir = match environment_app_data_dir {
-        Some(path) => PathBuf::from(path),
+    validate_profile_name(selected_name)?;
+    let (name, app_data_dir) = match environment_app_data_dir {
+        Some(path) => (custom_profile_name(path), PathBuf::from(path)),
         None => {
             let base = match xdg_data_home {
                 Some(path) => path.to_path_buf(),
@@ -182,12 +182,18 @@ pub fn resolve_cli_profile(
                         )
                     })?,
             };
-            base.join("kukuri").join("cli").join("profiles").join(name)
+            (
+                selected_name.to_string(),
+                base.join("kukuri")
+                    .join("cli")
+                    .join("profiles")
+                    .join(selected_name),
+            )
         }
     };
 
     Ok(ClientProfile {
-        name: name.to_string(),
+        name,
         app_data_dir,
         kind: ClientProfileKind::Cli,
     })
@@ -203,6 +209,11 @@ pub fn gui_profile(name: impl Into<String>, app_data_dir: PathBuf) -> ClientProf
 
 fn normalized_selector(value: Option<&str>) -> Option<&str> {
     value.map(str::trim).filter(|value| !value.is_empty())
+}
+
+fn custom_profile_name(path: &str) -> String {
+    let digest = blake3::hash(path.as_bytes()).to_hex();
+    format!("custom-{}", &digest[..32])
 }
 
 fn validate_profile_name(name: &str) -> Result<(), ProfileError> {
@@ -382,6 +393,22 @@ mod tests {
         let error = resolve_cli_profile(Some("../gui"), None, None, Some(Path::new("/data")), None)
             .expect_err("path traversal");
         assert_eq!(error.kind, ProfileErrorKind::InvalidProfile);
+    }
+
+    #[test]
+    fn custom_app_data_directories_have_stable_distinct_profile_names() {
+        let first = resolve_cli_profile(None, None, Some("/custom/first"), None, None)
+            .expect("first custom profile");
+        let first_again = resolve_cli_profile(None, None, Some("/custom/first"), None, None)
+            .expect("same custom profile");
+        let second = resolve_cli_profile(None, None, Some("/custom/second"), None, None)
+            .expect("second custom profile");
+
+        assert_eq!(first.name, first_again.name);
+        assert_ne!(first.name, second.name);
+        assert!(first.name.starts_with("custom-"));
+        assert_eq!(first.app_data_dir, Path::new("/custom/first"));
+        assert_eq!(second.app_data_dir, Path::new("/custom/second"));
     }
 
     #[test]

--- a/crates/desktop-runtime/src/host/subscriptions.rs
+++ b/crates/desktop-runtime/src/host/subscriptions.rs
@@ -1,0 +1,227 @@
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::identity::write_private_file_atomically;
+
+const DESIRED_SUBSCRIPTIONS_VERSION: u32 = 1;
+const DESIRED_SUBSCRIPTIONS_EXTENSION: &str = "subscriptions.json";
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+pub enum DesiredSubscriptionScope {
+    Public,
+    Channel { channel_id: String },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DesiredSubscription {
+    pub topic: String,
+    pub scope: DesiredSubscriptionScope,
+}
+
+impl DesiredSubscription {
+    pub fn validate(&self) -> Result<(), SubscriptionStateError> {
+        validate_identifier("topic", &self.topic)?;
+        if let DesiredSubscriptionScope::Channel { channel_id } = &self.scope {
+            validate_identifier("channel", channel_id)?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SubscriptionStateErrorKind {
+    InvalidSubscription,
+    ReadFailed,
+    DecodeFailed,
+    UnsupportedVersion,
+    PersistFailed,
+    ActivationFailed,
+}
+
+impl SubscriptionStateErrorKind {
+    pub fn code(self) -> &'static str {
+        match self {
+            Self::InvalidSubscription => "invalid_subscription",
+            Self::ReadFailed => "subscription_state_read_failed",
+            Self::DecodeFailed => "subscription_state_decode_failed",
+            Self::UnsupportedVersion => "subscription_state_version_unsupported",
+            Self::PersistFailed => "subscription_state_persist_failed",
+            Self::ActivationFailed => "subscription_activation_failed",
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct SubscriptionStateError {
+    pub kind: SubscriptionStateErrorKind,
+    pub message: String,
+}
+
+impl SubscriptionStateError {
+    pub(crate) fn new(kind: SubscriptionStateErrorKind, message: impl Into<String>) -> Self {
+        Self {
+            kind,
+            message: message.into(),
+        }
+    }
+
+    pub fn code(&self) -> &'static str {
+        self.kind.code()
+    }
+}
+
+impl std::fmt::Display for SubscriptionStateError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for SubscriptionStateError {}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct DesiredSubscriptionStore {
+    version: u32,
+    subscriptions: Vec<DesiredSubscription>,
+}
+
+pub fn desired_subscriptions_path(db_path: &Path) -> PathBuf {
+    db_path.with_extension(DESIRED_SUBSCRIPTIONS_EXTENSION)
+}
+
+pub(crate) fn load_desired_subscriptions(
+    db_path: &Path,
+) -> Result<Vec<DesiredSubscription>, SubscriptionStateError> {
+    let path = desired_subscriptions_path(db_path);
+    let bytes = match std::fs::read(&path) {
+        Ok(bytes) => bytes,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(error) => {
+            return Err(SubscriptionStateError::new(
+                SubscriptionStateErrorKind::ReadFailed,
+                format!("failed to read `{}`: {error}", path.display()),
+            ));
+        }
+    };
+    let mut store: DesiredSubscriptionStore = serde_json::from_slice(&bytes).map_err(|error| {
+        SubscriptionStateError::new(
+            SubscriptionStateErrorKind::DecodeFailed,
+            format!("failed to decode `{}`: {error}", path.display()),
+        )
+    })?;
+    if store.version != DESIRED_SUBSCRIPTIONS_VERSION {
+        return Err(SubscriptionStateError::new(
+            SubscriptionStateErrorKind::UnsupportedVersion,
+            format!(
+                "unsupported desired subscription version `{}`",
+                store.version
+            ),
+        ));
+    }
+    for subscription in &store.subscriptions {
+        subscription.validate()?;
+    }
+    store.subscriptions.sort();
+    store.subscriptions.dedup();
+    Ok(store.subscriptions)
+}
+
+pub(crate) fn save_desired_subscriptions(
+    db_path: &Path,
+    subscriptions: &[DesiredSubscription],
+) -> Result<(), SubscriptionStateError> {
+    let mut subscriptions = subscriptions.to_vec();
+    for subscription in &subscriptions {
+        subscription.validate()?;
+    }
+    subscriptions.sort();
+    subscriptions.dedup();
+    let bytes = serde_json::to_vec_pretty(&DesiredSubscriptionStore {
+        version: DESIRED_SUBSCRIPTIONS_VERSION,
+        subscriptions,
+    })
+    .map_err(|error| {
+        SubscriptionStateError::new(
+            SubscriptionStateErrorKind::PersistFailed,
+            format!("failed to encode desired subscriptions: {error}"),
+        )
+    })?;
+    let path = desired_subscriptions_path(db_path);
+    write_private_file_atomically(&path, &bytes).map_err(|error| {
+        SubscriptionStateError::new(
+            SubscriptionStateErrorKind::PersistFailed,
+            format!("failed to persist `{}`: {error:#}", path.display()),
+        )
+    })
+}
+
+fn validate_identifier(label: &str, value: &str) -> Result<(), SubscriptionStateError> {
+    if value.is_empty() || value.len() > 512 || value.chars().any(char::is_whitespace) {
+        Err(SubscriptionStateError::new(
+            SubscriptionStateErrorKind::InvalidSubscription,
+            format!("{label} identifier is invalid"),
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn public(topic: &str) -> DesiredSubscription {
+        DesiredSubscription {
+            topic: topic.to_string(),
+            scope: DesiredSubscriptionScope::Public,
+        }
+    }
+
+    #[test]
+    fn subscription_state_round_trips_in_canonical_order() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = dir.path().join("kukuri.db");
+        save_desired_subscriptions(&db_path, &[public("z"), public("a"), public("z")])
+            .expect("save");
+        assert_eq!(
+            load_desired_subscriptions(&db_path).expect("load"),
+            vec![public("a"), public("z")]
+        );
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                std::fs::metadata(desired_subscriptions_path(&db_path))
+                    .expect("metadata")
+                    .permissions()
+                    .mode()
+                    & 0o777,
+                0o600
+            );
+        }
+    }
+
+    #[test]
+    fn malformed_and_unknown_version_state_fail_closed() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = dir.path().join("kukuri.db");
+        let path = desired_subscriptions_path(&db_path);
+        std::fs::write(&path, b"not-json").expect("fixture");
+        assert_eq!(
+            load_desired_subscriptions(&db_path)
+                .expect_err("malformed")
+                .kind,
+            SubscriptionStateErrorKind::DecodeFailed
+        );
+        std::fs::write(&path, br#"{"version":2,"subscriptions":[]}"#).expect("fixture");
+        assert_eq!(
+            load_desired_subscriptions(&db_path)
+                .expect_err("unknown version")
+                .kind,
+            SubscriptionStateErrorKind::UnsupportedVersion
+        );
+    }
+}

--- a/crates/desktop-runtime/src/lib.rs
+++ b/crates/desktop-runtime/src/lib.rs
@@ -55,13 +55,16 @@ pub use discovery::{DiscoveryConfig, SetDiscoverySeedsRequest};
 pub use host::{
     AGE_ATTESTATION_VERSION, APP_LEGAL_AUTHORITATIVE_LANGUAGE, APP_LEGAL_DOCUMENTS,
     APP_LEGAL_EFFECTIVE_DATE, AgeAttestationRecord, AgeAttestationStatus, AppConsentDocumentRecord,
-    AppConsentDocumentStatus, AppConsentStore, ClientEventReceiver, ClientHost, ClientStartupError,
-    ClientStartupErrorKind, ClientStartupErrorView, ClientStartupState, ClientStartupStatus,
-    LEGAL_BUNDLE_VERSION, age_attestation_satisfied, age_attestation_status,
-    app_consent_documents_satisfied, app_consent_documents_status, app_consent_path,
-    app_consent_satisfied, consent_required_status, current_unix_seconds,
-    distribution_community_node_config, failed_startup_status, load_app_consent_store,
-    reset_app_consent_at_path, save_app_consent_store,
+    AppConsentDocumentStatus, AppConsentStore, ClientEventReceiver, ClientHost, ClientHostStart,
+    ClientProfile, ClientProfileKind, ClientStartupError, ClientStartupErrorKind,
+    ClientStartupErrorView, ClientStartupState, ClientStartupStatus, DesiredSubscription,
+    DesiredSubscriptionScope, LEGAL_BUNDLE_VERSION, ProfileError, ProfileErrorKind, ProfileLease,
+    SubscriptionStateError, SubscriptionStateErrorKind, age_attestation_satisfied,
+    age_attestation_status, app_consent_documents_satisfied, app_consent_documents_status,
+    app_consent_path, app_consent_satisfied, consent_required_status, current_unix_seconds,
+    desired_subscriptions_path, distribution_community_node_config, failed_startup_status,
+    gui_profile, load_app_consent_store, reset_app_consent_at_path, resolve_cli_profile,
+    save_app_consent_store,
 };
 // 起動エラーの typed 分類(WP-Q2)。src-tauri は downcast で DatabaseOpen/Migration を判定する。
 pub use kukuri_store::StoreStartupError;

--- a/crates/desktop-runtime/src/runtime/content_profile_api.rs
+++ b/crates/desktop-runtime/src/runtime/content_profile_api.rs
@@ -1,6 +1,41 @@
 use super::*;
 
 impl DesktopRuntime {
+    pub(crate) async fn ensure_desired_subscription(
+        &self,
+        subscription: &DesiredSubscription,
+    ) -> Result<()> {
+        let scope = match &subscription.scope {
+            DesiredSubscriptionScope::Public => TimelineScope::Public,
+            DesiredSubscriptionScope::Channel { channel_id } => TimelineScope::Channel {
+                channel_id: kukuri_core::ChannelId::new(channel_id),
+            },
+        };
+        self.app_service
+            .ensure_scope_subscriptions(subscription.topic.as_str(), &scope)
+            .await
+    }
+
+    pub(crate) async fn remove_desired_subscription(
+        &self,
+        subscription: &DesiredSubscription,
+        topic_still_desired: bool,
+    ) -> Result<()> {
+        match (&subscription.scope, topic_still_desired) {
+            (_, false) => {
+                self.app_service
+                    .unsubscribe_topic(subscription.topic.as_str())
+                    .await
+            }
+            (DesiredSubscriptionScope::Channel { channel_id }, true) => {
+                self.app_service
+                    .unsubscribe_private_channel(subscription.topic.as_str(), channel_id.as_str())
+                    .await
+            }
+            (DesiredSubscriptionScope::Public, true) => Ok(()),
+        }
+    }
+
     pub async fn create_post(&self, request: CreatePostRequest) -> Result<String> {
         let attachments = request
             .attachments

--- a/crates/desktop-runtime/src/runtime/mod.rs
+++ b/crates/desktop-runtime/src/runtime/mod.rs
@@ -34,8 +34,9 @@ use kukuri_core::{
     BlobHash, CreatePrivateChannelInput, CustomReactionAssetSnapshotV1, DomeHostTargetV1,
     DomeInstanceManifestV1, DomePresetManifestV1, FriendOnlyGrantPreview, FriendPlusSharePreview,
     KukuriKeys, PrivateChannelInvitePreview, Profile, SignedDomeHostingActivationV1,
-    SignedDomeHostingCloseV1, SignedDomeHostingLeaseV1, TopicId, build_signed_dome_session_input,
-    verify_signed_dome_host_heartbeat, verify_signed_dome_physics_snapshot,
+    SignedDomeHostingCloseV1, SignedDomeHostingLeaseV1, TimelineScope, TopicId,
+    build_signed_dome_session_input, verify_signed_dome_host_heartbeat,
+    verify_signed_dome_physics_snapshot,
 };
 use kukuri_docs_sync::{DocQuery, DocsSync};
 use kukuri_store::SqliteStore;
@@ -71,6 +72,7 @@ use crate::discovery::{
     DiscoveryConfig, SetDiscoverySeedsRequest, parse_seed_entries,
     resolve_discovery_config_from_env, save_discovery_config,
 };
+use crate::host::{DesiredSubscription, DesiredSubscriptionScope};
 use crate::identity::{
     IdentityStorageMode, delete_optional_secret, load_optional_secret, load_or_create_keys,
     persist_optional_secret,

--- a/crates/desktop-runtime/src/tests/accounts_migration.rs
+++ b/crates/desktop-runtime/src/tests/accounts_migration.rs
@@ -44,6 +44,11 @@ fn flat_layout_migrates_identity_db_and_siblings() {
     persist_keys(&flat_db, MODE, &keys).expect("seed flat identity");
     fs::write(&flat_db, b"sqlite").expect("seed flat db");
     fs::write(flat_db.with_extension("discovery.json"), b"{}").expect("seed discovery config");
+    fs::write(
+        flat_db.with_extension("subscriptions.json"),
+        br#"{"version":1,"subscriptions":[]}"#,
+    )
+    .expect("seed desired subscriptions");
     fs::create_dir_all(flat_db.with_extension("iroh-data")).expect("seed iroh data dir");
     fs::write(
         flat_db.with_extension("iroh-data").join("blob.bin"),
@@ -66,6 +71,11 @@ fn flat_layout_migrates_identity_db_and_siblings() {
         b"{}"
     );
     assert_eq!(
+        fs::read(db_path.with_extension("subscriptions.json"))
+            .expect("migrated desired subscriptions"),
+        br#"{"version":1,"subscriptions":[]}"#
+    );
+    assert_eq!(
         fs::read(db_path.with_extension("iroh-data").join("blob.bin")).expect("migrated blob"),
         b"blob"
     );
@@ -80,6 +90,7 @@ fn flat_layout_migrates_identity_db_and_siblings() {
     assert!(!flat_db.exists());
     assert!(!flat_db.with_extension("identity-key").exists());
     assert!(!flat_db.with_extension("identity-store").exists());
+    assert!(!flat_db.with_extension("subscriptions.json").exists());
     assert!(!capability_file.exists());
 
     let snapshot = list_accounts(dir.path()).expect("list accounts");

--- a/crates/desktop-runtime/src/tests/device_backup.rs
+++ b/crates/desktop-runtime/src/tests/device_backup.rs
@@ -22,6 +22,10 @@ use crate::community_node::{
     COMMUNITY_NODE_TOKEN_PURPOSE, CommunityNodeConfig, CommunityNodeNodeConfig,
     load_community_node_config_from_file, save_community_node_config,
 };
+use crate::host::{
+    DesiredSubscription, DesiredSubscriptionScope, load_desired_subscriptions,
+    save_desired_subscriptions,
+};
 use crate::identity::{
     IdentityStorageMode, KeyringStore, load_existing_keys, load_optional_secret,
     load_optional_secret_with_keyring, persist_optional_secret,
@@ -181,6 +185,12 @@ async fn encrypted_device_backup_restores_one_account_as_one_file() {
         },
     )
     .expect("persist community node config");
+    let desired_subscription = DesiredSubscription {
+        topic: "kukuri:topic:backup-subscription".to_string(),
+        scope: DesiredSubscriptionScope::Public,
+    };
+    save_desired_subscriptions(&source_db, std::slice::from_ref(&desired_subscription))
+        .expect("persist desired subscription fixture");
     for (purpose, key, value) in [
         (
             PRIVATE_CHANNEL_CAPABILITIES_PURPOSE,
@@ -308,6 +318,10 @@ async fn encrypted_device_backup_restores_one_account_as_one_file() {
         .expect("load restored identity")
         .expect("restored identity");
     assert_eq!(restored_keys.public_key_hex(), source_keys.public_key_hex());
+    assert_eq!(
+        load_desired_subscriptions(&restored_db).expect("load restored desired subscriptions"),
+        vec![desired_subscription]
+    );
     let snapshot = list_accounts(target.path()).expect("list restored accounts");
     assert_eq!(snapshot.active_account_id, result.account.id);
     assert_eq!(snapshot.accounts.len(), 2);

--- a/crates/harness/src/runtime.rs
+++ b/crates/harness/src/runtime.rs
@@ -247,6 +247,7 @@ pub(crate) fn cleanup_runtime_artifacts(db_path: &Path) -> Result<()> {
         db_path.with_extension("db-wal"),
         db_path.with_extension("iroh-data"),
         db_path.with_extension("community-node.json"),
+        db_path.with_extension("subscriptions.json"),
         db_path.with_extension("identity-store"),
         db_path.with_extension("identity-key"),
         db_path.with_extension("nsec"),

--- a/crates/kukuri-cli/Cargo.toml
+++ b/crates/kukuri-cli/Cargo.toml
@@ -12,6 +12,7 @@ serde.workspace = true
 serde_json.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
+blake3.workspace = true
 libc.workspace = true
 tokio = { workspace = true, features = ["io-util", "net", "process", "signal"] }
 

--- a/crates/kukuri-cli/Cargo.toml
+++ b/crates/kukuri-cli/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "kukuri-cli"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+clap.workspace = true
+kukuri-desktop-runtime = { path = "../desktop-runtime" }
+serde.workspace = true
+serde_json.workspace = true
+
+[target.'cfg(target_os = "linux")'.dependencies]
+libc.workspace = true
+tokio = { workspace = true, features = ["io-util", "net", "process", "signal"] }
+
+[dev-dependencies]
+tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/crates/kukuri-cli/src/daemon.rs
+++ b/crates/kukuri-cli/src/daemon.rs
@@ -94,6 +94,8 @@ async fn drain_connection(mut stream: UnixStream) {
 }
 
 fn daemon_socket_path(lease: &ProfileLease) -> Result<PathBuf, CliError> {
+    use std::os::unix::ffi::OsStrExt;
+
     let runtime_root = std::env::var_os("XDG_RUNTIME_DIR")
         .map(PathBuf::from)
         .ok_or_else(|| {
@@ -105,7 +107,18 @@ fn daemon_socket_path(lease: &ProfileLease) -> Result<PathBuf, CliError> {
         })?;
     let directory = runtime_root.join("kukuri");
     ensure_private_runtime_directory(&directory)?;
-    Ok(directory.join(format!("{}.sock", lease.profile().name)))
+    let profile_path = std::fs::canonicalize(&lease.profile().app_data_dir).map_err(|error| {
+        CliError::new(
+            "profile_path_unavailable",
+            format!(
+                "failed to resolve profile directory `{}`: {error}",
+                lease.profile().app_data_dir.display()
+            ),
+            1,
+        )
+    })?;
+    let digest = blake3::hash(profile_path.as_os_str().as_bytes()).to_hex();
+    Ok(directory.join(format!("profile-{}.sock", &digest[..32])))
 }
 
 fn ensure_private_runtime_directory(path: &Path) -> Result<(), CliError> {

--- a/crates/kukuri-cli/src/daemon.rs
+++ b/crates/kukuri-cli/src/daemon.rs
@@ -1,0 +1,282 @@
+use std::{
+    path::{Path, PathBuf},
+    process::Stdio,
+};
+
+use kukuri_desktop_runtime::{ClientHost, ClientHostStart, ClientProfile, ProfileLease};
+use tokio::{
+    io::AsyncReadExt,
+    net::{UnixListener, UnixStream},
+    process::Command,
+};
+
+use crate::{CliError, DaemonCommand};
+
+pub(crate) async fn run(profile: ClientProfile, command: DaemonCommand) -> Result<(), CliError> {
+    match command {
+        DaemonCommand::Run => run_foreground(profile).await,
+        DaemonCommand::Start => systemctl(&profile.name, "start").await,
+        DaemonCommand::Stop => systemctl(&profile.name, "stop").await,
+        DaemonCommand::Status => systemctl(&profile.name, "status").await,
+    }
+}
+
+async fn run_foreground(profile: ClientProfile) -> Result<(), CliError> {
+    let lease = ProfileLease::acquire(profile).map_err(CliError::from_profile)?;
+    let socket_path = daemon_socket_path(&lease)?;
+    let listener = bind_listener(&socket_path)?;
+    let _socket_cleanup = SocketCleanup(socket_path);
+
+    let host = match ClientHost::start_if_consented(lease.profile().app_data_dir.clone())
+        .await
+        .map_err(|error| CliError::new("host_start_failed", error.to_string(), 1))?
+    {
+        ClientHostStart::Ready(host) => Some(host),
+        ClientHostStart::ConsentRequired(_) => None,
+    };
+    println!(
+        "{}",
+        if host.is_some() {
+            "ready"
+        } else {
+            "consent_required"
+        }
+    );
+
+    wait_for_shutdown(&listener).await?;
+    if let Some(host) = host {
+        host.shutdown().await;
+    }
+    drop(lease);
+    Ok(())
+}
+
+async fn wait_for_shutdown(listener: &UnixListener) -> Result<(), CliError> {
+    let terminate = async {
+        let mut terminate =
+            tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+                .map_err(|error| CliError::new("signal_setup_failed", error.to_string(), 1))?;
+        terminate.recv().await;
+        Ok::<(), CliError>(())
+    };
+    tokio::pin!(terminate);
+
+    loop {
+        tokio::select! {
+            result = tokio::signal::ctrl_c() => {
+                result.map_err(|error| CliError::new("signal_wait_failed", error.to_string(), 1))?;
+                return Ok(());
+            }
+            result = &mut terminate => return result,
+            result = listener.accept() => {
+                let (stream, _) = result.map_err(|error| {
+                    CliError::new("socket_accept_failed", error.to_string(), 1)
+                })?;
+                match authorize_peer(&stream) {
+                    Ok(()) => {
+                        tokio::spawn(drain_connection(stream));
+                    }
+                    Err(error) => eprintln!("{}: {}", error.code, error.message),
+                }
+            }
+        }
+    }
+}
+
+async fn drain_connection(mut stream: UnixStream) {
+    let mut buffer = [0_u8; 1024];
+    loop {
+        match stream.read(&mut buffer).await {
+            Ok(0) | Err(_) => return,
+            Ok(_) => {}
+        }
+    }
+}
+
+fn daemon_socket_path(lease: &ProfileLease) -> Result<PathBuf, CliError> {
+    let runtime_root = std::env::var_os("XDG_RUNTIME_DIR")
+        .map(PathBuf::from)
+        .ok_or_else(|| {
+            CliError::new(
+                "runtime_dir_unavailable",
+                "XDG_RUNTIME_DIR is required for the daemon socket",
+                1,
+            )
+        })?;
+    let directory = runtime_root.join("kukuri");
+    ensure_private_runtime_directory(&directory)?;
+    Ok(directory.join(format!("{}.sock", lease.profile().name)))
+}
+
+fn ensure_private_runtime_directory(path: &Path) -> Result<(), CliError> {
+    use std::os::unix::fs::PermissionsExt;
+
+    if let Ok(metadata) = std::fs::symlink_metadata(path)
+        && metadata.file_type().is_symlink()
+    {
+        return Err(CliError::new(
+            "runtime_dir_invalid",
+            format!(
+                "runtime directory `{}` must not be a symlink",
+                path.display()
+            ),
+            1,
+        ));
+    }
+    std::fs::create_dir_all(path).map_err(|error| {
+        CliError::new(
+            "runtime_dir_unavailable",
+            format!("failed to create `{}`: {error}", path.display()),
+            1,
+        )
+    })?;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700)).map_err(|error| {
+        CliError::new(
+            "runtime_dir_permission_failed",
+            format!("failed to protect `{}`: {error}", path.display()),
+            1,
+        )
+    })
+}
+
+fn bind_listener(path: &Path) -> Result<UnixListener, CliError> {
+    use std::os::unix::fs::{FileTypeExt, PermissionsExt};
+
+    if let Ok(metadata) = std::fs::symlink_metadata(path) {
+        if !metadata.file_type().is_socket() {
+            return Err(CliError::new(
+                "socket_path_invalid",
+                format!("socket path `{}` is not a socket", path.display()),
+                1,
+            ));
+        }
+        std::fs::remove_file(path).map_err(|error| {
+            CliError::new(
+                "socket_cleanup_failed",
+                format!(
+                    "failed to remove stale socket `{}`: {error}",
+                    path.display()
+                ),
+                1,
+            )
+        })?;
+    }
+    let listener = UnixListener::bind(path).map_err(|error| {
+        CliError::new(
+            "socket_bind_failed",
+            format!("failed to bind `{}`: {error}", path.display()),
+            1,
+        )
+    })?;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600)).map_err(|error| {
+        CliError::new(
+            "socket_permission_failed",
+            format!("failed to protect `{}`: {error}", path.display()),
+            1,
+        )
+    })?;
+    Ok(listener)
+}
+
+fn authorize_peer(stream: &UnixStream) -> Result<(), CliError> {
+    let credential = stream
+        .peer_cred()
+        .map_err(|error| CliError::new("peer_credential_failed", error.to_string(), 1))?;
+    authorize_peer_uid(unsafe { libc::geteuid() }, credential.uid())
+}
+
+fn authorize_peer_uid(expected_uid: u32, actual_uid: u32) -> Result<(), CliError> {
+    if expected_uid == actual_uid {
+        Ok(())
+    } else {
+        Err(CliError::new(
+            "peer_uid_mismatch",
+            format!("peer uid {actual_uid} does not match daemon uid {expected_uid}"),
+            1,
+        ))
+    }
+}
+
+async fn systemctl(profile: &str, verb: &str) -> Result<(), CliError> {
+    let unit = format!("kukuri@{profile}.service");
+    let output = Command::new("systemctl")
+        .args(["--user", verb, unit.as_str()])
+        .stdin(Stdio::null())
+        .output()
+        .await
+        .map_err(|error| CliError::new("systemd_unavailable", error.to_string(), 1))?;
+    if !output.stdout.is_empty() {
+        print!("{}", String::from_utf8_lossy(&output.stdout));
+    }
+    if output.status.success() {
+        Ok(())
+    } else {
+        let message = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        Err(CliError::new(
+            "systemd_command_failed",
+            if message.is_empty() {
+                format!("systemctl --user {verb} {unit} failed")
+            } else {
+                message
+            },
+            output.status.code().unwrap_or(1),
+        ))
+    }
+}
+
+struct SocketCleanup(PathBuf);
+
+impl Drop for SocketCleanup {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.0);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::os::unix::fs::PermissionsExt;
+
+    use kukuri_desktop_runtime::{ClientProfileKind, resolve_cli_profile};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn runtime_directory_and_socket_are_private() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let runtime_dir = root.path().join("runtime");
+        ensure_private_runtime_directory(&runtime_dir).expect("runtime dir");
+        let socket = runtime_dir.join("test.sock");
+        let listener = bind_listener(&socket).expect("listener");
+        assert_eq!(
+            std::fs::metadata(&runtime_dir)
+                .expect("dir metadata")
+                .permissions()
+                .mode()
+                & 0o777,
+            0o700
+        );
+        assert_eq!(
+            std::fs::metadata(&socket)
+                .expect("socket metadata")
+                .permissions()
+                .mode()
+                & 0o777,
+            0o600
+        );
+        drop(listener);
+    }
+
+    #[test]
+    fn peer_uid_mismatch_is_rejected() {
+        let error = authorize_peer_uid(1000, 1001).expect_err("different uid");
+        assert_eq!(error.code, "peer_uid_mismatch");
+    }
+
+    #[test]
+    fn profile_kind_for_daemon_is_cli() {
+        let profile =
+            resolve_cli_profile(Some("alpha"), None, None, Some(Path::new("/data")), None)
+                .expect("profile");
+        assert_eq!(profile.kind, ClientProfileKind::Cli);
+    }
+}

--- a/crates/kukuri-cli/src/main.rs
+++ b/crates/kukuri-cli/src/main.rs
@@ -77,10 +77,13 @@ fn main() {
 
 fn run() -> Result<(), CliError> {
     let cli = Cli::parse();
+    let custom_app_data_selected = std::env::var("KUKURI_APP_DATA_DIR")
+        .ok()
+        .is_some_and(|value| !value.trim().is_empty());
     let profile = resolve_profile(cli.profile.as_deref()).map_err(CliError::from_profile)?;
     match cli.command {
         Command::Consent(args) => run_consent(profile, args.command),
-        Command::Daemon(args) => run_daemon(profile, args.command),
+        Command::Daemon(args) => run_daemon(profile, args.command, custom_app_data_selected),
     }
 }
 
@@ -169,7 +172,15 @@ fn accept_consents(path: &Path, args: ConsentAcceptArgs) -> Result<(), CliError>
 fn run_daemon(
     profile: kukuri_desktop_runtime::ClientProfile,
     command: DaemonCommand,
+    custom_app_data_selected: bool,
 ) -> Result<(), CliError> {
+    if custom_app_data_selected && !matches!(&command, DaemonCommand::Run) {
+        return Err(CliError::new(
+            "custom_profile_systemd_unsupported",
+            "KUKURI_APP_DATA_DIR can be used only with `daemon run`; systemd actions require a named profile",
+            2,
+        ));
+    }
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()
@@ -181,6 +192,7 @@ fn run_daemon(
 fn run_daemon(
     _profile: kukuri_desktop_runtime::ClientProfile,
     _command: DaemonCommand,
+    _custom_app_data_selected: bool,
 ) -> Result<(), CliError> {
     Err(CliError::new(
         "unsupported_platform",

--- a/crates/kukuri-cli/src/main.rs
+++ b/crates/kukuri-cli/src/main.rs
@@ -1,0 +1,247 @@
+use std::path::{Path, PathBuf};
+
+use clap::{Args, Parser, Subcommand};
+use kukuri_desktop_runtime::{
+    AGE_ATTESTATION_VERSION, APP_LEGAL_DOCUMENTS, AgeAttestationRecord, AppConsentDocumentRecord,
+    AppConsentStore, ProfileError, ProfileLease, app_consent_satisfied, current_unix_seconds,
+    load_app_consent_store, resolve_cli_profile, save_app_consent_store,
+};
+
+#[cfg(target_os = "linux")]
+mod daemon;
+
+#[derive(Parser)]
+#[command(name = "kukuri-cli", version)]
+struct Cli {
+    /// CLI専用profile。KUKURI_INSTANCEと同じselectorとして扱う。
+    #[arg(long)]
+    profile: Option<String>,
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    Daemon(DaemonArgs),
+    Consent(ConsentArgs),
+}
+
+#[derive(Args)]
+struct DaemonArgs {
+    #[command(subcommand)]
+    command: DaemonCommand,
+}
+
+#[derive(Subcommand)]
+enum DaemonCommand {
+    /// foregroundで常駐プロセスを実行する。
+    Run,
+    /// systemd user instanceを開始する。
+    Start,
+    /// systemd user instanceを停止する。
+    Stop,
+    /// systemd user instanceの状態を表示する。
+    Status,
+}
+
+#[derive(Args)]
+struct ConsentArgs {
+    #[command(subcommand)]
+    command: ConsentCommand,
+}
+
+#[derive(Subcommand)]
+enum ConsentCommand {
+    Status,
+    Accept(ConsentAcceptArgs),
+}
+
+#[derive(Args)]
+struct ConsentAcceptArgs {
+    /// 現行利用規約とプライバシーポリシーへの同意を明示する。
+    #[arg(long)]
+    accept_documents: bool,
+    /// 18歳以上であることの自己申告を明示する。
+    #[arg(long)]
+    age_confirmed: bool,
+    #[arg(long, default_value = "ja")]
+    language: String,
+}
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("{}: {}", error.code, error.message);
+        std::process::exit(error.exit_code);
+    }
+}
+
+fn run() -> Result<(), CliError> {
+    let cli = Cli::parse();
+    let profile = resolve_profile(cli.profile.as_deref()).map_err(CliError::from_profile)?;
+    match cli.command {
+        Command::Consent(args) => run_consent(profile, args.command),
+        Command::Daemon(args) => run_daemon(profile, args.command),
+    }
+}
+
+fn resolve_profile(
+    argument_profile: Option<&str>,
+) -> Result<kukuri_desktop_runtime::ClientProfile, ProfileError> {
+    let environment_instance = std::env::var("KUKURI_INSTANCE").ok();
+    let environment_app_data_dir = std::env::var("KUKURI_APP_DATA_DIR").ok();
+    let xdg_data_home = std::env::var_os("XDG_DATA_HOME").map(PathBuf::from);
+    let home = std::env::var_os("HOME").map(PathBuf::from);
+    resolve_cli_profile(
+        argument_profile,
+        environment_instance.as_deref(),
+        environment_app_data_dir.as_deref(),
+        xdg_data_home.as_deref(),
+        home.as_deref(),
+    )
+}
+
+fn run_consent(
+    profile: kukuri_desktop_runtime::ClientProfile,
+    command: ConsentCommand,
+) -> Result<(), CliError> {
+    let lease = ProfileLease::acquire(profile).map_err(CliError::from_profile)?;
+    let consent_db_path = lease.profile().app_data_dir.join("kukuri.db");
+    match command {
+        ConsentCommand::Status => {
+            let store = load_app_consent_store(&consent_db_path);
+            println!(
+                "{}",
+                if app_consent_satisfied(&store) {
+                    "satisfied"
+                } else {
+                    "consent_required"
+                }
+            );
+            Ok(())
+        }
+        ConsentCommand::Accept(args) => accept_consents(&consent_db_path, args),
+    }
+}
+
+fn accept_consents(path: &Path, args: ConsentAcceptArgs) -> Result<(), CliError> {
+    if !args.accept_documents || !args.age_confirmed {
+        return Err(CliError::new(
+            "consent_confirmation_required",
+            "--accept-documents and --age-confirmed are both required",
+            2,
+        ));
+    }
+    let language = args.language.trim();
+    if language.is_empty() {
+        return Err(CliError::new(
+            "invalid_consent_language",
+            "--language must not be empty",
+            2,
+        ));
+    }
+    let accepted_at = current_unix_seconds();
+    let app_version = env!("CARGO_PKG_VERSION").to_string();
+    let store = AppConsentStore {
+        records: APP_LEGAL_DOCUMENTS
+            .iter()
+            .map(|(slug, version)| AppConsentDocumentRecord {
+                slug: (*slug).to_string(),
+                version: *version,
+                accepted_at,
+                language: language.to_string(),
+                app_version: app_version.clone(),
+            })
+            .collect(),
+        age_attestations: vec![AgeAttestationRecord {
+            version: AGE_ATTESTATION_VERSION,
+            attested_at: accepted_at,
+            language: language.to_string(),
+            app_version,
+        }],
+    };
+    save_app_consent_store(path, &store)
+        .map_err(|error| CliError::new("consent_persist_failed", error, 1))?;
+    println!("accepted");
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn run_daemon(
+    profile: kukuri_desktop_runtime::ClientProfile,
+    command: DaemonCommand,
+) -> Result<(), CliError> {
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .map_err(|error| CliError::new("runtime_start_failed", error.to_string(), 1))?;
+    runtime.block_on(daemon::run(profile, command))
+}
+
+#[cfg(not(target_os = "linux"))]
+fn run_daemon(
+    _profile: kukuri_desktop_runtime::ClientProfile,
+    _command: DaemonCommand,
+) -> Result<(), CliError> {
+    Err(CliError::new(
+        "unsupported_platform",
+        "kukuri daemon is supported only on Linux",
+        2,
+    ))
+}
+
+#[derive(Debug)]
+struct CliError {
+    code: &'static str,
+    message: String,
+    exit_code: i32,
+}
+
+impl CliError {
+    fn new(code: &'static str, message: impl Into<String>, exit_code: i32) -> Self {
+        Self {
+            code,
+            message: message.into(),
+            exit_code,
+        }
+    }
+
+    fn from_profile(error: ProfileError) -> Self {
+        Self::new(error.code(), error.to_string(), 1)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn consent_requires_both_explicit_confirmations() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let error = accept_consents(
+            &dir.path().join("kukuri.db"),
+            ConsentAcceptArgs {
+                accept_documents: true,
+                age_confirmed: false,
+                language: "ja".to_string(),
+            },
+        )
+        .expect_err("age confirmation");
+        assert_eq!(error.code, "consent_confirmation_required");
+    }
+
+    #[test]
+    fn consent_acceptance_writes_current_documents_and_age() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("kukuri.db");
+        accept_consents(
+            &path,
+            ConsentAcceptArgs {
+                accept_documents: true,
+                age_confirmed: true,
+                language: "ja".to_string(),
+            },
+        )
+        .expect("accept consent");
+        assert!(app_consent_satisfied(&load_app_consent_store(&path)));
+    }
+}

--- a/crates/kukuri-cli/tests/daemon_linux.rs
+++ b/crates/kukuri-cli/tests/daemon_linux.rs
@@ -3,6 +3,7 @@
 use std::{
     fs,
     io::{BufRead, BufReader},
+    os::unix::ffi::OsStrExt,
     os::unix::{fs::PermissionsExt, net::UnixStream},
     path::{Path, PathBuf},
     process::{Child, Command, Stdio},
@@ -83,16 +84,25 @@ fn spawn_custom_daemon(root: &Path, app_data_dir: &Path) -> Child {
 }
 
 fn socket_path(root: &Path, profile: &str) -> PathBuf {
+    let app_data_dir = root
+        .join("data")
+        .join("kukuri")
+        .join("cli")
+        .join("profiles")
+        .join(profile);
+    socket_path_for_data_dir(root, &app_data_dir)
+}
+
+fn socket_path_for_data_dir(root: &Path, app_data_dir: &Path) -> PathBuf {
+    let canonical = fs::canonicalize(app_data_dir).expect("canonical profile path");
+    let digest = blake3::hash(canonical.as_os_str().as_bytes()).to_hex();
     root.join("runtime")
         .join("kukuri")
-        .join(format!("{profile}.sock"))
+        .join(format!("profile-{}.sock", &digest[..32]))
 }
 
 fn custom_socket_path(root: &Path, app_data_dir: &Path) -> PathBuf {
-    let app_data_dir = app_data_dir.to_str().expect("UTF-8 app data path");
-    let profile = resolve_cli_profile(None, None, Some(app_data_dir), None, None)
-        .expect("resolve custom profile");
-    socket_path(root, &profile.name)
+    socket_path_for_data_dir(root, app_data_dir)
 }
 
 fn wait_for_ready(child: &mut Child, path: &Path) {
@@ -250,4 +260,49 @@ fn custom_app_data_daemons_use_distinct_sockets() {
     terminate(second);
     assert!(!first_socket.exists());
     assert!(!second_socket.exists());
+}
+
+#[test]
+fn custom_and_same_named_profile_use_distinct_sockets() {
+    let root = tempfile::tempdir().expect("tempdir");
+    fs::create_dir_all(root.path().join("runtime")).expect("runtime root");
+    fs::create_dir_all(root.path().join("home")).expect("home");
+    let custom_data = root.path().join("custom");
+    accept_custom_consent(root.path(), &custom_data);
+    let custom_data_text = custom_data.to_str().expect("UTF-8 custom data path");
+    let custom_profile = resolve_cli_profile(None, None, Some(custom_data_text), None, None)
+        .expect("resolve custom profile");
+    accept_consent(root.path(), &custom_profile.name);
+
+    let custom_socket = custom_socket_path(root.path(), &custom_data);
+    let named_socket = socket_path(root.path(), &custom_profile.name);
+    assert_ne!(custom_socket, named_socket);
+
+    let mut custom = spawn_custom_daemon(root.path(), &custom_data);
+    wait_for_ready(&mut custom, &custom_socket);
+    let mut named = spawn_daemon(root.path(), &custom_profile.name);
+    wait_for_ready(&mut named, &named_socket);
+
+    terminate(custom);
+    assert!(named_socket.exists());
+    UnixStream::connect(&named_socket).expect("named daemon remains reachable");
+    terminate(named);
+    assert!(!custom_socket.exists());
+    assert!(!named_socket.exists());
+}
+
+#[test]
+fn custom_app_data_rejects_systemd_actions() {
+    let root = tempfile::tempdir().expect("tempdir");
+    let output = custom_cli_command(root.path(), &root.path().join("custom"))
+        .args(["daemon", "status"])
+        .output()
+        .expect("custom daemon status");
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("custom_profile_systemd_unsupported"),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
 }

--- a/crates/kukuri-cli/tests/daemon_linux.rs
+++ b/crates/kukuri-cli/tests/daemon_linux.rs
@@ -11,16 +11,29 @@ use std::{
     time::{Duration, Instant},
 };
 
-fn cli_command(root: &Path, profile: &str) -> Command {
+use kukuri_desktop_runtime::resolve_cli_profile;
+
+fn base_cli_command(root: &Path) -> Command {
     let mut command = Command::new(env!("CARGO_BIN_EXE_kukuri-cli"));
     command
-        .args(["--profile", profile])
         .env("XDG_DATA_HOME", root.join("data"))
         .env("XDG_RUNTIME_DIR", root.join("runtime"))
         .env("HOME", root.join("home"))
         .env("KUKURI_DISABLE_KEYRING", "1")
         .env_remove("KUKURI_APP_DATA_DIR")
         .env_remove("KUKURI_INSTANCE");
+    command
+}
+
+fn cli_command(root: &Path, profile: &str) -> Command {
+    let mut command = base_cli_command(root);
+    command.args(["--profile", profile]);
+    command
+}
+
+fn custom_cli_command(root: &Path, app_data_dir: &Path) -> Command {
+    let mut command = base_cli_command(root);
+    command.env("KUKURI_APP_DATA_DIR", app_data_dir);
     command
 }
 
@@ -40,6 +53,16 @@ fn accept_consent(root: &Path, profile: &str) {
     assert!(status.success(), "consent command exited with {status}");
 }
 
+fn accept_custom_consent(root: &Path, app_data_dir: &Path) {
+    let status = custom_cli_command(root, app_data_dir)
+        .args(["consent", "accept", "--accept-documents", "--age-confirmed"])
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .status()
+        .expect("accept custom consent");
+    assert!(status.success(), "consent command exited with {status}");
+}
+
 fn spawn_daemon(root: &Path, profile: &str) -> Child {
     daemon_command(root, profile)
         .stdin(Stdio::null())
@@ -49,10 +72,27 @@ fn spawn_daemon(root: &Path, profile: &str) -> Child {
         .expect("spawn daemon")
 }
 
+fn spawn_custom_daemon(root: &Path, app_data_dir: &Path) -> Child {
+    custom_cli_command(root, app_data_dir)
+        .args(["daemon", "run"])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn custom daemon")
+}
+
 fn socket_path(root: &Path, profile: &str) -> PathBuf {
     root.join("runtime")
         .join("kukuri")
         .join(format!("{profile}.sock"))
+}
+
+fn custom_socket_path(root: &Path, app_data_dir: &Path) -> PathBuf {
+    let app_data_dir = app_data_dir.to_str().expect("UTF-8 app data path");
+    let profile = resolve_cli_profile(None, None, Some(app_data_dir), None, None)
+        .expect("resolve custom profile");
+    socket_path(root, &profile.name)
 }
 
 fn wait_for_ready(child: &mut Child, path: &Path) {
@@ -183,4 +223,31 @@ fn daemon_enforces_profile_ownership_permissions_and_graceful_restart() {
     wait_for_ready(&mut restarted, &alpha_socket);
     terminate(restarted);
     assert!(!alpha_socket.exists());
+}
+
+#[test]
+fn custom_app_data_daemons_use_distinct_sockets() {
+    let root = tempfile::tempdir().expect("tempdir");
+    fs::create_dir_all(root.path().join("runtime")).expect("runtime root");
+    fs::create_dir_all(root.path().join("home")).expect("home");
+    let first_data = root.path().join("custom-first");
+    let second_data = root.path().join("custom-second");
+    accept_custom_consent(root.path(), &first_data);
+    accept_custom_consent(root.path(), &second_data);
+
+    let first_socket = custom_socket_path(root.path(), &first_data);
+    let second_socket = custom_socket_path(root.path(), &second_data);
+    assert_ne!(first_socket, second_socket);
+
+    let mut first = spawn_custom_daemon(root.path(), &first_data);
+    wait_for_ready(&mut first, &first_socket);
+    let mut second = spawn_custom_daemon(root.path(), &second_data);
+    wait_for_ready(&mut second, &second_socket);
+
+    terminate(first);
+    assert!(second_socket.exists());
+    UnixStream::connect(&second_socket).expect("second custom daemon remains reachable");
+    terminate(second);
+    assert!(!first_socket.exists());
+    assert!(!second_socket.exists());
 }

--- a/crates/kukuri-cli/tests/daemon_linux.rs
+++ b/crates/kukuri-cli/tests/daemon_linux.rs
@@ -1,0 +1,186 @@
+#![cfg(target_os = "linux")]
+
+use std::{
+    fs,
+    io::{BufRead, BufReader},
+    os::unix::{fs::PermissionsExt, net::UnixStream},
+    path::{Path, PathBuf},
+    process::{Child, Command, Stdio},
+    sync::mpsc,
+    thread,
+    time::{Duration, Instant},
+};
+
+fn cli_command(root: &Path, profile: &str) -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_kukuri-cli"));
+    command
+        .args(["--profile", profile])
+        .env("XDG_DATA_HOME", root.join("data"))
+        .env("XDG_RUNTIME_DIR", root.join("runtime"))
+        .env("HOME", root.join("home"))
+        .env("KUKURI_DISABLE_KEYRING", "1")
+        .env_remove("KUKURI_APP_DATA_DIR")
+        .env_remove("KUKURI_INSTANCE");
+    command
+}
+
+fn daemon_command(root: &Path, profile: &str) -> Command {
+    let mut command = cli_command(root, profile);
+    command.args(["daemon", "run"]);
+    command
+}
+
+fn accept_consent(root: &Path, profile: &str) {
+    let status = cli_command(root, profile)
+        .args(["consent", "accept", "--accept-documents", "--age-confirmed"])
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .status()
+        .expect("accept consent");
+    assert!(status.success(), "consent command exited with {status}");
+}
+
+fn spawn_daemon(root: &Path, profile: &str) -> Child {
+    daemon_command(root, profile)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn daemon")
+}
+
+fn socket_path(root: &Path, profile: &str) -> PathBuf {
+    root.join("runtime")
+        .join("kukuri")
+        .join(format!("{profile}.sock"))
+}
+
+fn wait_for_ready(child: &mut Child, path: &Path) {
+    let stdout = child.stdout.take().expect("daemon stdout");
+    let (sender, receiver) = mpsc::channel();
+    thread::spawn(move || {
+        let mut reader = BufReader::new(stdout);
+        let mut line = String::new();
+        let result = reader.read_line(&mut line).map(|_| line);
+        let _ = sender.send(result);
+    });
+    let line = match receiver.recv_timeout(Duration::from_secs(20)) {
+        Ok(result) => result.expect("read daemon readiness"),
+        Err(error) => {
+            let _ = child.kill();
+            panic!("daemon did not report readiness: {error}");
+        }
+    };
+    assert_eq!(line.trim(), "ready", "unexpected daemon readiness");
+    assert!(
+        path.exists(),
+        "daemon socket does not exist: {}",
+        path.display()
+    );
+    UnixStream::connect(path).expect("connect daemon socket");
+}
+
+fn terminate(mut child: Child) {
+    let result = unsafe { libc::kill(child.id() as i32, libc::SIGTERM) };
+    assert_eq!(result, 0, "send SIGTERM");
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        if let Some(status) = child.try_wait().expect("wait daemon") {
+            assert!(status.success(), "daemon exited with {status}");
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "daemon did not stop after SIGTERM"
+        );
+        thread::sleep(Duration::from_millis(25));
+    }
+}
+
+fn process_tcp_listener_count(pid: u32) -> usize {
+    let socket_inodes = fs::read_dir(format!("/proc/{pid}/fd"))
+        .expect("process fds")
+        .filter_map(Result::ok)
+        .filter_map(|entry| fs::read_link(entry.path()).ok())
+        .filter_map(|target| {
+            let value = target.to_string_lossy();
+            value
+                .strip_prefix("socket:[")
+                .and_then(|value| value.strip_suffix(']'))
+                .map(str::to_string)
+        })
+        .collect::<std::collections::HashSet<_>>();
+
+    ["/proc/net/tcp", "/proc/net/tcp6"]
+        .iter()
+        .filter_map(|path| fs::read_to_string(path).ok())
+        .flat_map(|table| {
+            table
+                .lines()
+                .skip(1)
+                .map(str::to_string)
+                .collect::<Vec<_>>()
+        })
+        .filter(|line| {
+            let columns = line.split_ascii_whitespace().collect::<Vec<_>>();
+            columns.get(3) == Some(&"0A")
+                && columns
+                    .get(9)
+                    .is_some_and(|inode| socket_inodes.contains(*inode))
+        })
+        .count()
+}
+
+#[test]
+fn daemon_enforces_profile_ownership_permissions_and_graceful_restart() {
+    let root = tempfile::tempdir().expect("tempdir");
+    fs::create_dir_all(root.path().join("runtime")).expect("runtime root");
+    fs::create_dir_all(root.path().join("home")).expect("home");
+    accept_consent(root.path(), "alpha");
+    accept_consent(root.path(), "beta");
+
+    let alpha_socket = socket_path(root.path(), "alpha");
+    let beta_socket = socket_path(root.path(), "beta");
+    let mut alpha = spawn_daemon(root.path(), "alpha");
+    wait_for_ready(&mut alpha, &alpha_socket);
+
+    assert_eq!(
+        fs::metadata(root.path().join("runtime/kukuri"))
+            .expect("runtime metadata")
+            .permissions()
+            .mode()
+            & 0o777,
+        0o700
+    );
+    assert_eq!(
+        fs::metadata(&alpha_socket)
+            .expect("socket metadata")
+            .permissions()
+            .mode()
+            & 0o777,
+        0o600
+    );
+    assert_eq!(process_tcp_listener_count(alpha.id()), 0);
+
+    let duplicate = daemon_command(root.path(), "alpha")
+        .output()
+        .expect("duplicate daemon");
+    assert!(!duplicate.status.success());
+    assert!(
+        String::from_utf8_lossy(&duplicate.stderr).contains("profile_in_use"),
+        "{}",
+        String::from_utf8_lossy(&duplicate.stderr)
+    );
+
+    let mut beta = spawn_daemon(root.path(), "beta");
+    wait_for_ready(&mut beta, &beta_socket);
+    terminate(alpha);
+    terminate(beta);
+    assert!(!alpha_socket.exists());
+    assert!(!beta_socket.exists());
+
+    let mut restarted = spawn_daemon(root.path(), "alpha");
+    wait_for_ready(&mut restarted, &alpha_socket);
+    terminate(restarted);
+    assert!(!alpha_socket.exists());
+}

--- a/docs/progress/2026-09-05-issue-886-shared-host-daemon.md
+++ b/docs/progress/2026-09-05-issue-886-shared-host-daemon.md
@@ -7,7 +7,7 @@ Scope revisionは`2026-09-04-issue-886-shared-host-daemon-v1`。公開command pr
 ## 実装結果
 
 - `kukuri-desktop-runtime::ClientHost`をGUIと常駐プロセスのruntime ownerとし、同意／年齢gate、account初期化、既定Community Node、scheduler、observer、account switch、runtime event、shutdownを共通化した。
-- GUI／CLI kind markerとprofile leaseを永続state読取り前に取得する。CLI profile pathは`$XDG_DATA_HOME`または`$HOME/.local/share`配下へ分離し、同profileの二重owner、selector競合、kind不一致、未分類legacy directoryを型付きerrorで拒否する。`KUKURI_APP_DATA_DIR`単独指定ではpath digestからsocket用profile名を導出し、異なるdirectoryのlocal socketを分離する。
+- GUI／CLI kind markerとprofile leaseを永続state読取り前に取得する。CLI profile pathは`$XDG_DATA_HOME`または`$HOME/.local/share`配下へ分離し、同profileの二重owner、selector競合、kind不一致、未分類legacy directoryを型付きerrorで拒否する。local socket名はcanonicalなprofile directoryのdigestから導出し、named／customを含む異なるdirectory間で名前空間を分離する。
 - `kukuri-cli daemon run|start|stop|status`とsystemd user instance unitを追加した。foreground daemonは`$XDG_RUNTIME_DIR`だけを使用し、runtime directory 0700、socket 0600、peer UID一致を要求し、TCP listenerを作らない。
 - 同意未成立時はprofile leaseとlocal socket以外を開始しない。同意成立後だけ共通hostを構築する。Secret Serviceを利用できない新規profileは既存の0600 file fallbackを使用できる。
 - account別のversion付き`kukuri.subscriptions.json`をatomic writeし、topic／channelの購読期待状態をhost起動とaccount切替時に復元する。破損、未知version、永続化失敗、購読再開失敗は型付きerrorとする。
@@ -32,4 +32,4 @@ Scope revisionは`2026-09-04-issue-886-shared-host-daemon-v1`。公開command pr
 
 ## Validation
 
-ローカルでは`cargo xtask check`、`cargo xtask test`（`rust-test`を含む）、`cargo xtask tauri-check`、`cargo xtask e2e-smoke`、`community_node_public_connectivity`、`desktop_device_backup_restore`、`cargo xtask oversized-files`、`git diff --check`がPASSした。Linuxでは`cargo test -p kukuri-cli`を実行し、同意済みruntimeのprocess testを含む7件がPASSした。PR headでは独立監査により固定inventory、transition、sensitive sink callerを再構築し、GitHub CIと併せて最終判定する。
+ローカルでは`cargo xtask check`、`cargo xtask test`（`rust-test`を含む）、`cargo xtask tauri-check`、`cargo xtask e2e-smoke`、`community_node_public_connectivity`、`desktop_device_backup_restore`、`cargo xtask oversized-files`、`git diff --check`がPASSした。Linuxでは`cargo test -p kukuri-cli`を実行し、同意済みruntimeのprocess testを含む9件がPASSした。PR headでは独立監査により固定inventory、transition、sensitive sink callerを再構築し、GitHub CIと併せて最終判定する。

--- a/docs/progress/2026-09-05-issue-886-shared-host-daemon.md
+++ b/docs/progress/2026-09-05-issue-886-shared-host-daemon.md
@@ -7,7 +7,7 @@ Scope revisionは`2026-09-04-issue-886-shared-host-daemon-v1`。公開command pr
 ## 実装結果
 
 - `kukuri-desktop-runtime::ClientHost`をGUIと常駐プロセスのruntime ownerとし、同意／年齢gate、account初期化、既定Community Node、scheduler、observer、account switch、runtime event、shutdownを共通化した。
-- GUI／CLI kind markerとprofile leaseを永続state読取り前に取得する。CLI profile pathは`$XDG_DATA_HOME`または`$HOME/.local/share`配下へ分離し、同profileの二重owner、selector競合、kind不一致、未分類legacy directoryを型付きerrorで拒否する。
+- GUI／CLI kind markerとprofile leaseを永続state読取り前に取得する。CLI profile pathは`$XDG_DATA_HOME`または`$HOME/.local/share`配下へ分離し、同profileの二重owner、selector競合、kind不一致、未分類legacy directoryを型付きerrorで拒否する。`KUKURI_APP_DATA_DIR`単独指定ではpath digestからsocket用profile名を導出し、異なるdirectoryのlocal socketを分離する。
 - `kukuri-cli daemon run|start|stop|status`とsystemd user instance unitを追加した。foreground daemonは`$XDG_RUNTIME_DIR`だけを使用し、runtime directory 0700、socket 0600、peer UID一致を要求し、TCP listenerを作らない。
 - 同意未成立時はprofile leaseとlocal socket以外を開始しない。同意成立後だけ共通hostを構築する。Secret Serviceを利用できない新規profileは既存の0600 file fallbackを使用できる。
 - account別のversion付き`kukuri.subscriptions.json`をatomic writeし、topic／channelの購読期待状態をhost起動とaccount切替時に復元する。破損、未知version、永続化失敗、購読再開失敗は型付きerrorとする。
@@ -32,4 +32,4 @@ Scope revisionは`2026-09-04-issue-886-shared-host-daemon-v1`。公開command pr
 
 ## Validation
 
-ローカルでは`cargo xtask check`、`cargo xtask test`（`rust-test`を含む）、`cargo xtask tauri-check`、`cargo xtask e2e-smoke`、`community_node_public_connectivity`、`desktop_device_backup_restore`、`cargo xtask oversized-files`、`git diff --check`がPASSした。Linuxでは`cargo test -p kukuri-cli`を実行し、同意済みruntimeのprocess testを含む6件がPASSした。PR headでは独立監査により固定inventory、transition、sensitive sink callerを再構築し、GitHub CIと併せて最終判定する。
+ローカルでは`cargo xtask check`、`cargo xtask test`（`rust-test`を含む）、`cargo xtask tauri-check`、`cargo xtask e2e-smoke`、`community_node_public_connectivity`、`desktop_device_backup_restore`、`cargo xtask oversized-files`、`git diff --check`がPASSした。Linuxでは`cargo test -p kukuri-cli`を実行し、同意済みruntimeのprocess testを含む7件がPASSした。PR headでは独立監査により固定inventory、transition、sensitive sink callerを再構築し、GitHub CIと併せて最終判定する。

--- a/docs/progress/2026-09-05-issue-886-shared-host-daemon.md
+++ b/docs/progress/2026-09-05-issue-886-shared-host-daemon.md
@@ -1,0 +1,35 @@
+# Issue #886 共通client hostとLinux常駐プロセス
+
+## Scope
+
+Scope revisionは`2026-09-04-issue-886-shared-host-daemon-v1`。公開command protocolとdomain command mappingは#887、#888が所有するため、本Issueでは共通host lifecycle、CLI profile、単一所有、認証済みUnix socket、購読期待状態、event供給点、graceful shutdownを固定する。
+
+## 実装結果
+
+- `kukuri-desktop-runtime::ClientHost`をGUIと常駐プロセスのruntime ownerとし、同意／年齢gate、account初期化、既定Community Node、scheduler、observer、account switch、runtime event、shutdownを共通化した。
+- GUI／CLI kind markerとprofile leaseを永続state読取り前に取得する。CLI profile pathは`$XDG_DATA_HOME`または`$HOME/.local/share`配下へ分離し、同profileの二重owner、selector競合、kind不一致、未分類legacy directoryを型付きerrorで拒否する。
+- `kukuri-cli daemon run|start|stop|status`とsystemd user instance unitを追加した。foreground daemonは`$XDG_RUNTIME_DIR`だけを使用し、runtime directory 0700、socket 0600、peer UID一致を要求し、TCP listenerを作らない。
+- 同意未成立時はprofile leaseとlocal socket以外を開始しない。同意成立後だけ共通hostを構築する。Secret Serviceを利用できない新規profileは既存の0600 file fallbackを使用できる。
+- account別のversion付き`kukuri.subscriptions.json`をatomic writeし、topic／channelの購読期待状態をhost起動とaccount切替時に復元する。破損、未知version、永続化失敗、購読再開失敗は型付きerrorとする。
+- `ClientHost`のevent receiverはremote runtime event、notification更新、直近のsync statusを継続配信する。SIGINT／SIGTERMとdesktop tray終了は共通host shutdownの完了を待つ。
+- device backupへ購読期待状態を含め、profile lock、marker、Unix socket、endpoint secretは含めない。
+
+## 固定surfaceとtransitionの対応
+
+| ID | 実装／test |
+| --- | --- |
+| `INV-1` | `ClientHost::start_if_consented`、`switch_account`、Tauri adapter、既存GUI regression |
+| `INV-2` | `ProfileLease`、`kukuri-cli daemon run`、Linux process test |
+| `INV-3` | Unix socket permission、`peer_cred` UID検証、TCP listener 0件 test |
+| `INV-4` | `DesiredSubscription` store、host restart／identity test、backup restore validation |
+| `INV-5` | host operation guard、冪等shutdown、SIGTERM restart test、desktop tray shutdown |
+| `TR-1` | 未同意時にaccount registryを生成しないhost test |
+| `TR-2` | 同profile二重owner testとLinux duplicate daemon test |
+| `TR-3` | 別profile同時lease／daemon test |
+| `TR-4` | 同一identityと購読期待状態のhost restart test |
+| `TR-5` | SIGTERM後のsocket cleanup／再起動testと冪等host shutdown test |
+| `TR-6` | profile selector／kind error、既存identity fallback test、runbook |
+
+## Validation
+
+ローカルでは`cargo xtask check`、`cargo xtask test`（`rust-test`を含む）、`cargo xtask tauri-check`、`cargo xtask e2e-smoke`、`community_node_public_connectivity`、`desktop_device_backup_restore`、`cargo xtask oversized-files`、`git diff --check`がPASSした。Linuxでは`cargo test -p kukuri-cli`を実行し、同意済みruntimeのprocess testを含む6件がPASSした。PR headでは独立監査により固定inventory、transition、sensitive sink callerを再構築し、GitHub CIと併せて最終判定する。

--- a/docs/runbooks/dev.md
+++ b/docs/runbooks/dev.md
@@ -295,7 +295,7 @@ cargo run -p kukuri-cli -- --profile dev daemon run
 ```
 
 - profileは`$XDG_DATA_HOME/kukuri/cli/profiles/<profile>`、未設定時は`$HOME/.local/share/kukuri/cli/profiles/<profile>`へ置く。`--profile`と`KUKURI_INSTANCE`が異なる場合、またはprofile selectorと`KUKURI_APP_DATA_DIR`を併用した場合は起動しない。
-- 同一profileを別processが所有している場合は`profile_in_use`で終了する。local socketは`$XDG_RUNTIME_DIR/kukuri/<profile>.sock`で、`XDG_RUNTIME_DIR`が無い環境では起動しない。
+- 同一profileを別processが所有している場合は`profile_in_use`で終了する。local socketは`$XDG_RUNTIME_DIR/kukuri/<profile>.sock`で、`KUKURI_APP_DATA_DIR`を単独指定した場合はdata directoryのdigestから導出した`custom-<digest>.sock`を使う。`XDG_RUNTIME_DIR`が無い環境では起動しない。
 - `daemon start`、`daemon stop`、`daemon status`は`packaging/linux/systemd/kukuri@.service`をuser unitとして配置した環境で`systemctl --user`を操作する。
 - Secret Serviceを利用できない画面なし環境では、新規profileの起動前に`KUKURI_DISABLE_KEYRING=1`を設定する。identityはprofile内の0600 fileへ保存され、以後も同じ設定で起動する。既にkeyringへ保存済みのidentityへこの設定を後付けした場合は、別identityを生成せず型付きstartup errorで停止する。
 - 同意が未成立の場合、常駐プロセスはlocal socketだけを開き、account identity、network runtime、scheduler、observerを開始しない。`consent accept`はprofile leaseを取得するため、常駐プロセスを停止してから実行する。

--- a/docs/runbooks/dev.md
+++ b/docs/runbooks/dev.md
@@ -295,8 +295,8 @@ cargo run -p kukuri-cli -- --profile dev daemon run
 ```
 
 - profileは`$XDG_DATA_HOME/kukuri/cli/profiles/<profile>`、未設定時は`$HOME/.local/share/kukuri/cli/profiles/<profile>`へ置く。`--profile`と`KUKURI_INSTANCE`が異なる場合、またはprofile selectorと`KUKURI_APP_DATA_DIR`を併用した場合は起動しない。
-- 同一profileを別processが所有している場合は`profile_in_use`で終了する。local socketは`$XDG_RUNTIME_DIR/kukuri/<profile>.sock`で、`KUKURI_APP_DATA_DIR`を単独指定した場合はdata directoryのdigestから導出した`custom-<digest>.sock`を使う。`XDG_RUNTIME_DIR`が無い環境では起動しない。
-- `daemon start`、`daemon stop`、`daemon status`は`packaging/linux/systemd/kukuri@.service`をuser unitとして配置した環境で`systemctl --user`を操作する。
+- 同一profileを別processが所有している場合は`profile_in_use`で終了する。local socketはcanonicalなprofile directoryのdigestから導出した`$XDG_RUNTIME_DIR/kukuri/profile-<digest>.sock`を使い、異なるprofile directory間で名前空間を共有しない。`XDG_RUNTIME_DIR`が無い環境では起動しない。
+- `daemon start`、`daemon stop`、`daemon status`は`packaging/linux/systemd/kukuri@.service`をuser unitとして配置した環境で`systemctl --user`を操作する。これらはnamed profile専用で、`KUKURI_APP_DATA_DIR`を指定した実行では使用できない。
 - Secret Serviceを利用できない画面なし環境では、新規profileの起動前に`KUKURI_DISABLE_KEYRING=1`を設定する。identityはprofile内の0600 fileへ保存され、以後も同じ設定で起動する。既にkeyringへ保存済みのidentityへこの設定を後付けした場合は、別identityを生成せず型付きstartup errorで停止する。
 - 同意が未成立の場合、常駐プロセスはlocal socketだけを開き、account identity、network runtime、scheduler、observerを開始しない。`consent accept`はprofile leaseを取得するため、常駐プロセスを停止してから実行する。
 

--- a/docs/runbooks/dev.md
+++ b/docs/runbooks/dev.md
@@ -284,6 +284,22 @@ export KUKURI_DISCOVERY_SEEDS=<node_id または node_id@host:port をカンマ�
 - `KUKURI_DISABLE_KEYRING=1` を設定すると OS keyring を使わず、app data dir 内の `*.identity-key` fallback file を使う。
 - `KUKURI_DISCOVERY_MODE` / `KUKURI_DISCOVERY_SEEDS` を設定すると discovery panel は read-only になり、env が local file より優先される。
 
+## Linux client daemon
+
+開発buildでは、CLI専用profileを選んで同意を記録した後、foregroundの常駐プロセスを起動する。
+
+```bash
+cargo run -p kukuri-cli -- --profile dev consent status
+cargo run -p kukuri-cli -- --profile dev consent accept --accept-documents --age-confirmed --language ja
+cargo run -p kukuri-cli -- --profile dev daemon run
+```
+
+- profileは`$XDG_DATA_HOME/kukuri/cli/profiles/<profile>`、未設定時は`$HOME/.local/share/kukuri/cli/profiles/<profile>`へ置く。`--profile`と`KUKURI_INSTANCE`が異なる場合、またはprofile selectorと`KUKURI_APP_DATA_DIR`を併用した場合は起動しない。
+- 同一profileを別processが所有している場合は`profile_in_use`で終了する。local socketは`$XDG_RUNTIME_DIR/kukuri/<profile>.sock`で、`XDG_RUNTIME_DIR`が無い環境では起動しない。
+- `daemon start`、`daemon stop`、`daemon status`は`packaging/linux/systemd/kukuri@.service`をuser unitとして配置した環境で`systemctl --user`を操作する。
+- Secret Serviceを利用できない画面なし環境では、新規profileの起動前に`KUKURI_DISABLE_KEYRING=1`を設定する。identityはprofile内の0600 fileへ保存され、以後も同じ設定で起動する。既にkeyringへ保存済みのidentityへこの設定を後付けした場合は、別identityを生成せず型付きstartup errorで停止する。
+- 同意が未成立の場合、常駐プロセスはlocal socketだけを開き、account identity、network runtime、scheduler、observerを開始しない。`consent accept`はprofile leaseを取得するため、常駐プロセスを停止してから実行する。
+
 PowerShell 例:
 ```powershell
 $env:KUKURI_BIND_ADDR="0.0.0.0:0"

--- a/packaging/linux/systemd/kukuri@.service
+++ b/packaging/linux/systemd/kukuri@.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=kukuri client daemon (%i)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/kukuri-cli --profile %i daemon run
+Restart=on-failure
+RestartSec=3
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
## 概要

Tauri非依存の`ClientHost`をLinux常駐プロセスから利用できるようにし、CLI専用profileの単一所有、同意前の起動抑止、認証済みUnix socket、購読期待状態の復元、signalによる安全な停止を実装します。GUIは同じhost lifecycleを利用し、tray終了時にshutdown完了を待つようになります。

## Issue lifecycle

- 対象Issue: Refs #886
- リスク区分: C
- Scope revision / 基準commit: `2026-09-04-issue-886-shared-host-daemon-v1` / `01b65483f1350c35d3325d8b6127c12797f9313d`
- Fixed surface inventory: CodeGraphで既存callerを確認し、`INV-1`〜`INV-5`の5件を実装・testへ対応付け。変更後の未分類は0件。
- Sensitive sink と shared helper の全caller確認: identity／endpoint secret、profile marker／lock、account registry／SQLite、購読期待状態、Iroh／Community Node、scheduler／observer、Tauri event bridge、Unix socketについて、GUI startup、daemon startup、account switch、restore、shutdownのcallerを確認。
- 対象状態遷移: `TR-1`同意待ち、`TR-2`同profile二重owner、`TR-3`別profile同時起動、`TR-4`restart復元、`TR-5`signal停止と再起動、`TR-6`profile／secret失敗。

## AC / invariant traceability

| AC / INVAR ID | 実装箇所 | test / contract / scenario | 結果 |
| --- | --- | --- | --- |
| `AC-1` / `INVAR-1` | `ClientHost::start_if_consented`、Tauri adapter、account switch | host tests、既存desktop tests、`tauri-check` | PASS |
| `AC-2` / `INVAR-3` | `ClientProfile`、`ProfileLease`、profile kind marker | profile unit tests、Linux process test | PASS |
| `AC-3` | `kukuri-cli daemon`、Unix socket、systemd user unit | socket 0600、runtime dir 0700、UID、TCP 0件、二重owner test | PASS |
| `AC-4` | 購読期待状態、host event receiver、共通shutdown | host restart test、backup test、Linux SIGTERM restart test | PASS |
| `AC-5` / `INVAR-2` | consent gate、既存file fallback | 同意前account未生成test、identity regression、Linux実process test | PASS |

## テスト先行証跡

- failing-before: featureのため既存不具合の再現は対象外。新規contractとしてprofile排他、権限、同意前副作用、購読復元、signal restartのtestを追加。
- passing-after: desktop-runtime対象test、Linux `kukuri-cli` 9件、backup／connectivity scenarioを含む必須検証がPASS。custom/customとcustom/同名namedのdaemonを同時起動し、片方の停止後も他方のsocketが生存するprocess testを含む。

## 種別

- [ ] fix
- [x] feature
- [ ] refactor
- [x] contract／scenario
- [x] docs
- [ ] deps

## 挙動変更

変更あり。Linuxで`kukuri-cli daemon run|start|stop|status`と`consent status|accept`を利用できます。GUIの既存startup／account switch／DTO／profile semanticsは維持し、tray終了のみ共通hostのshutdown完了を待つようにします。公開command protocolとdomain command mappingは#887、#888の対象です。

## UI変更

対象外: 画面、導線、表示、操作には変更なし。

## 検証

- targeted: `cargo clippy -p kukuri-app-api -p kukuri-desktop-runtime -p kukuri-cli --all-targets -- -D warnings`、desktop-runtime host／migration／backup tests、Linux `cargo test -p kukuri-cli`がPASS。
- path別必須validation: `cargo xtask check`、`cargo xtask test`、`cargo xtask tauri-check`、`cargo xtask e2e-smoke`、`cargo xtask scenario community_node_public_connectivity`、`cargo xtask scenario desktop_device_backup_restore`、`cargo xtask ipc-types --check`、`cargo xtask oversized-files`、`git diff --check`がPASS。
- 未実行と理由: なし。
- CI: 修正後headで14 checkすべてPASS。

## 独立監査

- 要否と理由: 必須。identity、同意前外部送信、profile単一所有、local IPC permission、shutdown durabilityを同時に変更するため。
- 監査対象commit: `1b9617d5b95c38ff5eb67768f3c542a44b528ec2`
- inventory: 5件中5件適合、不適合0件、未分類0件。
- AC / INVAR evidence: `AC-1`〜`AC-5`、`INVAR-1`〜`INVAR-3`すべて適合。canonical profile directory digestによるsocket分離、custom/同名named同時起動、片方停止後の他方socket生存、custom pathのsystemd操作拒否をproduction callerとLinux実process testで確認。
- blocker: 0件。
- non-blocker: 0件。
- 判定: PASS。
- 監査後delta: 1回目の指摘に`fb4144058d5e68cd1ec9376d00398b6a19076023`でcustom/custom分離を追加。2回目の同一bug class指摘に`1b9617d5b95c38ff5eb67768f3c542a44b528ec2`で全profile directory由来のsocket名前空間、custom/同名named回帰test、custom pathのsystemd操作拒否を追加。最終監査後のコード差分なし。

## リスク

- Existing-gap / Regression: profile lock取得前のstate読取り、同意前runtime起動、購読状態の破損、account switch失敗時の旧runtime喪失をfail-closedに扱う。GUI回帰は全体testとTauri checkで確認済み。
- New-requirement / Optional-hardening: 公開JSON／NDJSON protocol、command登録簿、domain command mapping、配布成果物は#887〜#890が所有し、本IssueのClose blockerにはしない。
