### PR TITLE
kukuri-cliのprotocol v1と安全なI/Oを実装する

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3185,6 +3185,7 @@ name = "kukuri-cli"
 version = "0.1.8"
 dependencies = [
  "anyhow",
+ "async-trait",
  "blake3",
  "clap",
  "kukuri-desktop-runtime",
@@ -3193,6 +3194,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
+ "uuid",
 ]
 
 [[package]]
@@ -3529,11 +3531,13 @@ dependencies = [
  "reqwest 0.13.4",
  "serde",
  "serde_json",
+ "sqlx",
  "tempfile",
  "tokio",
  "tracing",
  "ts-rs",
  "url",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,7 @@ tower-http = { version = "0.7.0", features = ["trace"] }
 tower_governor = "0.8.0"
 ts-rs = "12"
 url = "2.5.8"
-uuid = { version = "1.24.0", features = ["serde", "v4"] }
+uuid = { version = "1.24.0", features = ["serde", "v4", "v7"] }
 wiremock = "0.6"
 
 [patch.crates-io]

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -3920,9 +3920,11 @@ dependencies = [
  "reqwest 0.13.4",
  "serde",
  "serde_json",
+ "sqlx",
  "tokio",
  "tracing",
  "url",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/desktop-runtime/Cargo.toml
+++ b/crates/desktop-runtime/Cargo.toml
@@ -14,9 +14,11 @@ image.workspace = true
 reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+sqlx.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 url.workspace = true
+uuid.workspace = true
 kukuri-app-api = { path = "../app-api" }
 kukuri-blob-service = { path = "../blob-service" }
 kukuri-cn-protocol = { path = "../cn-protocol" }

--- a/crates/desktop-runtime/src/backup.rs
+++ b/crates/desktop-runtime/src/backup.rs
@@ -308,6 +308,15 @@ pub async fn validate_prepared_device_restore(prepared: &PreparedDeviceRestore) 
     let _ = load_community_node_config_from_file(&db_path)?;
     let _ = load_discovery_config_from_file(&db_path)?;
     validate_persisted_runtime_state(&db_path, identity_mode)?;
+    // 古いbackupや台帳欠落backupでも、復元前に発行済みだったkeyは再実行しない。
+    let ledger = crate::IdempotencyLedger::open(&db_path)
+        .await
+        .context("restored idempotency ledger is invalid")?;
+    ledger
+        .mark_restored(chrono::Utc::now().timestamp_millis())
+        .await
+        .context("failed to mark restored idempotency history")?;
+    ledger.close().await;
     Ok(())
 }
 

--- a/crates/desktop-runtime/src/backup/create.rs
+++ b/crates/desktop-runtime/src/backup/create.rs
@@ -16,7 +16,7 @@ use super::{
     FRONTEND_STATE_MAX_BYTES, SECRETS_ENTRY, active_account_for_db, collect_secret_bundle,
     ensure_backup_path_outside_app_data,
 };
-use crate::paths::DB_FILE_NAME;
+use crate::{IDEMPOTENCY_LEDGER_FILE_NAME, idempotency_ledger_path, paths::DB_FILE_NAME};
 
 const IROH_ENDPOINT_SECRET_FILE: &str = "endpoint-secret.json";
 
@@ -69,6 +69,9 @@ where
         FRONTEND_STATE_ENTRY.to_string(),
         EntrySource::Bytes(frontend_bytes),
     ));
+    let includes_idempotency_ledger = raw_sources
+        .iter()
+        .any(|(name, _)| name == "file/kukuri.idempotency.sqlite3");
     let total_bytes = raw_sources.iter().try_fold(0u64, |total, (_, source)| {
         let bytes = source_len(source)?;
         let total = total
@@ -102,6 +105,18 @@ where
         });
     }
 
+    let mut included = vec![
+        "account_key".to_string(),
+        "sqlite".to_string(),
+        "local_docs_and_blobs".to_string(),
+        "private_channel_state".to_string(),
+        "drafts_and_preferences".to_string(),
+        "community_node_configuration".to_string(),
+        "desired_subscriptions".to_string(),
+    ];
+    if includes_idempotency_ledger {
+        included.push("idempotency_ledger".to_string());
+    }
     let manifest = DeviceBackupManifestV1 {
         format_version: DEVICE_BACKUP_FORMAT_VERSION,
         component_version: DEVICE_BACKUP_COMPONENT_VERSION,
@@ -109,15 +124,7 @@ where
         app_version: env!("CARGO_PKG_VERSION").to_string(),
         public_key: account.pubkey.clone(),
         account_label: account.label.clone(),
-        included: vec![
-            "account_key".to_string(),
-            "sqlite".to_string(),
-            "local_docs_and_blobs".to_string(),
-            "private_channel_state".to_string(),
-            "drafts_and_preferences".to_string(),
-            "community_node_configuration".to_string(),
-            "desired_subscriptions".to_string(),
-        ],
+        included,
         requires_reconsent: vec![
             "app_legal_documents".to_string(),
             "age_attestation".to_string(),
@@ -214,6 +221,14 @@ fn account_file_sources(db_path: &Path) -> Result<Vec<(String, EntrySource)>> {
                 .ok_or_else(|| anyhow!("invalid account state filename"))?;
             add_file_source(&mut sources, &path, Path::new(name))?;
         }
+    }
+    let idempotency_path = idempotency_ledger_path(db_path);
+    if idempotency_path.is_file() {
+        add_file_source(
+            &mut sources,
+            &idempotency_path,
+            Path::new(IDEMPOTENCY_LEDGER_FILE_NAME),
+        )?;
     }
     let iroh_root = db_path.with_extension("iroh-data");
     if iroh_root.exists() {

--- a/crates/desktop-runtime/src/host/idempotency.rs
+++ b/crates/desktop-runtime/src/host/idempotency.rs
@@ -1,0 +1,721 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, bail};
+use serde_json::Value;
+use sqlx::{
+    Row, SqlitePool,
+    sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions, SqliteSynchronous},
+};
+use uuid::Uuid;
+
+pub const IDEMPOTENCY_LEDGER_FILE_NAME: &str = "kukuri.idempotency.sqlite3";
+const RETENTION_MS: i64 = 30 * 24 * 60 * 60 * 1000;
+const MAX_SCOPE_RECORDS: i64 = 10_000;
+const MAX_CLOCK_SKEW_MS: i64 = 5 * 60 * 1000;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct IdempotencyScope<'a> {
+    pub profile: &'a str,
+    pub account: &'a str,
+    pub command: &'a str,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum IdempotencyClaim {
+    Execute,
+    Replay(Value),
+    Conflict,
+    OutcomeUnknown,
+    Expired,
+}
+
+pub struct IdempotencyLedger {
+    pool: SqlitePool,
+    digest_key: [u8; 32],
+}
+
+impl IdempotencyLedger {
+    pub async fn open(db_path: &Path) -> Result<Self> {
+        let path = idempotency_ledger_path(db_path);
+        let options = SqliteConnectOptions::new()
+            .filename(&path)
+            .create_if_missing(true)
+            .journal_mode(SqliteJournalMode::Delete)
+            .synchronous(SqliteSynchronous::Full);
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect_with(options)
+            .await
+            .with_context(|| format!("failed to open idempotency ledger `{}`", path.display()))?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
+                .context("failed to protect idempotency ledger")?;
+        }
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS metadata (key TEXT PRIMARY KEY, value TEXT NOT NULL)",
+        )
+        .execute(&pool)
+        .await?;
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS records (
+                profile TEXT NOT NULL,
+                account TEXT NOT NULL,
+                command TEXT NOT NULL,
+                idempotency_key TEXT NOT NULL,
+                payload_hash TEXT NOT NULL,
+                state TEXT NOT NULL,
+                result_json TEXT,
+                created_at_ms INTEGER NOT NULL,
+                updated_at_ms INTEGER NOT NULL,
+                PRIMARY KEY (profile, account, command, idempotency_key)
+            )",
+        )
+        .execute(&pool)
+        .await?;
+        let salt = match sqlx::query_scalar::<_, String>(
+            "SELECT value FROM metadata WHERE key = 'digest_salt'",
+        )
+        .fetch_optional(&pool)
+        .await?
+        {
+            Some(value) => value,
+            None => {
+                let value = format!("{}{}", Uuid::new_v4().simple(), Uuid::new_v4().simple());
+                sqlx::query("INSERT INTO metadata (key, value) VALUES ('digest_salt', ?)")
+                    .bind(&value)
+                    .execute(&pool)
+                    .await?;
+                value
+            }
+        };
+        let digest_key = *blake3::hash(salt.as_bytes()).as_bytes();
+        Ok(Self { pool, digest_key })
+    }
+
+    pub fn digest_payload(&self, canonical_payload: &[u8], secret: Option<&[u8]>) -> String {
+        let mut hasher = blake3::Hasher::new_keyed(&self.digest_key);
+        hasher.update(&(canonical_payload.len() as u64).to_be_bytes());
+        hasher.update(canonical_payload);
+        if let Some(secret) = secret {
+            hasher.update(&(secret.len() as u64).to_be_bytes());
+            hasher.update(secret);
+        }
+        hasher.finalize().to_hex().to_string()
+    }
+
+    pub async fn claim(
+        &self,
+        scope: &IdempotencyScope<'_>,
+        key: &str,
+        payload_hash: &str,
+        now_ms: i64,
+    ) -> Result<IdempotencyClaim> {
+        let key_ms = uuid_v7_millis(key)?;
+        if key_ms > now_ms.saturating_add(MAX_CLOCK_SKEW_MS) {
+            bail!("idempotency_key timestamp is too far in the future");
+        }
+        self.prune(scope, now_ms).await?;
+        let mut transaction = self.pool.begin().await?;
+        if let Some(row) = sqlx::query(
+            "SELECT payload_hash, state, result_json FROM records
+             WHERE profile = ? AND account = ? AND command = ? AND idempotency_key = ?",
+        )
+        .bind(scope.profile)
+        .bind(scope.account)
+        .bind(scope.command)
+        .bind(key)
+        .fetch_optional(&mut *transaction)
+        .await?
+        {
+            let existing_hash: String = row.try_get("payload_hash")?;
+            if existing_hash != payload_hash {
+                transaction.commit().await?;
+                return Ok(IdempotencyClaim::Conflict);
+            }
+            let state: String = row.try_get("state")?;
+            let claim = match state.as_str() {
+                "completed" => {
+                    let result: Option<String> = row.try_get("result_json")?;
+                    let value = serde_json::from_str(
+                        result
+                            .as_deref()
+                            .context("completed idempotency record has no result")?,
+                    )
+                    .context("completed idempotency result is invalid")?;
+                    IdempotencyClaim::Replay(value)
+                }
+                "in_progress" | "unknown" => IdempotencyClaim::OutcomeUnknown,
+                _ => bail!("idempotency ledger contains an invalid state"),
+            };
+            transaction.commit().await?;
+            return Ok(claim);
+        }
+
+        let restore_ms = metadata_i64(&mut transaction, "restored_at_ms").await?;
+        if restore_ms.is_some_and(|value| key_ms <= value.saturating_add(MAX_CLOCK_SKEW_MS)) {
+            transaction.commit().await?;
+            return Ok(IdempotencyClaim::OutcomeUnknown);
+        }
+        if key_ms < now_ms.saturating_sub(RETENTION_MS) {
+            transaction.commit().await?;
+            return Ok(IdempotencyClaim::Expired);
+        }
+        let watermark_ms = metadata_i64(&mut transaction, "retention_watermark_ms").await?;
+        if watermark_ms.is_some_and(|value| key_ms <= value) {
+            transaction.commit().await?;
+            return Ok(IdempotencyClaim::Expired);
+        }
+        let count: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM records WHERE profile = ? AND account = ?")
+                .bind(scope.profile)
+                .bind(scope.account)
+                .fetch_one(&mut *transaction)
+                .await?;
+        if count >= MAX_SCOPE_RECORDS {
+            bail!("idempotency ledger capacity is exhausted by unresolved records");
+        }
+        sqlx::query(
+            "INSERT INTO records (
+                profile, account, command, idempotency_key, payload_hash, state,
+                result_json, created_at_ms, updated_at_ms
+             ) VALUES (?, ?, ?, ?, ?, 'in_progress', NULL, ?, ?)",
+        )
+        .bind(scope.profile)
+        .bind(scope.account)
+        .bind(scope.command)
+        .bind(key)
+        .bind(payload_hash)
+        .bind(now_ms)
+        .bind(now_ms)
+        .execute(&mut *transaction)
+        .await?;
+        transaction.commit().await?;
+        Ok(IdempotencyClaim::Execute)
+    }
+
+    pub async fn complete(
+        &self,
+        scope: &IdempotencyScope<'_>,
+        key: &str,
+        result: &Value,
+        now_ms: i64,
+    ) -> Result<()> {
+        let result =
+            serde_json::to_string(result).context("failed to encode idempotency result")?;
+        let updated = sqlx::query(
+            "UPDATE records SET state = 'completed', result_json = ?, updated_at_ms = ?
+             WHERE profile = ? AND account = ? AND command = ? AND idempotency_key = ?
+               AND state = 'in_progress'",
+        )
+        .bind(result)
+        .bind(now_ms)
+        .bind(scope.profile)
+        .bind(scope.account)
+        .bind(scope.command)
+        .bind(key)
+        .execute(&self.pool)
+        .await?
+        .rows_affected();
+        if updated != 1 {
+            bail!("idempotency record was not in progress");
+        }
+        Ok(())
+    }
+
+    pub async fn mark_unknown(
+        &self,
+        scope: &IdempotencyScope<'_>,
+        key: &str,
+        now_ms: i64,
+    ) -> Result<()> {
+        sqlx::query(
+            "UPDATE records SET state = 'unknown', result_json = NULL, updated_at_ms = ?
+             WHERE profile = ? AND account = ? AND command = ? AND idempotency_key = ?
+               AND state = 'in_progress'",
+        )
+        .bind(now_ms)
+        .bind(scope.profile)
+        .bind(scope.account)
+        .bind(scope.command)
+        .bind(key)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    pub async fn mark_restored(&self, now_ms: i64) -> Result<()> {
+        set_metadata_i64(&self.pool, "restored_at_ms", now_ms).await
+    }
+
+    pub async fn close(self) {
+        self.pool.close().await;
+    }
+
+    async fn prune(&self, scope: &IdempotencyScope<'_>, now_ms: i64) -> Result<()> {
+        let cutoff = now_ms.saturating_sub(RETENTION_MS);
+        let mut transaction = self.pool.begin().await?;
+        let removed_time: Option<i64> = sqlx::query_scalar(
+            "SELECT MAX(updated_at_ms) FROM records
+             WHERE profile = ? AND account = ? AND state = 'completed' AND updated_at_ms < ?",
+        )
+        .bind(scope.profile)
+        .bind(scope.account)
+        .bind(cutoff)
+        .fetch_one(&mut *transaction)
+        .await?;
+        sqlx::query(
+            "DELETE FROM records
+             WHERE profile = ? AND account = ? AND state = 'completed' AND updated_at_ms < ?",
+        )
+        .bind(scope.profile)
+        .bind(scope.account)
+        .bind(cutoff)
+        .execute(&mut *transaction)
+        .await?;
+        if let Some(removed_time) = removed_time {
+            let previous = metadata_i64(&mut transaction, "retention_watermark_ms")
+                .await?
+                .unwrap_or(0);
+            set_metadata_i64_tx(
+                &mut transaction,
+                "retention_watermark_ms",
+                previous.max(removed_time),
+            )
+            .await?;
+        }
+        let count: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM records WHERE profile = ? AND account = ?")
+                .bind(scope.profile)
+                .bind(scope.account)
+                .fetch_one(&mut *transaction)
+                .await?;
+        let required_removals = count.saturating_sub(MAX_SCOPE_RECORDS - 1);
+        if required_removals > 0 {
+            let keys = sqlx::query_as::<_, (String, String)>(
+                "SELECT command, idempotency_key FROM records
+                 WHERE profile = ? AND account = ? AND state = 'completed'
+                 ORDER BY updated_at_ms ASC, command ASC, idempotency_key ASC LIMIT ?",
+            )
+            .bind(scope.profile)
+            .bind(scope.account)
+            .bind(required_removals)
+            .fetch_all(&mut *transaction)
+            .await?;
+            if keys.len() < required_removals as usize {
+                bail!("idempotency ledger capacity is exhausted by unresolved records");
+            }
+            let mut removed_key_ms = 0;
+            for (command, key) in keys {
+                removed_key_ms = removed_key_ms.max(uuid_v7_millis(&key)?);
+                sqlx::query(
+                    "DELETE FROM records
+                     WHERE profile = ? AND account = ? AND command = ? AND idempotency_key = ?",
+                )
+                .bind(scope.profile)
+                .bind(scope.account)
+                .bind(command)
+                .bind(key)
+                .execute(&mut *transaction)
+                .await?;
+            }
+            let previous = metadata_i64(&mut transaction, "retention_watermark_ms")
+                .await?
+                .unwrap_or(0);
+            set_metadata_i64_tx(
+                &mut transaction,
+                "retention_watermark_ms",
+                previous.max(removed_key_ms),
+            )
+            .await?;
+        }
+        transaction.commit().await?;
+        Ok(())
+    }
+}
+
+pub fn idempotency_ledger_path(db_path: &Path) -> PathBuf {
+    db_path.with_file_name(IDEMPOTENCY_LEDGER_FILE_NAME)
+}
+
+fn uuid_v7_millis(key: &str) -> Result<i64> {
+    let uuid = Uuid::parse_str(key).context("idempotency_key must be a UUID")?;
+    if uuid.get_version_num() != 7 {
+        bail!("idempotency_key must be UUIDv7");
+    }
+    let (seconds, nanos) = uuid
+        .get_timestamp()
+        .context("idempotency_key has no timestamp")?
+        .to_unix();
+    i64::try_from(seconds.saturating_mul(1000) + u64::from(nanos / 1_000_000))
+        .context("idempotency_key timestamp is out of range")
+}
+
+async fn metadata_i64(
+    transaction: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    key: &str,
+) -> Result<Option<i64>> {
+    let value = sqlx::query_scalar::<_, String>("SELECT value FROM metadata WHERE key = ?")
+        .bind(key)
+        .fetch_optional(&mut **transaction)
+        .await?;
+    value
+        .map(|value| value.parse::<i64>().context("invalid ledger metadata"))
+        .transpose()
+}
+
+async fn set_metadata_i64(pool: &SqlitePool, key: &str, value: i64) -> Result<()> {
+    sqlx::query(
+        "INSERT INTO metadata (key, value) VALUES (?, ?)
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+    )
+    .bind(key)
+    .bind(value.to_string())
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+async fn set_metadata_i64_tx(
+    transaction: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    key: &str,
+    value: i64,
+) -> Result<()> {
+    sqlx::query(
+        "INSERT INTO metadata (key, value) VALUES (?, ?)
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+    )
+    .bind(key)
+    .bind(value.to_string())
+    .execute(&mut **transaction)
+    .await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn unix_millis() -> i64 {
+        chrono::Utc::now().timestamp_millis()
+    }
+
+    #[tokio::test]
+    async fn replay_conflict_and_crash_unknown_are_durable() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let db_path = root.path().join("kukuri.db");
+        let key = Uuid::now_v7().to_string();
+        let scope = IdempotencyScope {
+            profile: "test",
+            account: "account-a",
+            command: "fixture.write",
+        };
+        let ledger = IdempotencyLedger::open(&db_path).await.expect("ledger");
+        assert_eq!(
+            ledger
+                .claim(&scope, &key, "hash-a", unix_millis())
+                .await
+                .expect("claim"),
+            IdempotencyClaim::Execute
+        );
+        drop(ledger);
+        let ledger = IdempotencyLedger::open(&db_path).await.expect("reopen");
+        assert_eq!(
+            ledger
+                .claim(&scope, &key, "hash-a", unix_millis())
+                .await
+                .expect("unknown"),
+            IdempotencyClaim::OutcomeUnknown
+        );
+        assert_eq!(
+            ledger
+                .claim(&scope, &key, "hash-b", unix_millis())
+                .await
+                .expect("conflict"),
+            IdempotencyClaim::Conflict
+        );
+
+        let completed_key = Uuid::now_v7().to_string();
+        assert_eq!(
+            ledger
+                .claim(&scope, &completed_key, "hash-c", unix_millis())
+                .await
+                .expect("claim"),
+            IdempotencyClaim::Execute
+        );
+        ledger
+            .complete(
+                &scope,
+                &completed_key,
+                &json!({"id": "post-1"}),
+                unix_millis(),
+            )
+            .await
+            .expect("complete");
+        assert_eq!(
+            ledger
+                .claim(&scope, &completed_key, "hash-c", unix_millis())
+                .await
+                .expect("replay"),
+            IdempotencyClaim::Replay(json!({"id": "post-1"}))
+        );
+    }
+
+    #[tokio::test]
+    async fn secret_bytes_are_keyed_and_never_persisted() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let db_path = root.path().join("kukuri.db");
+        let ledger = IdempotencyLedger::open(&db_path).await.expect("ledger");
+        let sentinel = b"do-not-persist-this-secret";
+        let digest = ledger.digest_payload(b"{}", Some(sentinel));
+        assert!(!digest.contains(std::str::from_utf8(sentinel).expect("utf8")));
+        drop(ledger);
+        let bytes = std::fs::read(idempotency_ledger_path(&db_path)).expect("ledger bytes");
+        assert!(
+            !bytes
+                .windows(sentinel.len())
+                .any(|window| window == sentinel)
+        );
+    }
+
+    #[tokio::test]
+    async fn missing_key_from_before_restore_is_never_executed() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let db_path = root.path().join("kukuri.db");
+        let key = Uuid::now_v7().to_string();
+        let ledger = IdempotencyLedger::open(&db_path).await.expect("ledger");
+        ledger
+            .mark_restored(unix_millis().saturating_add(1))
+            .await
+            .expect("restore marker");
+        let scope = IdempotencyScope {
+            profile: "test",
+            account: "account-a",
+            command: "fixture.write",
+        };
+        assert_eq!(
+            ledger
+                .claim(&scope, &key, "hash", unix_millis().saturating_add(2))
+                .await
+                .expect("claim"),
+            IdempotencyClaim::OutcomeUnknown
+        );
+    }
+
+    #[tokio::test]
+    async fn missing_key_older_than_retention_is_expired() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let db_path = root.path().join("kukuri.db");
+        let now_ms = unix_millis();
+        let old_ms = now_ms - RETENTION_MS - 1;
+        let timestamp = uuid::Timestamp::from_unix(
+            uuid::NoContext,
+            (old_ms / 1000) as u64,
+            ((old_ms % 1000) * 1_000_000) as u32,
+        );
+        let key = Uuid::new_v7(timestamp).to_string();
+        let ledger = IdempotencyLedger::open(&db_path).await.expect("ledger");
+        let scope = IdempotencyScope {
+            profile: "test",
+            account: "account-a",
+            command: "fixture.write",
+        };
+        assert_eq!(
+            ledger
+                .claim(&scope, &key, "hash", now_ms)
+                .await
+                .expect("claim"),
+            IdempotencyClaim::Expired
+        );
+    }
+
+    #[tokio::test]
+    async fn future_key_cannot_bypass_restore_marker() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let db_path = root.path().join("kukuri.db");
+        let now_ms = unix_millis();
+        let future_ms = now_ms + MAX_CLOCK_SKEW_MS + 1;
+        let timestamp = uuid::Timestamp::from_unix(
+            uuid::NoContext,
+            (future_ms / 1000) as u64,
+            ((future_ms % 1000) * 1_000_000) as u32,
+        );
+        let key = Uuid::new_v7(timestamp).to_string();
+        let ledger = IdempotencyLedger::open(&db_path).await.expect("ledger");
+        ledger.mark_restored(now_ms).await.expect("restore marker");
+        let scope = IdempotencyScope {
+            profile: "test",
+            account: "account-a",
+            command: "fixture.write",
+        };
+        let error = ledger
+            .claim(&scope, &key, "hash", now_ms)
+            .await
+            .expect_err("future key");
+        assert!(error.to_string().contains("future"));
+    }
+
+    #[tokio::test]
+    async fn concurrent_same_key_has_one_executor() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let db_path = root.path().join("kukuri.db");
+        let ledger = IdempotencyLedger::open(&db_path).await.expect("ledger");
+        let scope = IdempotencyScope {
+            profile: "test",
+            account: "account-a",
+            command: "fixture.write",
+        };
+        let key = Uuid::now_v7().to_string();
+        let now_ms = unix_millis();
+        let (left, right) = tokio::join!(
+            ledger.claim(&scope, &key, "hash", now_ms),
+            ledger.claim(&scope, &key, "hash", now_ms)
+        );
+        let claims = [left.expect("left claim"), right.expect("right claim")];
+        assert_eq!(
+            claims
+                .iter()
+                .filter(|claim| **claim == IdempotencyClaim::Execute)
+                .count(),
+            1
+        );
+        assert_eq!(
+            claims
+                .iter()
+                .filter(|claim| **claim == IdempotencyClaim::OutcomeUnknown)
+                .count(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn unresolved_capacity_limit_fails_closed() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let db_path = root.path().join("kukuri.db");
+        let ledger = IdempotencyLedger::open(&db_path).await.expect("ledger");
+        let now_ms = unix_millis();
+        let mut transaction = ledger.pool.begin().await.expect("transaction");
+        for index in 0..MAX_SCOPE_RECORDS {
+            sqlx::query(
+                "INSERT INTO records (
+                    profile, account, command, idempotency_key, payload_hash, state,
+                    result_json, created_at_ms, updated_at_ms
+                 ) VALUES ('test', 'account-a', 'fixture.write', ?, 'hash', 'unknown', NULL, ?, ?)",
+            )
+            .bind(format!("fixture-{index}"))
+            .bind(now_ms)
+            .bind(now_ms)
+            .execute(&mut *transaction)
+            .await
+            .expect("fixture record");
+        }
+        transaction.commit().await.expect("commit fixtures");
+        let scope = IdempotencyScope {
+            profile: "test",
+            account: "account-a",
+            command: "fixture.write",
+        };
+        let error = ledger
+            .claim(&scope, &Uuid::now_v7().to_string(), "hash", now_ms)
+            .await
+            .expect_err("capacity must fail closed");
+        assert!(error.to_string().contains("capacity is exhausted"));
+    }
+
+    #[tokio::test]
+    async fn completed_records_are_trimmed_at_capacity() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let db_path = root.path().join("kukuri.db");
+        let ledger = IdempotencyLedger::open(&db_path).await.expect("ledger");
+        let now_ms = unix_millis();
+        let mut oldest_key = String::new();
+        let mut transaction = ledger.pool.begin().await.expect("transaction");
+        for index in 0..(MAX_SCOPE_RECORDS - 1) {
+            let key_ms = now_ms - MAX_SCOPE_RECORDS + index;
+            let timestamp = uuid::Timestamp::from_unix(
+                uuid::NoContext,
+                (key_ms / 1000) as u64,
+                ((key_ms % 1000) * 1_000_000) as u32,
+            );
+            let key = Uuid::new_v7(timestamp).to_string();
+            if index == 0 {
+                oldest_key.clone_from(&key);
+            }
+            sqlx::query(
+                "INSERT INTO records (
+                    profile, account, command, idempotency_key, payload_hash, state,
+                    result_json, created_at_ms, updated_at_ms
+                 ) VALUES ('test', 'account-a', 'fixture.write', ?, 'hash', 'completed', '{}', ?, ?)",
+            )
+            .bind(key)
+            .bind(key_ms)
+            .bind(key_ms)
+            .execute(&mut *transaction)
+            .await
+            .expect("fixture record");
+        }
+        sqlx::query(
+            "INSERT INTO records (
+                profile, account, command, idempotency_key, payload_hash, state,
+                result_json, created_at_ms, updated_at_ms
+             ) VALUES ('test', 'account-a', 'fixture.other-write', ?, 'hash', 'completed', '{}', ?, ?)",
+        )
+        .bind(&oldest_key)
+        .bind(now_ms)
+        .bind(now_ms)
+        .execute(&mut *transaction)
+        .await
+        .expect("same-key other-command fixture");
+        transaction.commit().await.expect("commit fixtures");
+        let scope = IdempotencyScope {
+            profile: "test",
+            account: "account-a",
+            command: "fixture.write",
+        };
+        let new_key = Uuid::now_v7().to_string();
+        assert_eq!(
+            ledger
+                .claim(&scope, &new_key, "hash", now_ms)
+                .await
+                .expect("new claim"),
+            IdempotencyClaim::Execute
+        );
+        let count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM records WHERE profile = 'test' AND account = 'account-a'",
+        )
+        .fetch_one(&ledger.pool)
+        .await
+        .expect("record count");
+        assert_eq!(count, MAX_SCOPE_RECORDS);
+        let other_scope = IdempotencyScope {
+            profile: "test",
+            account: "account-a",
+            command: "fixture.other-write",
+        };
+        assert_eq!(
+            ledger
+                .claim(&other_scope, &oldest_key, "hash", now_ms)
+                .await
+                .expect("same-key other-command replay"),
+            IdempotencyClaim::Replay(json!({}))
+        );
+        assert_eq!(
+            ledger
+                .claim(&scope, &oldest_key, "hash", now_ms)
+                .await
+                .expect("trimmed claim"),
+            IdempotencyClaim::Expired
+        );
+    }
+
+    #[tokio::test]
+    async fn corrupted_ledger_is_rejected() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let db_path = root.path().join("kukuri.db");
+        std::fs::write(idempotency_ledger_path(&db_path), b"not sqlite")
+            .expect("corrupt ledger fixture");
+        assert!(IdempotencyLedger::open(&db_path).await.is_err());
+    }
+}

--- a/crates/desktop-runtime/src/host/mod.rs
+++ b/crates/desktop-runtime/src/host/mod.rs
@@ -1,4 +1,5 @@
 mod consent;
+mod idempotency;
 mod profile;
 mod subscriptions;
 
@@ -25,6 +26,10 @@ pub use consent::{
     app_consent_documents_satisfied, app_consent_documents_status, app_consent_path,
     app_consent_satisfied, consent_required_status, current_unix_seconds, load_app_consent_store,
     reset_app_consent_at_path, save_app_consent_store,
+};
+pub use idempotency::{
+    IDEMPOTENCY_LEDGER_FILE_NAME, IdempotencyClaim, IdempotencyLedger, IdempotencyScope,
+    idempotency_ledger_path,
 };
 pub use profile::{
     ClientProfile, ClientProfileKind, ProfileError, ProfileErrorKind, ProfileLease, gui_profile,

--- a/crates/desktop-runtime/src/lib.rs
+++ b/crates/desktop-runtime/src/lib.rs
@@ -58,13 +58,14 @@ pub use host::{
     AppConsentDocumentStatus, AppConsentStore, ClientEventReceiver, ClientHost, ClientHostStart,
     ClientProfile, ClientProfileKind, ClientStartupError, ClientStartupErrorKind,
     ClientStartupErrorView, ClientStartupState, ClientStartupStatus, DesiredSubscription,
-    DesiredSubscriptionScope, LEGAL_BUNDLE_VERSION, ProfileError, ProfileErrorKind, ProfileLease,
+    DesiredSubscriptionScope, IDEMPOTENCY_LEDGER_FILE_NAME, IdempotencyClaim, IdempotencyLedger,
+    IdempotencyScope, LEGAL_BUNDLE_VERSION, ProfileError, ProfileErrorKind, ProfileLease,
     SubscriptionStateError, SubscriptionStateErrorKind, age_attestation_satisfied,
     age_attestation_status, app_consent_documents_satisfied, app_consent_documents_status,
     app_consent_path, app_consent_satisfied, consent_required_status, current_unix_seconds,
     desired_subscriptions_path, distribution_community_node_config, failed_startup_status,
-    gui_profile, load_app_consent_store, reset_app_consent_at_path, resolve_cli_profile,
-    save_app_consent_store,
+    gui_profile, idempotency_ledger_path, load_app_consent_store, reset_app_consent_at_path,
+    resolve_cli_profile, save_app_consent_store,
 };
 // 起動エラーの typed 分類(WP-Q2)。src-tauri は downcast で DatabaseOpen/Migration を判定する。
 pub use kukuri_store::StoreStartupError;

--- a/crates/desktop-runtime/src/tests/device_backup.rs
+++ b/crates/desktop-runtime/src/tests/device_backup.rs
@@ -23,8 +23,8 @@ use crate::community_node::{
     load_community_node_config_from_file, save_community_node_config,
 };
 use crate::host::{
-    DesiredSubscription, DesiredSubscriptionScope, load_desired_subscriptions,
-    save_desired_subscriptions,
+    DesiredSubscription, DesiredSubscriptionScope, IdempotencyClaim, IdempotencyLedger,
+    IdempotencyScope, load_desired_subscriptions, save_desired_subscriptions,
 };
 use crate::identity::{
     IdentityStorageMode, KeyringStore, load_existing_keys, load_optional_secret,
@@ -191,6 +191,39 @@ async fn encrypted_device_backup_restores_one_account_as_one_file() {
     };
     save_desired_subscriptions(&source_db, std::slice::from_ref(&desired_subscription))
         .expect("persist desired subscription fixture");
+    let idempotency_key = uuid::Uuid::now_v7().to_string();
+    let idempotency_scope = IdempotencyScope {
+        profile: "backup-test",
+        account: "source-account",
+        command: "fixture.write",
+    };
+    let idempotency_now = chrono::Utc::now().timestamp_millis();
+    let ledger = IdempotencyLedger::open(&source_db)
+        .await
+        .expect("open idempotency ledger");
+    assert_eq!(
+        ledger
+            .claim(
+                &idempotency_scope,
+                &idempotency_key,
+                "fixture-hash",
+                idempotency_now,
+            )
+            .await
+            .expect("claim fixture key"),
+        IdempotencyClaim::Execute
+    );
+    ledger
+        .complete(
+            &idempotency_scope,
+            &idempotency_key,
+            &serde_json::json!({"id": "fixture-result"}),
+            idempotency_now,
+        )
+        .await
+        .expect("complete fixture key");
+    ledger.close().await;
+    assert!(crate::idempotency_ledger_path(&source_db).is_file());
     for (purpose, key, value) in [
         (
             PRIVATE_CHANNEL_CAPABILITIES_PURPOSE,
@@ -264,6 +297,7 @@ async fn encrypted_device_backup_restores_one_account_as_one_file() {
     .expect("preview device backup");
     assert_eq!(preview.public_key, source_keys.public_key_hex());
     assert!(preview.existing_account_id.is_none());
+    assert!(preview.included.contains(&"idempotency_ledger".to_string()));
     assert!(
         preview
             .requires_reconsent
@@ -282,6 +316,7 @@ async fn encrypted_device_backup_restores_one_account_as_one_file() {
         |_| {},
     )
     .expect("prepare device restore");
+    assert!(crate::idempotency_ledger_path(&prepared.staging_db_path()).is_file());
     assert_eq!(
         fs::read(
             prepared
@@ -321,6 +356,21 @@ async fn encrypted_device_backup_restores_one_account_as_one_file() {
     assert_eq!(
         load_desired_subscriptions(&restored_db).expect("load restored desired subscriptions"),
         vec![desired_subscription]
+    );
+    let restored_ledger = IdempotencyLedger::open(&restored_db)
+        .await
+        .expect("open restored idempotency ledger");
+    assert_eq!(
+        restored_ledger
+            .claim(
+                &idempotency_scope,
+                &idempotency_key,
+                "fixture-hash",
+                chrono::Utc::now().timestamp_millis(),
+            )
+            .await
+            .expect("replay restored fixture key"),
+        IdempotencyClaim::Replay(serde_json::json!({"id": "fixture-result"}))
     );
     let snapshot = list_accounts(target.path()).expect("list restored accounts");
     assert_eq!(snapshot.active_account_id, result.account.id);

--- a/crates/desktop-runtime/src/tests/device_backup/recovery.rs
+++ b/crates/desktop-runtime/src/tests/device_backup/recovery.rs
@@ -472,6 +472,10 @@ async fn validation_only_checks_all_restored_inputs_without_creating_runtime_art
         .await
         .expect("validate restored inputs without runtime");
     assert!(!iroh_root.exists());
+    assert!(
+        crate::idempotency_ledger_path(&staging_db).is_file(),
+        "validation creates a restore marker even when the backup had no ledger"
+    );
 
     let identity_path = staging_db.with_extension("identity-key");
     let identity_bytes = fs::read(&identity_path).expect("read staged identity");

--- a/crates/kukuri-cli/Cargo.toml
+++ b/crates/kukuri-cli/Cargo.toml
@@ -6,13 +6,16 @@ license.workspace = true
 
 [dependencies]
 anyhow.workspace = true
+async-trait.workspace = true
+blake3.workspace = true
 clap.workspace = true
 kukuri-desktop-runtime = { path = "../desktop-runtime" }
 serde.workspace = true
 serde_json.workspace = true
+tokio.workspace = true
+uuid.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
-blake3.workspace = true
 libc.workspace = true
 tokio = { workspace = true, features = ["io-util", "net", "process", "signal"] }
 

--- a/crates/kukuri-cli/src/client.rs
+++ b/crates/kukuri-cli/src/client.rs
@@ -1,0 +1,190 @@
+use std::os::unix::ffi::OsStrExt;
+use std::{ffi::OsStr, path::PathBuf, time::Duration};
+
+use kukuri_desktop_runtime::ClientProfile;
+use tokio::{
+    io::{AsyncWriteExt, BufReader, ReadHalf, WriteHalf},
+    net::UnixStream,
+};
+
+use crate::{
+    framing::{read_json_frame, read_secret_frame, write_json_frame, write_secret_frame},
+    protocol::{
+        ProtocolError, RequestEnvelope, ResponseEnvelope, SCHEMA_VERSION, SecretInput,
+        SecretOutput, error_code,
+    },
+};
+
+pub struct ClientSession {
+    reader: BufReader<ReadHalf<UnixStream>>,
+    _writer: WriteHalf<UnixStream>,
+    request_id: String,
+    command: String,
+    profile: String,
+    accepts_secret_output: bool,
+}
+
+impl ClientSession {
+    pub async fn connect(
+        profile: &ClientProfile,
+        request: &RequestEnvelope,
+        secret: Option<&SecretInput>,
+    ) -> Result<Self, ProtocolError> {
+        let socket_path = daemon_socket_path(profile)?;
+        let timeout = Duration::from_millis(request.timeout_ms()?);
+        let deadline = tokio::time::Instant::now() + timeout;
+        let stream = tokio::time::timeout(timeout, UnixStream::connect(&socket_path))
+            .await
+            .map_err(|_| ProtocolError::new(error_code::TIMEOUT, "daemon connection timed out"))?
+            .map_err(|_| {
+                ProtocolError::new(error_code::DAEMON_UNAVAILABLE, "daemon is unavailable")
+            })?;
+        let (read, mut write) = tokio::io::split(stream);
+        let mut reader = BufReader::new(read);
+        tokio::time::timeout_at(deadline, write_json_frame(&mut write, request))
+            .await
+            .map_err(|_| ProtocolError::new(error_code::TIMEOUT, "request output timed out"))??;
+        if let Some(secret) = secret {
+            let bytes = tokio::time::timeout_at(deadline, read_json_frame(&mut reader))
+                .await
+                .map_err(|_| {
+                    ProtocolError::new(error_code::TIMEOUT, "secret preflight timed out")
+                })??
+                .ok_or_else(|| {
+                    ProtocolError::new(
+                        error_code::NETWORK_UNAVAILABLE,
+                        "daemon closed during secret preflight",
+                    )
+                })?;
+            let response: ResponseEnvelope = serde_json::from_slice(&bytes).map_err(|_| {
+                ProtocolError::new(error_code::INVALID_REQUEST, "daemon returned invalid JSON")
+            })?;
+            validate_response(request, &response)?;
+            if !response.ok {
+                return Err(response_error(response));
+            }
+            if !response.more
+                || response
+                    .data
+                    .as_ref()
+                    .and_then(|data| data.get("ready_for_secret"))
+                    != Some(&serde_json::Value::Bool(true))
+            {
+                return Err(ProtocolError::new(
+                    error_code::PROTOCOL_MISMATCH,
+                    "daemon did not authorize the secret frame",
+                ));
+            }
+            tokio::time::timeout_at(deadline, write_secret_frame(&mut write, secret.expose()))
+                .await
+                .map_err(|_| ProtocolError::new(error_code::TIMEOUT, "secret input timed out"))??;
+        }
+        tokio::time::timeout_at(deadline, async {
+            write.shutdown().await.map_err(|_| {
+                ProtocolError::new(error_code::NETWORK_UNAVAILABLE, "failed to finish request")
+            })
+        })
+        .await
+        .map_err(|_| ProtocolError::new(error_code::TIMEOUT, "request output timed out"))??;
+        Ok(Self {
+            reader,
+            _writer: write,
+            request_id: request.request_id.clone(),
+            command: request.command.clone(),
+            profile: request.profile.clone(),
+            accepts_secret_output: request.accepts_secret_output,
+        })
+    }
+
+    pub async fn next(
+        &mut self,
+    ) -> Result<Option<(ResponseEnvelope, Option<SecretOutput>)>, ProtocolError> {
+        let Some(bytes) = read_json_frame(&mut self.reader).await? else {
+            return Ok(None);
+        };
+        let response: ResponseEnvelope = serde_json::from_slice(&bytes).map_err(|_| {
+            ProtocolError::new(error_code::INVALID_REQUEST, "daemon returned invalid JSON")
+        })?;
+        validate_response_parts(&self.request_id, &self.command, &self.profile, &response)?;
+        if response.secret_bytes.is_some() && !self.accepts_secret_output {
+            return Err(ProtocolError::new(
+                error_code::PROTOCOL_MISMATCH,
+                "daemon returned an undeclared secret frame",
+            ));
+        }
+        let secret = match response.secret_bytes {
+            Some(length) => Some(SecretOutput::new(
+                read_secret_frame(&mut self.reader, length).await?,
+            )),
+            None => None,
+        };
+        Ok(Some((response, secret)))
+    }
+}
+
+fn validate_response(
+    request: &RequestEnvelope,
+    response: &ResponseEnvelope,
+) -> Result<(), ProtocolError> {
+    validate_response_parts(
+        &request.request_id,
+        &request.command,
+        &request.profile,
+        response,
+    )
+}
+
+fn validate_response_parts(
+    request_id: &str,
+    command: &str,
+    profile: &str,
+    response: &ResponseEnvelope,
+) -> Result<(), ProtocolError> {
+    if response.schema_version != SCHEMA_VERSION
+        || response.request_id != request_id
+        || response.command != command
+        || response.profile != profile
+    {
+        return Err(ProtocolError::new(
+            error_code::PROTOCOL_MISMATCH,
+            "daemon response does not match the request",
+        ));
+    }
+    Ok(())
+}
+
+fn response_error(response: ResponseEnvelope) -> ProtocolError {
+    match response.error {
+        Some(error) => ProtocolError {
+            code: error.code,
+            message: error.message,
+            details: error.details,
+        },
+        None => ProtocolError::new(error_code::INTERNAL_ERROR, "daemon returned an empty error"),
+    }
+}
+
+pub fn daemon_socket_path(profile: &ClientProfile) -> Result<PathBuf, ProtocolError> {
+    let runtime_root = std::env::var_os("XDG_RUNTIME_DIR")
+        .map(PathBuf::from)
+        .ok_or_else(|| {
+            ProtocolError::new(
+                error_code::DAEMON_UNAVAILABLE,
+                "XDG_RUNTIME_DIR is required for the daemon socket",
+            )
+        })?;
+    let profile_path = std::fs::canonicalize(&profile.app_data_dir).map_err(|_| {
+        ProtocolError::new(
+            error_code::DAEMON_UNAVAILABLE,
+            "profile directory is unavailable",
+        )
+    })?;
+    let digest = blake3::hash(os_str_bytes(profile_path.as_os_str())).to_hex();
+    Ok(runtime_root
+        .join("kukuri")
+        .join(format!("profile-{}.sock", &digest[..32])))
+}
+
+fn os_str_bytes(value: &OsStr) -> &[u8] {
+    value.as_bytes()
+}

--- a/crates/kukuri-cli/src/daemon.rs
+++ b/crates/kukuri-cli/src/daemon.rs
@@ -56,6 +56,11 @@ async fn run_foreground(profile: ClientProfile) -> Result<(), CliError> {
         ClientHostStart::Ready(host) => Some(host),
         ClientHostStart::ConsentRequired(_) => None,
     };
+    // readinessを通知する前にsignal handlerを登録し、直後の停止要求を取りこぼさない。
+    let interrupt = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::interrupt())
+        .map_err(|error| CliError::new("signal_setup_failed", error.to_string(), 1))?;
+    let terminate = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+        .map_err(|error| CliError::new("signal_setup_failed", error.to_string(), 1))?;
     eprintln!(
         "{}",
         if host.is_some() {
@@ -70,6 +75,8 @@ async fn run_foreground(profile: ClientProfile) -> Result<(), CliError> {
         lease.profile().name.clone(),
         host.clone(),
         Arc::new(Dispatcher::builtin()),
+        interrupt,
+        terminate,
     )
     .await?;
     if let Some(host) = host {
@@ -84,26 +91,17 @@ async fn wait_for_shutdown(
     profile: String,
     host: Option<Arc<ClientHost>>,
     dispatcher: Arc<Dispatcher>,
+    mut interrupt: tokio::signal::unix::Signal,
+    mut terminate: tokio::signal::unix::Signal,
 ) -> Result<(), CliError> {
-    let terminate = async {
-        let mut terminate =
-            tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
-                .map_err(|error| CliError::new("signal_setup_failed", error.to_string(), 1))?;
-        terminate.recv().await;
-        Ok::<(), CliError>(())
-    };
-    tokio::pin!(terminate);
-
     let mut connections = JoinSet::new();
     let connection_permits = Arc::new(Semaphore::new(MAX_CONNECTIONS));
     loop {
         tokio::select! {
-            result = tokio::signal::ctrl_c() => {
-                result.map_err(|error| CliError::new("signal_wait_failed", error.to_string(), 1))?;
+            _ = interrupt.recv() => {
                 break;
             }
-            result = &mut terminate => {
-                result?;
+            _ = terminate.recv() => {
                 break;
             },
             result = listener.accept() => {

--- a/crates/kukuri-cli/src/daemon.rs
+++ b/crates/kukuri-cli/src/daemon.rs
@@ -1,16 +1,29 @@
 use std::{
     path::{Path, PathBuf},
     process::Stdio,
+    sync::Arc,
+    time::Duration,
 };
 
+use kukuri_cli::{
+    client::daemon_socket_path,
+    dispatcher::{DispatchReply, Dispatcher, decode_request},
+    framing::{read_json_frame, read_secret_frame, write_json_frame, write_secret_frame},
+    protocol::{DEFAULT_TIMEOUT_MS, ProtocolError, ResponseEnvelope, SecretInput, error_code},
+};
 use kukuri_desktop_runtime::{ClientHost, ClientHostStart, ClientProfile, ProfileLease};
 use tokio::{
-    io::AsyncReadExt,
+    io::BufReader,
     net::{UnixListener, UnixStream},
     process::Command,
+    sync::Semaphore,
+    task::JoinSet,
+    time::Instant,
 };
 
 use crate::{CliError, DaemonCommand};
+
+const MAX_CONNECTIONS: usize = 64;
 
 pub(crate) async fn run(profile: ClientProfile, command: DaemonCommand) -> Result<(), CliError> {
     match command {
@@ -22,8 +35,17 @@ pub(crate) async fn run(profile: ClientProfile, command: DaemonCommand) -> Resul
 }
 
 async fn run_foreground(profile: ClientProfile) -> Result<(), CliError> {
+    std::panic::set_hook(Box::new(|_| eprintln!("daemon task panicked")));
     let lease = ProfileLease::acquire(profile).map_err(CliError::from_profile)?;
-    let socket_path = daemon_socket_path(&lease)?;
+    let socket_path = daemon_socket_path(lease.profile()).map_err(CliError::from_protocol)?;
+    let runtime_directory = socket_path.parent().ok_or_else(|| {
+        CliError::new(
+            "runtime_dir_unavailable",
+            "daemon socket has no runtime directory",
+            1,
+        )
+    })?;
+    ensure_private_runtime_directory(runtime_directory)?;
     let listener = bind_listener(&socket_path)?;
     let _socket_cleanup = SocketCleanup(socket_path);
 
@@ -34,7 +56,7 @@ async fn run_foreground(profile: ClientProfile) -> Result<(), CliError> {
         ClientHostStart::Ready(host) => Some(host),
         ClientHostStart::ConsentRequired(_) => None,
     };
-    println!(
+    eprintln!(
         "{}",
         if host.is_some() {
             "ready"
@@ -43,7 +65,13 @@ async fn run_foreground(profile: ClientProfile) -> Result<(), CliError> {
         }
     );
 
-    wait_for_shutdown(&listener).await?;
+    wait_for_shutdown(
+        listener,
+        lease.profile().name.clone(),
+        host.clone(),
+        Arc::new(Dispatcher::builtin()),
+    )
+    .await?;
     if let Some(host) = host {
         host.shutdown().await;
     }
@@ -51,7 +79,12 @@ async fn run_foreground(profile: ClientProfile) -> Result<(), CliError> {
     Ok(())
 }
 
-async fn wait_for_shutdown(listener: &UnixListener) -> Result<(), CliError> {
+async fn wait_for_shutdown(
+    listener: UnixListener,
+    profile: String,
+    host: Option<Arc<ClientHost>>,
+    dispatcher: Arc<Dispatcher>,
+) -> Result<(), CliError> {
     let terminate = async {
         let mut terminate =
             tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
@@ -61,64 +94,273 @@ async fn wait_for_shutdown(listener: &UnixListener) -> Result<(), CliError> {
     };
     tokio::pin!(terminate);
 
+    let mut connections = JoinSet::new();
+    let connection_permits = Arc::new(Semaphore::new(MAX_CONNECTIONS));
     loop {
         tokio::select! {
             result = tokio::signal::ctrl_c() => {
                 result.map_err(|error| CliError::new("signal_wait_failed", error.to_string(), 1))?;
-                return Ok(());
+                break;
             }
-            result = &mut terminate => return result,
+            result = &mut terminate => {
+                result?;
+                break;
+            },
             result = listener.accept() => {
                 let (stream, _) = result.map_err(|error| {
                     CliError::new("socket_accept_failed", error.to_string(), 1)
                 })?;
                 match authorize_peer(&stream) {
                     Ok(()) => {
-                        tokio::spawn(drain_connection(stream));
+                        let Ok(permit) = connection_permits.clone().try_acquire_owned() else {
+                            reject_over_capacity(stream, &profile).await;
+                            continue;
+                        };
+                        let dispatcher = dispatcher.clone();
+                        let host = host.clone();
+                        let profile = profile.clone();
+                        connections.spawn(async move {
+                            let _permit = permit;
+                            handle_connection(stream, dispatcher, profile, host).await
+                        });
                     }
                     Err(error) => eprintln!("{}: {}", error.code, error.message),
                 }
             }
+            Some(result) = connections.join_next(), if !connections.is_empty() => {
+                if let Ok(Err(error)) = result {
+                    eprintln!("{}: {}", error.code, error.message);
+                }
+            }
         }
     }
-}
-
-async fn drain_connection(mut stream: UnixStream) {
-    let mut buffer = [0_u8; 1024];
-    loop {
-        match stream.read(&mut buffer).await {
-            Ok(0) | Err(_) => return,
-            Ok(_) => {}
-        }
+    drop(listener);
+    let drain = async { while connections.join_next().await.is_some() {} };
+    if tokio::time::timeout(Duration::from_secs(5), drain)
+        .await
+        .is_err()
+    {
+        connections.abort_all();
+        while connections.join_next().await.is_some() {}
     }
+    Ok(())
 }
 
-fn daemon_socket_path(lease: &ProfileLease) -> Result<PathBuf, CliError> {
-    use std::os::unix::ffi::OsStrExt;
+async fn reject_over_capacity(stream: UnixStream, profile: &str) {
+    let (read, mut write) = tokio::io::split(stream);
+    let mut reader = BufReader::new(read);
+    let request = tokio::time::timeout(Duration::from_millis(100), read_json_frame(&mut reader))
+        .await
+        .ok()
+        .and_then(Result::ok)
+        .flatten()
+        .and_then(|bytes| decode_request(&bytes).ok());
+    let error = ProtocolError::new(error_code::BACKPRESSURE, "daemon connection limit reached");
+    let response = match request {
+        Some(request) => ResponseEnvelope::failure(&request, error),
+        None => ResponseEnvelope::failure_parts("", "", profile, error),
+    };
+    let _ = tokio::time::timeout(
+        Duration::from_millis(100),
+        write_json_frame(&mut write, &response),
+    )
+    .await;
+}
 
-    let runtime_root = std::env::var_os("XDG_RUNTIME_DIR")
-        .map(PathBuf::from)
-        .ok_or_else(|| {
-            CliError::new(
-                "runtime_dir_unavailable",
-                "XDG_RUNTIME_DIR is required for the daemon socket",
-                1,
+async fn handle_connection(
+    stream: UnixStream,
+    dispatcher: Arc<Dispatcher>,
+    profile: String,
+    host: Option<Arc<ClientHost>>,
+) -> Result<(), ProtocolError> {
+    let (read, mut write) = tokio::io::split(stream);
+    let mut reader = BufReader::new(read);
+    let bytes = match tokio::time::timeout(
+        Duration::from_millis(DEFAULT_TIMEOUT_MS),
+        read_json_frame(&mut reader),
+    )
+    .await
+    {
+        Err(_) => {
+            let response = ResponseEnvelope::failure_parts(
+                "",
+                "",
+                &profile,
+                ProtocolError::new(error_code::TIMEOUT, "request frame timed out"),
+            );
+            let _ = tokio::time::timeout(
+                Duration::from_millis(100),
+                write_json_frame(&mut write, &response),
             )
-        })?;
-    let directory = runtime_root.join("kukuri");
-    ensure_private_runtime_directory(&directory)?;
-    let profile_path = std::fs::canonicalize(&lease.profile().app_data_dir).map_err(|error| {
-        CliError::new(
-            "profile_path_unavailable",
-            format!(
-                "failed to resolve profile directory `{}`: {error}",
-                lease.profile().app_data_dir.display()
+            .await;
+            return Ok(());
+        }
+        Ok(result) => match result {
+            Ok(Some(bytes)) => bytes,
+            Ok(None) => return Ok(()),
+            Err(error) => {
+                let response = ResponseEnvelope::failure_parts("", "", &profile, error);
+                write_json_frame(&mut write, &response).await?;
+                return Ok(());
+            }
+        },
+    };
+    let request = match decode_request(&bytes) {
+        Ok(request) => request,
+        Err(error) => {
+            let response = ResponseEnvelope::failure_parts("", "", &profile, error);
+            write_json_frame(&mut write, &response).await?;
+            return Ok(());
+        }
+    };
+    let timeout_ms = match request.timeout_ms() {
+        Ok(timeout) => timeout,
+        Err(error) => {
+            let response = ResponseEnvelope::failure(&request, error);
+            write_json_frame(&mut write, &response).await?;
+            return Ok(());
+        }
+    };
+    let deadline = Instant::now() + Duration::from_millis(timeout_ms);
+    if let Err(error) = dispatcher
+        .preflight(&request, &profile, host.as_ref())
+        .await
+    {
+        let response = ResponseEnvelope::failure(&request, error);
+        write_json_before(deadline, &mut write, &response).await?;
+        return Ok(());
+    }
+    let secret = match request.secret_bytes {
+        Some(length) => {
+            let mut ready =
+                ResponseEnvelope::success(&request, serde_json::json!({"ready_for_secret": true}));
+            ready.more = true;
+            write_json_before(deadline, &mut write, &ready).await?;
+            let bytes =
+                match tokio::time::timeout_at(deadline, read_secret_frame(&mut reader, length))
+                    .await
+                {
+                    Ok(Ok(bytes)) => bytes,
+                    Ok(Err(error)) => {
+                        let response = ResponseEnvelope::failure(&request, error);
+                        let _ = tokio::time::timeout(
+                            Duration::from_millis(100),
+                            write_json_frame(&mut write, &response),
+                        )
+                        .await;
+                        return Ok(());
+                    }
+                    Err(_) => {
+                        let response = ResponseEnvelope::failure(
+                            &request,
+                            ProtocolError::new(error_code::TIMEOUT, "secret input timed out"),
+                        );
+                        let _ = tokio::time::timeout(
+                            Duration::from_millis(100),
+                            write_json_frame(&mut write, &response),
+                        )
+                        .await;
+                        return Ok(());
+                    }
+                };
+            Some(SecretInput::new(bytes))
+        }
+        None => None,
+    };
+    let reply = match tokio::time::timeout_at(
+        deadline,
+        dispatcher.dispatch(request.clone(), secret, &profile, host.as_ref()),
+    )
+    .await
+    {
+        Ok(reply) => reply,
+        Err(_) => DispatchReply::Unary(
+            ResponseEnvelope::failure(
+                &request,
+                ProtocolError::new(error_code::TIMEOUT, "command timed out"),
             ),
-            1,
-        )
-    })?;
-    let digest = blake3::hash(profile_path.as_os_str().as_bytes()).to_hex();
-    Ok(directory.join(format!("profile-{}.sock", &digest[..32])))
+            None,
+        ),
+    };
+    match reply {
+        DispatchReply::Unary(response, secret) => {
+            write_json_before(deadline, &mut write, &response).await?;
+            if let Some(secret) = secret {
+                tokio::time::timeout_at(deadline, write_secret_frame(&mut write, secret.expose()))
+                    .await
+                    .map_err(|_| {
+                        ProtocolError::new(error_code::TIMEOUT, "secret output timed out")
+                    })??;
+            }
+        }
+        DispatchReply::Events {
+            request,
+            mut receiver,
+        } => {
+            let mut started =
+                ResponseEnvelope::success(&request, serde_json::json!({"subscribed": true}));
+            started.more = true;
+            write_json_before(deadline, &mut write, &started).await?;
+            loop {
+                let received = tokio::time::timeout_at(deadline, receiver.recv()).await;
+                match received {
+                    Err(_) => {
+                        let response = ResponseEnvelope::failure(
+                            &request,
+                            ProtocolError::new(error_code::TIMEOUT, "command timed out"),
+                        );
+                        let _ = tokio::time::timeout(
+                            Duration::from_millis(100),
+                            write_json_frame(&mut write, &response),
+                        )
+                        .await;
+                        break;
+                    }
+                    Ok(Ok(event)) => {
+                        let data = serde_json::to_value(event).map_err(|_| {
+                            ProtocolError::new(
+                                error_code::INTERNAL_ERROR,
+                                "failed to encode runtime event",
+                            )
+                        })?;
+                        let mut response = ResponseEnvelope::success(&request, data);
+                        response.more = true;
+                        write_json_before(deadline, &mut write, &response).await?;
+                    }
+                    Ok(Err(error)) => {
+                        if let Some(response) = stream_receive_failure(&request, error) {
+                            write_json_before(deadline, &mut write, &response).await?;
+                        }
+                        break;
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn stream_receive_failure(
+    request: &kukuri_cli::protocol::RequestEnvelope,
+    error: tokio::sync::broadcast::error::RecvError,
+) -> Option<ResponseEnvelope> {
+    match error {
+        tokio::sync::broadcast::error::RecvError::Lagged(_) => Some(ResponseEnvelope::failure(
+            request,
+            ProtocolError::new(error_code::BACKPRESSURE, "event consumer fell behind"),
+        )),
+        tokio::sync::broadcast::error::RecvError::Closed => None,
+    }
+}
+
+async fn write_json_before<W: tokio::io::AsyncWrite + Unpin, T: serde::Serialize>(
+    deadline: Instant,
+    writer: &mut W,
+    value: &T,
+) -> Result<(), ProtocolError> {
+    tokio::time::timeout_at(deadline, write_json_frame(writer, value))
+        .await
+        .map_err(|_| ProtocolError::new(error_code::TIMEOUT, "response output timed out"))?
 }
 
 fn ensure_private_runtime_directory(path: &Path) -> Result<(), CliError> {
@@ -249,7 +491,18 @@ impl Drop for SocketCleanup {
 mod tests {
     use std::os::unix::fs::PermissionsExt;
 
+    use async_trait::async_trait;
+    use kukuri_cli::{
+        protocol::{
+            CommandEffect, CommandMetadata, PROTOCOL_VERSION, RequestEnvelope, SecretOutput,
+        },
+        registry::{
+            CommandHandler, CommandOutput, CommandRegistration, CommandRegistry, HandlerContext,
+        },
+    };
     use kukuri_desktop_runtime::{ClientProfileKind, resolve_cli_profile};
+    use serde_json::{Value, json};
+    use tokio::io::{AsyncWriteExt, BufReader};
 
     use super::*;
 
@@ -291,5 +544,148 @@ mod tests {
             resolve_cli_profile(Some("alpha"), None, None, Some(Path::new("/data")), None)
                 .expect("profile");
         assert_eq!(profile.kind, ClientProfileKind::Cli);
+    }
+
+    #[tokio::test]
+    async fn lagged_event_queue_maps_to_typed_backpressure() {
+        let (sender, mut receiver) = tokio::sync::broadcast::channel(1);
+        sender.send(1).expect("first event");
+        sender.send(2).expect("second event");
+        let error = receiver.recv().await.expect_err("receiver lagged");
+        let request = kukuri_cli::protocol::RequestEnvelope {
+            protocol_version: kukuri_cli::protocol::PROTOCOL_VERSION,
+            request_id: "req-1".to_string(),
+            command: "events.watch".to_string(),
+            profile: "test".to_string(),
+            payload: serde_json::json!({}),
+            idempotency_key: None,
+            timeout_ms: None,
+            secret_bytes: None,
+            accepts_secret_output: false,
+        };
+        let response = stream_receive_failure(&request, error).expect("terminal response");
+        assert_eq!(response.error_code(), Some(error_code::BACKPRESSURE));
+    }
+
+    struct SecretRoundtripHandler;
+
+    #[async_trait]
+    impl CommandHandler for SecretRoundtripHandler {
+        async fn execute(
+            &self,
+            _context: HandlerContext<'_>,
+            _payload: Value,
+            secret: Option<&SecretInput>,
+        ) -> Result<CommandOutput, ProtocolError> {
+            Ok(CommandOutput::Secret {
+                data: json!({"accepted": true}),
+                secret: SecretOutput::new(secret.expect("secret input").expose().to_vec()),
+            })
+        }
+    }
+
+    fn secret_dispatcher() -> Arc<Dispatcher> {
+        let metadata = CommandMetadata {
+            name: "fixture.secret-roundtrip".to_string(),
+            effect: CommandEffect::Read,
+            secret_input: true,
+            secret_output: true,
+            idempotency_required: false,
+            streaming: false,
+            guards: Vec::new(),
+            input_schema: json!({"type": "object", "additionalProperties": false}),
+            output_schema: json!({"type": "object"}),
+        };
+        Arc::new(Dispatcher::new(
+            CommandRegistry::new(vec![CommandRegistration::new(
+                metadata,
+                Arc::new(SecretRoundtripHandler),
+            )])
+            .expect("registry"),
+        ))
+    }
+
+    fn secret_request(length: usize) -> RequestEnvelope {
+        RequestEnvelope {
+            protocol_version: PROTOCOL_VERSION,
+            request_id: "secret-request".to_string(),
+            command: "fixture.secret-roundtrip".to_string(),
+            profile: "test".to_string(),
+            payload: json!({}),
+            idempotency_key: None,
+            timeout_ms: Some(2_000),
+            secret_bytes: Some(length as u64),
+            accepts_secret_output: true,
+        }
+    }
+
+    #[tokio::test]
+    async fn secret_handshake_roundtrips_and_partial_body_returns_typed_error() {
+        let sentinel = b"socket-secret-\"-\\-sentinel";
+        let (client, server) = UnixStream::pair().expect("socket pair");
+        let task = tokio::spawn(handle_connection(
+            server,
+            secret_dispatcher(),
+            "test".to_string(),
+            None,
+        ));
+        let (read, mut write) = tokio::io::split(client);
+        let mut reader = BufReader::new(read);
+        let request = secret_request(sentinel.len());
+        write_json_frame(&mut write, &request)
+            .await
+            .expect("header");
+        let ready = read_json_frame(&mut reader)
+            .await
+            .expect("ready frame")
+            .expect("ready response");
+        let ready: ResponseEnvelope = serde_json::from_slice(&ready).expect("ready JSON");
+        assert!(ready.ok && ready.more);
+        write_secret_frame(&mut write, sentinel)
+            .await
+            .expect("secret body");
+        write.shutdown().await.expect("finish request");
+        let response = read_json_frame(&mut reader)
+            .await
+            .expect("response frame")
+            .expect("response");
+        let response: ResponseEnvelope = serde_json::from_slice(&response).expect("response JSON");
+        assert!(response.ok);
+        let output = read_secret_frame(
+            &mut reader,
+            response.secret_bytes.expect("secret response length"),
+        )
+        .await
+        .expect("secret response");
+        assert_eq!(output, sentinel);
+        task.await.expect("server task").expect("server result");
+
+        let (client, server) = UnixStream::pair().expect("partial socket pair");
+        let task = tokio::spawn(handle_connection(
+            server,
+            secret_dispatcher(),
+            "test".to_string(),
+            None,
+        ));
+        let (read, mut write) = tokio::io::split(client);
+        let mut reader = BufReader::new(read);
+        let request = secret_request(sentinel.len());
+        write_json_frame(&mut write, &request)
+            .await
+            .expect("header");
+        let _ready = read_json_frame(&mut reader)
+            .await
+            .expect("ready frame")
+            .expect("ready response");
+        write.write_all(&sentinel[..3]).await.expect("partial body");
+        write.shutdown().await.expect("finish partial request");
+        let response = read_json_frame(&mut reader)
+            .await
+            .expect("error frame")
+            .expect("error response");
+        let response: ResponseEnvelope = serde_json::from_slice(&response).expect("error JSON");
+        assert_eq!(response.request_id, request.request_id);
+        assert_eq!(response.error_code(), Some(error_code::INVALID_REQUEST));
+        task.await.expect("server task").expect("server result");
     }
 }

--- a/crates/kukuri-cli/src/dispatcher.rs
+++ b/crates/kukuri-cli/src/dispatcher.rs
@@ -1,0 +1,992 @@
+use std::sync::Arc;
+
+mod validation;
+
+use async_trait::async_trait;
+use kukuri_desktop_runtime::{ClientHost, IdempotencyClaim, IdempotencyLedger, IdempotencyScope};
+use serde_json::Value;
+
+use crate::{
+    protocol::{
+        GuardRequirement, PROTOCOL_VERSION, ProtocolError, RequestEnvelope, ResponseEnvelope,
+        SecretInput, error_code,
+    },
+    registry::{CommandOutput, CommandRegistry, HandlerContext},
+};
+use validation::{redact_protocol_error, validate_command_output, validate_payload};
+
+pub enum DispatchReply {
+    Unary(ResponseEnvelope, Option<crate::protocol::SecretOutput>),
+    Events {
+        request: RequestEnvelope,
+        receiver: kukuri_desktop_runtime::ClientEventReceiver,
+    },
+}
+
+pub struct Dispatcher {
+    registry: CommandRegistry,
+    mutation_guard: tokio::sync::Mutex<()>,
+    guard_evaluator: Arc<dyn GuardEvaluator>,
+}
+
+pub struct GuardContext<'a> {
+    pub request: &'a RequestEnvelope,
+    pub host: Option<&'a Arc<ClientHost>>,
+}
+
+#[async_trait]
+pub trait GuardEvaluator: Send + Sync {
+    async fn evaluate(
+        &self,
+        requirement: GuardRequirement,
+        context: &GuardContext<'_>,
+    ) -> Result<(), ProtocolError>;
+}
+
+struct HostGuardEvaluator;
+
+#[async_trait]
+impl GuardEvaluator for HostGuardEvaluator {
+    async fn evaluate(
+        &self,
+        requirement: GuardRequirement,
+        context: &GuardContext<'_>,
+    ) -> Result<(), ProtocolError> {
+        match requirement {
+            GuardRequirement::HostReady if context.host.is_none() => Err(ProtocolError::new(
+                error_code::CONSENT_REQUIRED,
+                "application consent is required",
+            )),
+            GuardRequirement::HostReady => Ok(()),
+            _ => Err(ProtocolError::new(
+                error_code::ACTION_REQUIRED,
+                "the command guard is not available in this protocol version",
+            )),
+        }
+    }
+}
+
+impl Dispatcher {
+    pub fn builtin() -> Self {
+        Self {
+            registry: CommandRegistry::builtin(),
+            mutation_guard: tokio::sync::Mutex::new(()),
+            guard_evaluator: Arc::new(HostGuardEvaluator),
+        }
+    }
+
+    pub fn new(registry: CommandRegistry) -> Self {
+        Self {
+            registry,
+            mutation_guard: tokio::sync::Mutex::new(()),
+            guard_evaluator: Arc::new(HostGuardEvaluator),
+        }
+    }
+
+    pub fn with_guard_evaluator(mut self, evaluator: Arc<dyn GuardEvaluator>) -> Self {
+        self.guard_evaluator = evaluator;
+        self
+    }
+
+    pub fn registry(&self) -> &CommandRegistry {
+        &self.registry
+    }
+
+    pub async fn preflight(
+        &self,
+        request: &RequestEnvelope,
+        expected_profile: &str,
+        host: Option<&Arc<ClientHost>>,
+    ) -> Result<(), ProtocolError> {
+        let registration = self.registration_for(request, expected_profile)?;
+        if registration.metadata.secret_output && !request.accepts_secret_output {
+            return Err(ProtocolError::new(
+                error_code::ACTION_REQUIRED,
+                "secret response requires an explicit output sink",
+            ));
+        }
+        let context = GuardContext { request, host };
+        let secret_bearing =
+            registration.metadata.secret_input || registration.metadata.secret_output;
+        for requirement in &registration.metadata.guards {
+            self.guard_evaluator
+                .evaluate(*requirement, &context)
+                .await
+                .map_err(|error| redact_protocol_error(error, secret_bearing))?;
+        }
+        Ok(())
+    }
+
+    pub async fn dispatch(
+        &self,
+        request: RequestEnvelope,
+        secret: Option<SecretInput>,
+        expected_profile: &str,
+        host: Option<&Arc<ClientHost>>,
+    ) -> DispatchReply {
+        match self
+            .dispatch_inner(&request, secret, expected_profile, host)
+            .await
+        {
+            Ok(CommandOutput::Unary(data)) => {
+                DispatchReply::Unary(ResponseEnvelope::success(&request, data), None)
+            }
+            Ok(CommandOutput::Secret { data, secret }) => {
+                let mut response = ResponseEnvelope::success(&request, data);
+                response.secret_bytes = Some(secret.expose().len() as u64);
+                DispatchReply::Unary(response, Some(secret))
+            }
+            Ok(CommandOutput::Events(receiver)) => DispatchReply::Events { request, receiver },
+            Err(error) => DispatchReply::Unary(ResponseEnvelope::failure(&request, error), None),
+        }
+    }
+
+    async fn dispatch_inner(
+        &self,
+        request: &RequestEnvelope,
+        secret: Option<SecretInput>,
+        expected_profile: &str,
+        host: Option<&Arc<ClientHost>>,
+    ) -> Result<CommandOutput, ProtocolError> {
+        self.preflight(request, expected_profile, host).await?;
+        let registration = self
+            .registry
+            .get(&request.command)
+            .expect("preflight resolved the command");
+        if request.secret_bytes.is_some() != secret.is_some() {
+            return Err(ProtocolError::new(
+                error_code::INVALID_REQUEST,
+                "secret frame is missing or unexpected",
+            ));
+        }
+        if !registration.metadata.idempotency_required {
+            let result = registration
+                .handler
+                .execute(
+                    HandlerContext {
+                        registry: &self.registry,
+                        host,
+                        profile: expected_profile,
+                    },
+                    request.payload.clone(),
+                    secret.as_ref(),
+                )
+                .await
+                .map_err(|error| {
+                    redact_protocol_error(
+                        error,
+                        registration.metadata.secret_input || registration.metadata.secret_output,
+                    )
+                })?;
+            validate_command_output(&registration.metadata, &result, secret.as_ref())?;
+            return Ok(result);
+        }
+
+        let _mutation_guard = self.mutation_guard.lock().await;
+        let host = host.ok_or_else(|| {
+            ProtocolError::new(
+                error_code::INTERNAL_ERROR,
+                "mutating command requires a ready client host",
+            )
+        })?;
+        let runtime = host.runtime();
+        let db_path = runtime.db_path();
+        let account = db_path
+            .parent()
+            .and_then(|path| path.file_name())
+            .and_then(|value| value.to_str())
+            .unwrap_or("active-account")
+            .to_string();
+        let ledger = IdempotencyLedger::open(db_path)
+            .await
+            .map_err(internal_ledger_error)?;
+        let canonical_payload = canonical_json(&request.payload)?;
+        let payload_hash =
+            ledger.digest_payload(&canonical_payload, secret.as_ref().map(SecretInput::expose));
+        let key = request
+            .idempotency_key
+            .as_deref()
+            .expect("idempotency requirement checked above");
+        let scope = IdempotencyScope {
+            profile: expected_profile,
+            account: &account,
+            command: &request.command,
+        };
+        match ledger
+            .claim(&scope, key, &payload_hash, unix_millis())
+            .await
+            .map_err(map_claim_error)?
+        {
+            IdempotencyClaim::Replay(value) => return Ok(CommandOutput::Unary(value)),
+            IdempotencyClaim::Conflict => {
+                return Err(ProtocolError::new(
+                    error_code::IDEMPOTENCY_CONFLICT,
+                    "idempotency key was already used with a different payload",
+                ));
+            }
+            IdempotencyClaim::OutcomeUnknown => {
+                return Err(ProtocolError::new(
+                    error_code::OPERATION_OUTCOME_UNKNOWN,
+                    "the previous operation outcome cannot be determined",
+                ));
+            }
+            IdempotencyClaim::Expired => {
+                return Err(ProtocolError::new(
+                    error_code::IDEMPOTENCY_EXPIRED,
+                    "the idempotency key is outside the retained history",
+                ));
+            }
+            IdempotencyClaim::Execute => {}
+        }
+        let result = registration
+            .handler
+            .execute(
+                HandlerContext {
+                    registry: &self.registry,
+                    host: Some(host),
+                    profile: expected_profile,
+                },
+                request.payload.clone(),
+                secret.as_ref(),
+            )
+            .await
+            .map_err(|error| {
+                redact_protocol_error(
+                    error,
+                    registration.metadata.secret_input || registration.metadata.secret_output,
+                )
+            });
+        if let Ok(output) = &result
+            && let Err(error) =
+                validate_command_output(&registration.metadata, output, secret.as_ref())
+        {
+            ledger
+                .mark_unknown(&scope, key, unix_millis())
+                .await
+                .map_err(internal_ledger_error)?;
+            return Err(error);
+        }
+        match result {
+            Ok(CommandOutput::Unary(data)) => {
+                ledger
+                    .complete(&scope, key, &data, unix_millis())
+                    .await
+                    .map_err(internal_ledger_error)?;
+                Ok(CommandOutput::Unary(data))
+            }
+            Ok(CommandOutput::Secret { .. }) => {
+                unreachable!("registry rejects mutating secret output")
+            }
+            Ok(CommandOutput::Events(_)) => unreachable!("registry rejects streaming mutation"),
+            Err(error) => {
+                ledger
+                    .mark_unknown(&scope, key, unix_millis())
+                    .await
+                    .map_err(internal_ledger_error)?;
+                Err(error)
+            }
+        }
+    }
+
+    fn registration_for<'a>(
+        &'a self,
+        request: &RequestEnvelope,
+        expected_profile: &str,
+    ) -> Result<&'a crate::registry::CommandRegistration, ProtocolError> {
+        if request.protocol_version != PROTOCOL_VERSION {
+            return Err(ProtocolError::new(
+                error_code::PROTOCOL_MISMATCH,
+                format!(
+                    "unsupported protocol version {}; expected {PROTOCOL_VERSION}",
+                    request.protocol_version
+                ),
+            ));
+        }
+        if request.request_id.trim().is_empty() || request.command.trim().is_empty() {
+            return Err(ProtocolError::new(
+                error_code::VALIDATION_FAILED,
+                "request_id and command must not be empty",
+            ));
+        }
+        if request.profile != expected_profile {
+            return Err(ProtocolError::new(
+                error_code::AUTHORIZATION_FAILED,
+                "request profile does not match the daemon profile",
+            ));
+        }
+        if !request.payload.is_object() {
+            return Err(ProtocolError::new(
+                error_code::VALIDATION_FAILED,
+                "payload must be a JSON object",
+            ));
+        }
+        let registration = self
+            .registry
+            .get(&request.command)
+            .ok_or_else(|| ProtocolError::new(error_code::NOT_FOUND, "unknown command"))?;
+        validate_payload(&registration.metadata.input_schema, &request.payload).map_err(
+            |error| {
+                redact_protocol_error(
+                    error,
+                    registration.metadata.secret_input || registration.metadata.secret_output,
+                )
+            },
+        )?;
+        if request.secret_bytes.is_some() != registration.metadata.secret_input {
+            return Err(ProtocolError::new(
+                error_code::VALIDATION_FAILED,
+                "secret input does not match command metadata",
+            ));
+        }
+        if registration.metadata.idempotency_required && request.idempotency_key.is_none() {
+            return Err(ProtocolError::new(
+                error_code::VALIDATION_FAILED,
+                "this command requires an idempotency_key",
+            ));
+        }
+        Ok(registration)
+    }
+}
+
+fn canonical_json(value: &Value) -> Result<Vec<u8>, ProtocolError> {
+    fn canonicalize(value: &Value) -> Value {
+        match value {
+            Value::Array(items) => Value::Array(items.iter().map(canonicalize).collect()),
+            Value::Object(map) => {
+                let mut keys = map.keys().collect::<Vec<_>>();
+                keys.sort();
+                let mut output = serde_json::Map::new();
+                for key in keys {
+                    output.insert(key.clone(), canonicalize(&map[key]));
+                }
+                Value::Object(output)
+            }
+            scalar => scalar.clone(),
+        }
+    }
+    serde_json::to_vec(&canonicalize(value)).map_err(|_| {
+        ProtocolError::new(
+            error_code::INVALID_REQUEST,
+            "payload could not be canonicalized",
+        )
+    })
+}
+
+fn unix_millis() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+        .try_into()
+        .unwrap_or(i64::MAX)
+}
+
+fn internal_ledger_error(error: anyhow::Error) -> ProtocolError {
+    ProtocolError::new(
+        error_code::INTERNAL_ERROR,
+        format!("idempotency ledger failure: {error:#}"),
+    )
+}
+
+fn map_claim_error(error: anyhow::Error) -> ProtocolError {
+    let message = error.to_string();
+    if message.contains("UUIDv7")
+        || message.contains("must be a UUID")
+        || message.contains("too far in the future")
+    {
+        ProtocolError::new(error_code::VALIDATION_FAILED, message)
+    } else if message.contains("capacity is exhausted") {
+        ProtocolError::new(error_code::ACTION_REQUIRED, message)
+    } else {
+        internal_ledger_error(error)
+    }
+}
+
+pub fn decode_request(bytes: &[u8]) -> Result<RequestEnvelope, ProtocolError> {
+    let value: Value = serde_json::from_slice(bytes)
+        .map_err(|_| ProtocolError::new(error_code::INVALID_REQUEST, "invalid JSON request"))?;
+    serde_json::from_value(value)
+        .map_err(|error| ProtocolError::new(error_code::INVALID_REQUEST, error.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use async_trait::async_trait;
+    use kukuri_desktop_runtime::DesktopRuntime;
+    use serde_json::json;
+    use uuid::Uuid;
+
+    use super::*;
+    use crate::{
+        protocol::{CommandEffect, CommandMetadata, GuardRequirement},
+        registry::{CommandHandler, CommandRegistration},
+    };
+
+    fn request(command: &str) -> RequestEnvelope {
+        RequestEnvelope {
+            protocol_version: PROTOCOL_VERSION,
+            request_id: "req-1".to_string(),
+            command: command.to_string(),
+            profile: "test".to_string(),
+            payload: json!({}),
+            idempotency_key: None,
+            timeout_ms: None,
+            secret_bytes: None,
+            accepts_secret_output: false,
+        }
+    }
+
+    #[tokio::test]
+    async fn mismatch_and_unknown_command_are_typed_errors() {
+        let dispatcher = Dispatcher::builtin();
+        let mut mismatch = request("client.status");
+        mismatch.protocol_version = 99;
+        let DispatchReply::Unary(response, _) =
+            dispatcher.dispatch(mismatch, None, "test", None).await
+        else {
+            panic!("expected unary response")
+        };
+        assert_eq!(response.error_code(), Some(error_code::PROTOCOL_MISMATCH));
+
+        let DispatchReply::Unary(response, _) = dispatcher
+            .dispatch(request("missing.command"), None, "test", None)
+            .await
+        else {
+            panic!("expected unary response")
+        };
+        assert_eq!(response.error_code(), Some(error_code::NOT_FOUND));
+    }
+
+    #[tokio::test]
+    async fn status_is_available_before_consent_but_events_are_guarded() {
+        let dispatcher = Dispatcher::builtin();
+        let DispatchReply::Unary(status, _) = dispatcher
+            .dispatch(request("client.status"), None, "test", None)
+            .await
+        else {
+            panic!("expected status")
+        };
+        assert!(status.ok);
+        assert_eq!(status.data.expect("data")["ready"], false);
+
+        let DispatchReply::Unary(events, _) = dispatcher
+            .dispatch(request("events.watch"), None, "test", None)
+            .await
+        else {
+            panic!("expected guarded response")
+        };
+        assert_eq!(events.error_code(), Some(error_code::CONSENT_REQUIRED));
+    }
+
+    struct CountingWriteHandler(Arc<AtomicUsize>);
+
+    #[async_trait]
+    impl CommandHandler for CountingWriteHandler {
+        async fn execute(
+            &self,
+            _context: crate::registry::HandlerContext<'_>,
+            payload: Value,
+            _secret: Option<&SecretInput>,
+        ) -> Result<CommandOutput, ProtocolError> {
+            self.0.fetch_add(1, Ordering::SeqCst);
+            Ok(CommandOutput::Unary(json!({"saved": payload})))
+        }
+    }
+
+    struct SecretEchoHandler;
+
+    #[async_trait]
+    impl CommandHandler for SecretEchoHandler {
+        async fn execute(
+            &self,
+            _context: crate::registry::HandlerContext<'_>,
+            _payload: Value,
+            secret: Option<&SecretInput>,
+        ) -> Result<CommandOutput, ProtocolError> {
+            let bytes = secret.expect("secret input").expose().to_vec();
+            Ok(CommandOutput::Secret {
+                data: json!({"written": true}),
+                secret: crate::protocol::SecretOutput::new(bytes),
+            })
+        }
+    }
+
+    struct SecretErrorHandler;
+
+    #[async_trait]
+    impl CommandHandler for SecretErrorHandler {
+        async fn execute(
+            &self,
+            _context: crate::registry::HandlerContext<'_>,
+            _payload: Value,
+            secret: Option<&SecretInput>,
+        ) -> Result<CommandOutput, ProtocolError> {
+            let secret =
+                std::str::from_utf8(secret.expect("secret input").expose()).expect("fixture UTF-8");
+            Err(
+                ProtocolError::new(error_code::VALIDATION_FAILED, format!("rejected {secret}"))
+                    .with_details(json!({"reason": secret})),
+            )
+        }
+    }
+
+    struct SecretOutputLeakHandler;
+
+    #[async_trait]
+    impl CommandHandler for SecretOutputLeakHandler {
+        async fn execute(
+            &self,
+            _context: crate::registry::HandlerContext<'_>,
+            _payload: Value,
+            _secret: Option<&SecretInput>,
+        ) -> Result<CommandOutput, ProtocolError> {
+            Ok(CommandOutput::Secret {
+                data: json!({"leak": "secret-output-\"-\\-sentinel"}),
+                secret: crate::protocol::SecretOutput::new(
+                    b"secret-output-\"-\\-sentinel".to_vec(),
+                ),
+            })
+        }
+    }
+
+    struct SecretOutputErrorHandler;
+
+    #[async_trait]
+    impl CommandHandler for SecretOutputErrorHandler {
+        async fn execute(
+            &self,
+            _context: crate::registry::HandlerContext<'_>,
+            _payload: Value,
+            _secret: Option<&SecretInput>,
+        ) -> Result<CommandOutput, ProtocolError> {
+            Err(
+                ProtocolError::new(error_code::INTERNAL_ERROR, "secret-output-error-sentinel")
+                    .with_details(json!({"leak": "secret-output-error-sentinel"})),
+            )
+        }
+    }
+
+    struct AllowAllGuards;
+
+    #[async_trait]
+    impl GuardEvaluator for AllowAllGuards {
+        async fn evaluate(
+            &self,
+            _requirement: GuardRequirement,
+            _context: &GuardContext<'_>,
+        ) -> Result<(), ProtocolError> {
+            Ok(())
+        }
+    }
+
+    struct LeakingGuard;
+
+    #[async_trait]
+    impl GuardEvaluator for LeakingGuard {
+        async fn evaluate(
+            &self,
+            _requirement: GuardRequirement,
+            _context: &GuardContext<'_>,
+        ) -> Result<(), ProtocolError> {
+            Err(
+                ProtocolError::new(error_code::AUTHORIZATION_FAILED, "guard-secret-sentinel")
+                    .with_details(json!({"credential": "guard-secret-sentinel"})),
+            )
+        }
+    }
+
+    fn write_dispatcher(counter: Arc<AtomicUsize>) -> Dispatcher {
+        let metadata = CommandMetadata {
+            name: "fixture.write".to_string(),
+            effect: CommandEffect::Write,
+            secret_input: false,
+            secret_output: false,
+            idempotency_required: true,
+            streaming: false,
+            guards: vec![GuardRequirement::HostReady],
+            input_schema: json!({"type": "object"}),
+            output_schema: json!({"type": "object"}),
+        };
+        Dispatcher::new(
+            CommandRegistry::new(vec![CommandRegistration::new(
+                metadata,
+                Arc::new(CountingWriteHandler(counter)),
+            )])
+            .expect("registry"),
+        )
+    }
+
+    #[tokio::test]
+    async fn guard_runs_before_ledger_and_mutation_sink() {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let dispatcher = write_dispatcher(counter.clone());
+        let mut request = request("fixture.write");
+        request.idempotency_key = Some(Uuid::now_v7().to_string());
+        let DispatchReply::Unary(response, _) =
+            dispatcher.dispatch(request, None, "test", None).await
+        else {
+            panic!("expected guarded response")
+        };
+        assert_eq!(response.error_code(), Some(error_code::CONSENT_REQUIRED));
+        assert_eq!(counter.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn successful_mutation_replays_and_payload_mismatch_conflicts() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let runtime = Arc::new(
+            DesktopRuntime::new(root.path().join("kukuri.db"))
+                .await
+                .expect("runtime"),
+        );
+        let host = ClientHost::from_runtime(root.path().to_path_buf(), runtime)
+            .await
+            .expect("host");
+        let counter = Arc::new(AtomicUsize::new(0));
+        let dispatcher = write_dispatcher(counter.clone());
+        let mut first = request("fixture.write");
+        first.idempotency_key = Some(Uuid::now_v7().to_string());
+        first.payload = json!({"value": 1});
+        let DispatchReply::Unary(response, _) = dispatcher
+            .dispatch(first.clone(), None, "test", Some(&host))
+            .await
+        else {
+            panic!("expected first response")
+        };
+        assert!(response.ok);
+        let DispatchReply::Unary(replay, _) = dispatcher
+            .dispatch(first.clone(), None, "test", Some(&host))
+            .await
+        else {
+            panic!("expected replay")
+        };
+        assert!(replay.ok);
+        assert_eq!(replay.data, response.data);
+        assert_eq!(counter.load(Ordering::SeqCst), 1);
+
+        first.payload = json!({"value": 2});
+        let DispatchReply::Unary(conflict, _) =
+            dispatcher.dispatch(first, None, "test", Some(&host)).await
+        else {
+            panic!("expected conflict")
+        };
+        assert_eq!(
+            conflict.error_code(),
+            Some(error_code::IDEMPOTENCY_CONFLICT)
+        );
+        assert_eq!(counter.load(Ordering::SeqCst), 1);
+        host.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn secret_is_kept_out_of_the_json_response() {
+        let metadata = CommandMetadata {
+            name: "fixture.secret".to_string(),
+            effect: CommandEffect::Read,
+            secret_input: true,
+            secret_output: true,
+            idempotency_required: false,
+            streaming: false,
+            guards: Vec::new(),
+            input_schema: json!({"type": "object", "additionalProperties": false}),
+            output_schema: json!({"type": "object"}),
+        };
+        let dispatcher = Dispatcher::new(
+            CommandRegistry::new(vec![CommandRegistration::new(
+                metadata,
+                Arc::new(SecretEchoHandler),
+            )])
+            .expect("registry"),
+        );
+        let sentinel = b"secret-sentinel";
+        let mut request = request("fixture.secret");
+        request.secret_bytes = Some(sentinel.len() as u64);
+        request.accepts_secret_output = true;
+        let DispatchReply::Unary(response, secret) = dispatcher
+            .dispatch(
+                request,
+                Some(SecretInput::new(sentinel.to_vec())),
+                "test",
+                None,
+            )
+            .await
+        else {
+            panic!("expected secret response")
+        };
+        let encoded = serde_json::to_string(&response).expect("response json");
+        assert!(!encoded.contains("secret-sentinel"));
+        assert_eq!(secret.expect("secret frame").expose(), sentinel);
+    }
+
+    #[tokio::test]
+    async fn preflight_rejects_guarded_secret_before_a_secret_frame_is_needed() {
+        let metadata = CommandMetadata {
+            name: "fixture.guarded-secret".to_string(),
+            effect: CommandEffect::Read,
+            secret_input: true,
+            secret_output: false,
+            idempotency_required: false,
+            streaming: false,
+            guards: vec![GuardRequirement::HostReady],
+            input_schema: json!({"type": "object"}),
+            output_schema: json!({"type": "object"}),
+        };
+        let dispatcher = Dispatcher::new(
+            CommandRegistry::new(vec![CommandRegistration::new(
+                metadata,
+                Arc::new(SecretEchoHandler),
+            )])
+            .expect("registry"),
+        );
+        let mut request = request("fixture.guarded-secret");
+        request.secret_bytes = Some(64);
+        let error = dispatcher
+            .preflight(&request, "test", None)
+            .await
+            .expect_err("guard blocks before secret read");
+        assert_eq!(error.code, error_code::CONSENT_REQUIRED);
+    }
+
+    #[tokio::test]
+    async fn domain_guard_has_an_injectable_success_path() {
+        let metadata = CommandMetadata {
+            name: "fixture.domain-read".to_string(),
+            effect: CommandEffect::Read,
+            secret_input: false,
+            secret_output: false,
+            idempotency_required: false,
+            streaming: false,
+            guards: vec![GuardRequirement::DomainAuthorization],
+            input_schema: json!({"type": "object"}),
+            output_schema: json!({"type": "object"}),
+        };
+        let dispatcher = Dispatcher::new(
+            CommandRegistry::new(vec![CommandRegistration::new(
+                metadata,
+                Arc::new(CountingWriteHandler(Arc::new(AtomicUsize::new(0)))),
+            )])
+            .expect("registry"),
+        )
+        .with_guard_evaluator(Arc::new(AllowAllGuards));
+        let DispatchReply::Unary(response, _) = dispatcher
+            .dispatch(request("fixture.domain-read"), None, "test", None)
+            .await
+        else {
+            panic!("expected unary response")
+        };
+        assert!(response.ok);
+    }
+
+    #[tokio::test]
+    async fn secret_is_redacted_from_handler_errors_and_details() {
+        let metadata = CommandMetadata {
+            name: "fixture.secret-error".to_string(),
+            effect: CommandEffect::Read,
+            secret_input: true,
+            secret_output: false,
+            idempotency_required: false,
+            streaming: false,
+            guards: Vec::new(),
+            input_schema: json!({"type": "object"}),
+            output_schema: json!({"type": "object"}),
+        };
+        let dispatcher = Dispatcher::new(
+            CommandRegistry::new(vec![CommandRegistration::new(
+                metadata,
+                Arc::new(SecretErrorHandler),
+            )])
+            .expect("registry"),
+        );
+        let sentinel = b"secret-error-sentinel";
+        let mut request = request("fixture.secret-error");
+        request.secret_bytes = Some(sentinel.len() as u64);
+        let DispatchReply::Unary(response, _) = dispatcher
+            .dispatch(
+                request,
+                Some(SecretInput::new(sentinel.to_vec())),
+                "test",
+                None,
+            )
+            .await
+        else {
+            panic!("expected error response")
+        };
+        let encoded = serde_json::to_string(&response).expect("response JSON");
+        assert!(!encoded.contains("secret-error-sentinel"));
+        assert!(encoded.contains("secret-bearing command failed"));
+    }
+
+    #[tokio::test]
+    async fn handler_cannot_return_an_unregistered_secret_output() {
+        let metadata = CommandMetadata {
+            name: "fixture.secret-leak".to_string(),
+            effect: CommandEffect::Read,
+            secret_input: true,
+            secret_output: false,
+            idempotency_required: false,
+            streaming: false,
+            guards: Vec::new(),
+            input_schema: json!({"type": "object"}),
+            output_schema: json!({"type": "object"}),
+        };
+        let dispatcher = Dispatcher::new(
+            CommandRegistry::new(vec![CommandRegistration::new(
+                metadata,
+                Arc::new(SecretEchoHandler),
+            )])
+            .expect("registry"),
+        );
+        let sentinel = b"unregistered-secret";
+        let mut request = request("fixture.secret-leak");
+        request.secret_bytes = Some(sentinel.len() as u64);
+        let DispatchReply::Unary(response, secret) = dispatcher
+            .dispatch(
+                request,
+                Some(SecretInput::new(sentinel.to_vec())),
+                "test",
+                None,
+            )
+            .await
+        else {
+            panic!("expected guarded response")
+        };
+        assert_eq!(response.error_code(), Some(error_code::INTERNAL_ERROR));
+        assert!(secret.is_none());
+        assert!(
+            !serde_json::to_string(&response)
+                .expect("response JSON")
+                .contains("unregistered-secret")
+        );
+    }
+
+    #[test]
+    fn nested_schema_constraints_are_enforced() {
+        let schema = json!({
+            "type": "object",
+            "required": ["mode", "items"],
+            "properties": {
+                "mode": {"type": "string", "enum": ["safe"]},
+                "items": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "object",
+                        "required": ["name"],
+                        "properties": {"name": {"type": "string", "minLength": 1}},
+                        "additionalProperties": false
+                    }
+                }
+            },
+            "additionalProperties": false
+        });
+        assert!(
+            validate_payload(&schema, &json!({"mode": "safe", "items": [{"name": "a"}]})).is_ok()
+        );
+        assert!(validate_payload(&schema, &json!({"mode": "unsafe", "items": []})).is_err());
+        assert!(
+            validate_payload(&schema, &json!({"mode": "safe", "items": [{"name": ""}]})).is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn secret_output_cannot_also_appear_in_json() {
+        let metadata = CommandMetadata {
+            name: "fixture.secret-output-leak".to_string(),
+            effect: CommandEffect::Read,
+            secret_input: false,
+            secret_output: true,
+            idempotency_required: false,
+            streaming: false,
+            guards: Vec::new(),
+            input_schema: json!({"type": "object"}),
+            output_schema: json!({"type": "object"}),
+        };
+        let dispatcher = Dispatcher::new(
+            CommandRegistry::new(vec![CommandRegistration::new(
+                metadata,
+                Arc::new(SecretOutputLeakHandler),
+            )])
+            .expect("registry"),
+        );
+        let mut request = request("fixture.secret-output-leak");
+        request.accepts_secret_output = true;
+        let DispatchReply::Unary(response, secret) =
+            dispatcher.dispatch(request, None, "test", None).await
+        else {
+            panic!("expected error response")
+        };
+        assert_eq!(response.error_code(), Some(error_code::INTERNAL_ERROR));
+        assert!(secret.is_none());
+        assert!(
+            !serde_json::to_string(&response)
+                .expect("response JSON")
+                .contains("secret-output-\\\"-\\\\-sentinel")
+        );
+    }
+
+    #[tokio::test]
+    async fn secret_output_only_errors_are_redacted() {
+        let metadata = CommandMetadata {
+            name: "fixture.secret-output-error".to_string(),
+            effect: CommandEffect::Read,
+            secret_input: false,
+            secret_output: true,
+            idempotency_required: false,
+            streaming: false,
+            guards: Vec::new(),
+            input_schema: json!({"type": "object"}),
+            output_schema: json!({"type": "object"}),
+        };
+        let dispatcher = Dispatcher::new(
+            CommandRegistry::new(vec![CommandRegistration::new(
+                metadata,
+                Arc::new(SecretOutputErrorHandler),
+            )])
+            .expect("registry"),
+        );
+        let mut request = request("fixture.secret-output-error");
+        request.accepts_secret_output = true;
+        let DispatchReply::Unary(response, _) =
+            dispatcher.dispatch(request, None, "test", None).await
+        else {
+            panic!("expected error response")
+        };
+        let encoded = serde_json::to_string(&response).expect("response JSON");
+        assert!(!encoded.contains("secret-output-error-sentinel"));
+        assert!(encoded.contains("secret-bearing command failed"));
+    }
+
+    #[tokio::test]
+    async fn secret_bearing_guard_errors_are_redacted() {
+        let metadata = CommandMetadata {
+            name: "fixture.secret-guard".to_string(),
+            effect: CommandEffect::Read,
+            secret_input: true,
+            secret_output: false,
+            idempotency_required: false,
+            streaming: false,
+            guards: vec![GuardRequirement::Credential],
+            input_schema: json!({"type": "object"}),
+            output_schema: json!({"type": "object"}),
+        };
+        let dispatcher = Dispatcher::new(
+            CommandRegistry::new(vec![CommandRegistration::new(
+                metadata,
+                Arc::new(SecretEchoHandler),
+            )])
+            .expect("registry"),
+        )
+        .with_guard_evaluator(Arc::new(LeakingGuard));
+        let mut request = request("fixture.secret-guard");
+        request.secret_bytes = Some(1);
+        let error = dispatcher
+            .preflight(&request, "test", None)
+            .await
+            .expect_err("guard rejection");
+        assert_eq!(error.code, error_code::AUTHORIZATION_FAILED);
+        assert_eq!(error.message, "secret-bearing command failed");
+        assert!(error.details.is_none());
+    }
+}

--- a/crates/kukuri-cli/src/dispatcher/validation.rs
+++ b/crates/kukuri-cli/src/dispatcher/validation.rs
@@ -1,0 +1,228 @@
+use serde_json::Value;
+
+use crate::{
+    protocol::{CommandMetadata, ProtocolError, SecretInput, error_code},
+    registry::CommandOutput,
+};
+
+pub(super) fn validate_payload(schema: &Value, payload: &Value) -> Result<(), ProtocolError> {
+    validate_value(schema, payload, "payload")
+}
+
+fn validate_value(schema: &Value, value: &Value, path: &str) -> Result<(), ProtocolError> {
+    let valid_type = match schema.get("type").and_then(Value::as_str) {
+        Some("string") => value.is_string(),
+        Some("integer") => {
+            value.as_i64().is_some()
+                || value.as_u64().is_some()
+                || value.as_f64().is_some_and(|number| number.fract() == 0.0)
+        }
+        Some("number") => value.is_number(),
+        Some("boolean") => value.is_boolean(),
+        Some("object") => value.is_object(),
+        Some("array") => value.is_array(),
+        Some("null") => value.is_null(),
+        Some(_) | None => true,
+    };
+    if !valid_type {
+        return validation_error(format!("{path} has an invalid type"));
+    }
+    if let Some(expected) = schema.get("const")
+        && expected != value
+    {
+        return validation_error(format!("{path} does not match the required value"));
+    }
+    if let Some(values) = schema.get("enum").and_then(Value::as_array)
+        && !values.contains(value)
+    {
+        return validation_error(format!("{path} is not an allowed value"));
+    }
+    if let Some(text) = value.as_str() {
+        let length = text.chars().count() as u64;
+        if schema
+            .get("minLength")
+            .and_then(Value::as_u64)
+            .is_some_and(|minimum| length < minimum)
+            || schema
+                .get("maxLength")
+                .and_then(Value::as_u64)
+                .is_some_and(|maximum| length > maximum)
+        {
+            return validation_error(format!("{path} has an invalid length"));
+        }
+    }
+    if let Some(number) = value.as_f64()
+        && (schema
+            .get("minimum")
+            .and_then(Value::as_f64)
+            .is_some_and(|minimum| number < minimum)
+            || schema
+                .get("maximum")
+                .and_then(Value::as_f64)
+                .is_some_and(|maximum| number > maximum))
+    {
+        return validation_error(format!("{path} is outside the supported range"));
+    }
+    if let Some(items) = value.as_array() {
+        if schema
+            .get("minItems")
+            .and_then(Value::as_u64)
+            .is_some_and(|minimum| items.len() < minimum as usize)
+            || schema
+                .get("maxItems")
+                .and_then(Value::as_u64)
+                .is_some_and(|maximum| items.len() > maximum as usize)
+        {
+            return validation_error(format!("{path} has an invalid item count"));
+        }
+        if let Some(item_schema) = schema.get("items") {
+            for (index, item) in items.iter().enumerate() {
+                validate_value(item_schema, item, &format!("{path}[{index}]"))?;
+            }
+        }
+    }
+    if let Some(object) = value.as_object() {
+        let properties = schema.get("properties").and_then(Value::as_object);
+        if let Some(required) = schema.get("required").and_then(Value::as_array) {
+            for key in required.iter().filter_map(Value::as_str) {
+                if !object.contains_key(key) {
+                    return validation_error(format!("{path} is missing required field `{key}`"));
+                }
+            }
+        }
+        if schema.get("additionalProperties") == Some(&Value::Bool(false)) {
+            for key in object.keys() {
+                if !properties.is_some_and(|properties| properties.contains_key(key)) {
+                    return validation_error(format!("{path} contains unknown field `{key}`"));
+                }
+            }
+        }
+        if let Some(properties) = properties {
+            for (key, field_schema) in properties {
+                if let Some(field) = object.get(key) {
+                    validate_value(field_schema, field, &format!("{path}.{key}"))?;
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validation_error(message: String) -> Result<(), ProtocolError> {
+    Err(ProtocolError::new(error_code::VALIDATION_FAILED, message))
+}
+
+pub(super) fn validate_command_output(
+    metadata: &CommandMetadata,
+    output: &CommandOutput,
+    secret_input: Option<&SecretInput>,
+) -> Result<(), ProtocolError> {
+    let (data, secret_output) = match output {
+        CommandOutput::Unary(data) if !metadata.secret_output && !metadata.streaming => {
+            (data, None)
+        }
+        CommandOutput::Secret { data, secret }
+            if metadata.secret_output
+                && !metadata.streaming
+                && secret.expose().len() <= crate::protocol::MAX_FRAME_BYTES =>
+        {
+            (data, Some(secret))
+        }
+        CommandOutput::Events(_) if metadata.streaming => return Ok(()),
+        _ => {
+            return Err(ProtocolError::new(
+                error_code::INTERNAL_ERROR,
+                "command output does not match registry metadata",
+            ));
+        }
+    };
+    reject_secret_in_json(data, secret_input.map(SecretInput::expose), "secret input")?;
+    reject_secret_in_json(
+        data,
+        secret_output.map(|secret| secret.expose()),
+        "secret output",
+    )?;
+    validate_value(&metadata.output_schema, data, "output").map_err(|_| {
+        ProtocolError::new(
+            error_code::INTERNAL_ERROR,
+            "command output does not match its registered schema",
+        )
+    })
+}
+
+fn reject_secret_in_json(
+    data: &Value,
+    secret: Option<&[u8]>,
+    label: &str,
+) -> Result<(), ProtocolError> {
+    let Some(secret) = secret.filter(|secret| !secret.is_empty()) else {
+        return Ok(());
+    };
+    let encoded = serde_json::to_vec(data).map_err(|_| {
+        ProtocolError::new(
+            error_code::INTERNAL_ERROR,
+            "command output could not be encoded",
+        )
+    })?;
+    if encoded.windows(secret.len()).any(|window| window == secret)
+        || json_contains_secret(data, secret)
+    {
+        return Err(ProtocolError::new(
+            error_code::INTERNAL_ERROR,
+            format!("{label} was also returned in JSON"),
+        ));
+    }
+    Ok(())
+}
+
+fn json_contains_secret(value: &Value, secret: &[u8]) -> bool {
+    match value {
+        Value::String(text) => text
+            .as_bytes()
+            .windows(secret.len())
+            .any(|window| window == secret),
+        Value::Array(items) => items.iter().any(|item| json_contains_secret(item, secret)),
+        Value::Object(fields) => fields.iter().any(|(key, value)| {
+            key.as_bytes()
+                .windows(secret.len())
+                .any(|window| window == secret)
+                || json_contains_secret(value, secret)
+        }),
+        _ => false,
+    }
+}
+
+pub(super) fn redact_protocol_error(
+    mut error: ProtocolError,
+    secret_bearing: bool,
+) -> ProtocolError {
+    if !secret_bearing {
+        return error;
+    }
+    if !matches!(
+        error.code.as_str(),
+        error_code::INVALID_REQUEST
+            | error_code::VALIDATION_FAILED
+            | error_code::CONSENT_REQUIRED
+            | error_code::ACTION_REQUIRED
+            | error_code::DAEMON_UNAVAILABLE
+            | error_code::PROTOCOL_MISMATCH
+            | error_code::PROFILE_IN_USE
+            | error_code::AUTHORIZATION_FAILED
+            | error_code::NOT_FOUND
+            | error_code::CONFLICT
+            | error_code::IDEMPOTENCY_CONFLICT
+            | error_code::IDEMPOTENCY_EXPIRED
+            | error_code::OPERATION_OUTCOME_UNKNOWN
+            | error_code::NETWORK_UNAVAILABLE
+            | error_code::TIMEOUT
+            | error_code::INTERRUPTED
+            | error_code::INTERNAL_ERROR
+            | error_code::BACKPRESSURE
+    ) {
+        error.code = error_code::INTERNAL_ERROR.to_string();
+    }
+    error.message = "secret-bearing command failed".to_string();
+    error.details = None;
+    error
+}

--- a/crates/kukuri-cli/src/framing.rs
+++ b/crates/kukuri-cli/src/framing.rs
@@ -1,0 +1,134 @@
+use tokio::io::{
+    AsyncBufRead, AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt,
+};
+
+use crate::protocol::{MAX_FRAME_BYTES, ProtocolError, error_code};
+
+pub async fn read_json_frame<R: AsyncBufRead + Unpin>(
+    reader: &mut R,
+) -> Result<Option<Vec<u8>>, ProtocolError> {
+    let mut output = Vec::new();
+    loop {
+        let available = reader.fill_buf().await.map_err(io_error)?;
+        if available.is_empty() {
+            if output.is_empty() {
+                return Ok(None);
+            }
+            return Err(ProtocolError::new(
+                error_code::INVALID_REQUEST,
+                "JSON frame ended before a newline",
+            ));
+        }
+        let newline = available.iter().position(|byte| *byte == b'\n');
+        let take = newline.map_or(available.len(), |index| index + 1);
+        if output.len().saturating_add(take) > MAX_FRAME_BYTES {
+            return Err(ProtocolError::new(
+                error_code::INVALID_REQUEST,
+                "JSON frame exceeds the supported size",
+            ));
+        }
+        output.extend_from_slice(&available[..take]);
+        reader.consume(take);
+        if newline.is_some() {
+            output.pop();
+            if output.last() == Some(&b'\r') {
+                output.pop();
+            }
+            if output.is_empty() {
+                return Err(ProtocolError::new(
+                    error_code::INVALID_REQUEST,
+                    "JSON frame is empty",
+                ));
+            }
+            return Ok(Some(output));
+        }
+    }
+}
+
+pub async fn read_secret_frame<R: AsyncRead + Unpin>(
+    reader: &mut R,
+    length: u64,
+) -> Result<Vec<u8>, ProtocolError> {
+    let length = usize::try_from(length).map_err(|_| {
+        ProtocolError::new(
+            error_code::INVALID_REQUEST,
+            "secret frame length is invalid",
+        )
+    })?;
+    if length > MAX_FRAME_BYTES {
+        return Err(ProtocolError::new(
+            error_code::INVALID_REQUEST,
+            "secret frame exceeds the supported size",
+        ));
+    }
+    let mut bytes = vec![0; length];
+    reader.read_exact(&mut bytes).await.map_err(|_| {
+        ProtocolError::new(
+            error_code::INVALID_REQUEST,
+            "secret frame ended before the declared length",
+        )
+    })?;
+    Ok(bytes)
+}
+
+pub async fn write_json_frame<W: AsyncWrite + Unpin, T: serde::Serialize>(
+    writer: &mut W,
+    value: &T,
+) -> Result<(), ProtocolError> {
+    let bytes = serde_json::to_vec(value).map_err(|_| {
+        ProtocolError::new(error_code::INTERNAL_ERROR, "failed to encode JSON frame")
+    })?;
+    if bytes.len() + 1 > MAX_FRAME_BYTES {
+        return Err(ProtocolError::new(
+            error_code::INTERNAL_ERROR,
+            "JSON response exceeds the supported size",
+        ));
+    }
+    writer.write_all(&bytes).await.map_err(io_error)?;
+    writer.write_all(b"\n").await.map_err(io_error)?;
+    writer.flush().await.map_err(io_error)
+}
+
+pub async fn write_secret_frame<W: AsyncWrite + Unpin>(
+    writer: &mut W,
+    bytes: &[u8],
+) -> Result<(), ProtocolError> {
+    if bytes.len() > MAX_FRAME_BYTES {
+        return Err(ProtocolError::new(
+            error_code::INTERNAL_ERROR,
+            "secret response exceeds the supported size",
+        ));
+    }
+    writer.write_all(bytes).await.map_err(io_error)?;
+    writer.flush().await.map_err(io_error)
+}
+
+fn io_error(_error: std::io::Error) -> ProtocolError {
+    ProtocolError::new(error_code::NETWORK_UNAVAILABLE, "local socket I/O failed")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn oversized_and_partial_frames_fail_closed() {
+        let oversized = vec![b'a'; MAX_FRAME_BYTES + 1];
+        let mut reader = tokio::io::BufReader::new(oversized.as_slice());
+        assert_eq!(
+            read_json_frame(&mut reader)
+                .await
+                .expect_err("oversized")
+                .code,
+            error_code::INVALID_REQUEST
+        );
+        let mut reader = tokio::io::BufReader::new(b"{}".as_slice());
+        assert_eq!(
+            read_json_frame(&mut reader)
+                .await
+                .expect_err("partial")
+                .code,
+            error_code::INVALID_REQUEST
+        );
+    }
+}

--- a/crates/kukuri-cli/src/lib.rs
+++ b/crates/kukuri-cli/src/lib.rs
@@ -1,0 +1,8 @@
+pub mod dispatcher;
+pub mod protocol;
+pub mod registry;
+
+#[cfg(target_os = "linux")]
+pub mod client;
+#[cfg(target_os = "linux")]
+pub mod framing;

--- a/crates/kukuri-cli/src/main.rs
+++ b/crates/kukuri-cli/src/main.rs
@@ -1,6 +1,12 @@
 use std::path::{Path, PathBuf};
 
 use clap::{Args, Parser, Subcommand};
+use kukuri_cli::protocol::PROTOCOL_VERSION;
+#[cfg(target_os = "linux")]
+use kukuri_cli::protocol::{
+    MAX_FRAME_BYTES, ProtocolError, RequestEnvelope, ResponseEnvelope, SecretInput, error_code,
+    exit_code_for,
+};
 use kukuri_desktop_runtime::{
     AGE_ATTESTATION_VERSION, APP_LEGAL_DOCUMENTS, AgeAttestationRecord, AppConsentDocumentRecord,
     AppConsentStore, ProfileError, ProfileLease, app_consent_satisfied, current_unix_seconds,
@@ -24,6 +30,38 @@ struct Cli {
 enum Command {
     Daemon(DaemonArgs),
     Consent(ConsentArgs),
+    /// daemonへversion付きrequestを送る。
+    Call(CallArgs),
+}
+
+#[derive(Args)]
+struct CallArgs {
+    /// registryに登録されたcommand名。
+    command: String,
+    /// JSON request file。`-`はstdin。
+    #[arg(long, conflicts_with = "input_fd")]
+    input: Option<String>,
+    /// JSON requestを読むfile descriptor。
+    #[arg(long)]
+    input_fd: Option<u32>,
+    /// secretを読む0600 file。`-`はstdin。
+    #[arg(long, conflicts_with = "secret_input_fd")]
+    secret_input: Option<String>,
+    /// secretを読むfile descriptor。
+    #[arg(long)]
+    secret_input_fd: Option<u32>,
+    /// secret responseを書き込む新規0600 file。
+    #[arg(long, conflicts_with = "secret_output_fd")]
+    secret_output: Option<PathBuf>,
+    /// secret responseを書き込むfile descriptor。
+    #[arg(long)]
+    secret_output_fd: Option<u32>,
+    #[arg(long)]
+    idempotency_key: Option<String>,
+    #[arg(long)]
+    timeout_ms: Option<u64>,
+    #[arg(long, default_value_t = PROTOCOL_VERSION, hide = true)]
+    protocol_version: u32,
 }
 
 #[derive(Args)]
@@ -69,21 +107,65 @@ struct ConsentAcceptArgs {
 }
 
 fn main() {
-    if let Err(error) = run() {
-        eprintln!("{}: {}", error.code, error.message);
+    let cli = match Cli::try_parse() {
+        Ok(cli) => cli,
+        Err(error) => {
+            if matches!(
+                error.kind(),
+                clap::error::ErrorKind::DisplayHelp | clap::error::ErrorKind::DisplayVersion
+            ) {
+                let _ = error.print();
+                std::process::exit(0);
+            }
+            #[cfg(target_os = "linux")]
+            {
+                let response = ResponseEnvelope::failure_parts(
+                    "",
+                    "",
+                    "",
+                    ProtocolError::new(error_code::INVALID_REQUEST, error.to_string()),
+                );
+                println!(
+                    "{}",
+                    serde_json::to_string(&response).expect("error envelope")
+                );
+                std::process::exit(2);
+            }
+            #[cfg(not(target_os = "linux"))]
+            error.exit();
+        }
+    };
+    if let Err(error) = run(cli) {
+        if !error.reported {
+            eprintln!("{}: {}", error.code, error.message);
+        }
         std::process::exit(error.exit_code);
     }
 }
 
-fn run() -> Result<(), CliError> {
-    let cli = Cli::parse();
+fn run(cli: Cli) -> Result<(), CliError> {
     let custom_app_data_selected = std::env::var("KUKURI_APP_DATA_DIR")
         .ok()
         .is_some_and(|value| !value.trim().is_empty());
-    let profile = resolve_profile(cli.profile.as_deref()).map_err(CliError::from_profile)?;
+    let profile = match resolve_profile(cli.profile.as_deref()) {
+        Ok(profile) => profile,
+        Err(error) => {
+            #[cfg(target_os = "linux")]
+            if let Command::Call(args) = &cli.command {
+                return emit_local_failure(
+                    &args.command,
+                    "",
+                    cli.profile.as_deref().unwrap_or("default"),
+                    ProtocolError::new(error_code::VALIDATION_FAILED, error.to_string()),
+                );
+            }
+            return Err(CliError::from_profile(error));
+        }
+    };
     match cli.command {
         Command::Consent(args) => run_consent(profile, args.command),
         Command::Daemon(args) => run_daemon(profile, args.command, custom_app_data_selected),
+        Command::Call(args) => run_call(profile, args),
     }
 }
 
@@ -206,6 +288,7 @@ struct CliError {
     code: &'static str,
     message: String,
     exit_code: i32,
+    reported: bool,
 }
 
 impl CliError {
@@ -214,12 +297,367 @@ impl CliError {
             code,
             message: message.into(),
             exit_code,
+            reported: false,
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    fn reported(exit_code: i32) -> Self {
+        Self {
+            code: "protocol_error",
+            message: String::new(),
+            exit_code,
+            reported: true,
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    fn from_protocol(error: ProtocolError) -> Self {
+        let exit_code = exit_code_for(&error.code);
+        Self {
+            code: "protocol_error",
+            message: error.to_string(),
+            exit_code,
+            reported: false,
         }
     }
 
     fn from_profile(error: ProfileError) -> Self {
         Self::new(error.code(), error.to_string(), 1)
     }
+}
+
+#[cfg(target_os = "linux")]
+fn run_call(
+    profile: kukuri_desktop_runtime::ClientProfile,
+    args: CallArgs,
+) -> Result<(), CliError> {
+    let request_id = uuid::Uuid::new_v4().to_string();
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .map_err(|_| {
+            let error = ProtocolError::new(error_code::INTERNAL_ERROR, "runtime startup failed");
+            let _ = emit_local_failure(&args.command, &request_id, &profile.name, error);
+            CliError::reported(1)
+        })?;
+    runtime.block_on(run_call_async(profile, args))
+}
+
+#[cfg(not(target_os = "linux"))]
+fn run_call(
+    _profile: kukuri_desktop_runtime::ClientProfile,
+    _args: CallArgs,
+) -> Result<(), CliError> {
+    Err(CliError::new(
+        "unsupported_platform",
+        "kukuri daemon is supported only on Linux",
+        2,
+    ))
+}
+
+#[cfg(target_os = "linux")]
+async fn run_call_async(
+    profile: kukuri_desktop_runtime::ClientProfile,
+    args: CallArgs,
+) -> Result<(), CliError> {
+    use kukuri_cli::client::ClientSession;
+    use serde_json::json;
+    use uuid::Uuid;
+
+    let request_id = Uuid::new_v4().to_string();
+    if args.secret_output_fd.is_some_and(|fd| fd <= 2) {
+        return emit_local_failure(
+            &args.command,
+            &request_id,
+            &profile.name,
+            ProtocolError::new(
+                error_code::VALIDATION_FAILED,
+                "secret output FD must not be stdin, stdout, or stderr",
+            ),
+        );
+    }
+    if args.input.as_deref() == Some("-") && args.secret_input.as_deref() == Some("-") {
+        return emit_local_failure(
+            &args.command,
+            &request_id,
+            &profile.name,
+            ProtocolError::new(
+                error_code::VALIDATION_FAILED,
+                "stdin cannot be both JSON input and secret input",
+            ),
+        );
+    }
+    let payload = match read_json_input(args.input.as_deref(), args.input_fd) {
+        Ok(payload) => payload,
+        Err(error) => return emit_local_failure(&args.command, &request_id, &profile.name, error),
+    };
+    let secret = match read_secret_input(args.secret_input.as_deref(), args.secret_input_fd) {
+        Ok(secret) => secret.map(SecretInput::new),
+        Err(error) => return emit_local_failure(&args.command, &request_id, &profile.name, error),
+    };
+    let request = RequestEnvelope {
+        protocol_version: args.protocol_version,
+        request_id: request_id.clone(),
+        command: args.command.clone(),
+        profile: profile.name.clone(),
+        payload,
+        idempotency_key: args.idempotency_key.clone(),
+        timeout_ms: args.timeout_ms,
+        secret_bytes: secret.as_ref().map(|secret| secret.len() as u64),
+        accepts_secret_output: args.secret_output.is_some() || args.secret_output_fd.is_some(),
+    };
+    let timeout_ms = match request.timeout_ms() {
+        Ok(timeout) => timeout,
+        Err(error) => return emit_local_failure(&args.command, &request_id, &profile.name, error),
+    };
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_millis(timeout_ms);
+    let mut session = match ClientSession::connect(&profile, &request, secret.as_ref()).await {
+        Ok(session) => session,
+        Err(error) => return emit_local_failure(&args.command, &request_id, &profile.name, error),
+    };
+    loop {
+        let next = tokio::select! {
+            result = tokio::time::timeout_at(deadline, session.next()) => match result {
+                Ok(result) => result,
+                Err(_) => Err(ProtocolError::new(error_code::TIMEOUT, "command timed out")),
+            },
+            result = tokio::signal::ctrl_c() => {
+                let error = match result {
+                    Ok(()) => ProtocolError::new(error_code::INTERRUPTED, "command was interrupted"),
+                    Err(_) => ProtocolError::new(error_code::INTERNAL_ERROR, "failed to wait for interrupt"),
+                };
+                return emit_local_failure(&args.command, &request_id, &profile.name, error);
+            }
+        };
+        let next = match next {
+            Ok(next) => next,
+            Err(error) => {
+                return emit_local_failure(&args.command, &request_id, &profile.name, error);
+            }
+        };
+        let Some((response, secret_output)) = next else {
+            return emit_local_failure(
+                &args.command,
+                &request_id,
+                &profile.name,
+                ProtocolError::new(
+                    error_code::NETWORK_UNAVAILABLE,
+                    "daemon closed the connection before a complete response",
+                ),
+            );
+        };
+        if let Some(secret_output) = secret_output
+            && let Err(error) = write_secret_output(
+                secret_output.expose(),
+                args.secret_output.as_deref(),
+                args.secret_output_fd,
+            )
+        {
+            return emit_local_failure(&args.command, &request_id, &profile.name, error);
+        }
+        println!(
+            "{}",
+            serde_json::to_string(&response).unwrap_or_else(|_| json!({
+                "schema_version": 1,
+                "ok": false,
+                "command": args.command,
+                "request_id": request_id,
+                "profile": profile.name,
+                "error": {"code": "internal_error", "message": "failed to encode response"}
+            })
+            .to_string())
+        );
+        if !response.ok {
+            return Err(CliError::reported(exit_code_for(
+                response.error_code().unwrap_or(error_code::INTERNAL_ERROR),
+            )));
+        }
+        if !response.more {
+            return Ok(());
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn read_json_input(
+    path: Option<&str>,
+    fd: Option<u32>,
+) -> Result<serde_json::Value, ProtocolError> {
+    let bytes = match (path, fd) {
+        (None, None) => return Ok(serde_json::json!({})),
+        (Some("-"), None) => read_stdin()?,
+        (Some(path), None) => read_owner_only_file(Path::new(path), "JSON input")?,
+        (None, Some(fd)) => read_fd(fd, "JSON")?,
+        _ => unreachable!("clap rejects conflicting input sources"),
+    };
+    ensure_input_bound(&bytes, "JSON input")?;
+    let value: serde_json::Value = serde_json::from_slice(&bytes)
+        .map_err(|_| ProtocolError::new(error_code::INVALID_REQUEST, "input is not valid JSON"))?;
+    if !value.is_object() {
+        return Err(ProtocolError::new(
+            error_code::VALIDATION_FAILED,
+            "input JSON must be an object",
+        ));
+    }
+    Ok(value)
+}
+
+#[cfg(target_os = "linux")]
+fn read_secret_input(
+    path: Option<&str>,
+    fd: Option<u32>,
+) -> Result<Option<Vec<u8>>, ProtocolError> {
+    match (path, fd) {
+        (None, None) => Ok(None),
+        (Some("-"), None) => read_stdin().and_then(|bytes| {
+            ensure_input_bound(&bytes, "secret input")?;
+            Ok(Some(bytes))
+        }),
+        (Some(path), None) => read_owner_only_file(Path::new(path), "secret input").map(Some),
+        (None, Some(fd)) => read_fd(fd, "secret").and_then(|bytes| {
+            ensure_input_bound(&bytes, "secret input")?;
+            Ok(Some(bytes))
+        }),
+        _ => unreachable!("clap rejects conflicting secret sources"),
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn ensure_input_bound(bytes: &[u8], label: &str) -> Result<(), ProtocolError> {
+    if bytes.len() > MAX_FRAME_BYTES {
+        return Err(ProtocolError::new(
+            error_code::VALIDATION_FAILED,
+            format!("{label} exceeds the supported size"),
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn read_stdin() -> Result<Vec<u8>, ProtocolError> {
+    read_bounded(std::io::stdin(), "stdin")
+}
+
+#[cfg(target_os = "linux")]
+fn read_fd(fd: u32, label: &str) -> Result<Vec<u8>, ProtocolError> {
+    let file = std::fs::File::open(format!("/proc/self/fd/{fd}")).map_err(|_| {
+        ProtocolError::new(
+            error_code::VALIDATION_FAILED,
+            format!("failed to read {label} file descriptor"),
+        )
+    })?;
+    read_bounded(file, label)
+}
+
+#[cfg(target_os = "linux")]
+fn read_owner_only_file(path: &Path, label: &str) -> Result<Vec<u8>, ProtocolError> {
+    use std::os::unix::fs::PermissionsExt;
+    let metadata = std::fs::metadata(path).map_err(|_| {
+        ProtocolError::new(
+            error_code::VALIDATION_FAILED,
+            format!("failed to inspect {label} file"),
+        )
+    })?;
+    if !metadata.is_file() || metadata.permissions().mode() & 0o077 != 0 {
+        return Err(ProtocolError::new(
+            error_code::VALIDATION_FAILED,
+            format!("{label} file must be a regular owner-only file"),
+        ));
+    }
+    let file = std::fs::File::open(path).map_err(|_| {
+        ProtocolError::new(
+            error_code::VALIDATION_FAILED,
+            format!("failed to read {label} file"),
+        )
+    })?;
+    read_bounded(file, label)
+}
+
+#[cfg(target_os = "linux")]
+fn read_bounded(reader: impl std::io::Read, label: &str) -> Result<Vec<u8>, ProtocolError> {
+    use std::io::Read;
+    let mut bytes = Vec::new();
+    reader
+        .take((MAX_FRAME_BYTES + 1) as u64)
+        .read_to_end(&mut bytes)
+        .map_err(|_| {
+            ProtocolError::new(
+                error_code::VALIDATION_FAILED,
+                format!("failed to read {label}"),
+            )
+        })?;
+    ensure_input_bound(&bytes, label)?;
+    Ok(bytes)
+}
+
+#[cfg(target_os = "linux")]
+fn write_secret_output(
+    bytes: &[u8],
+    path: Option<&Path>,
+    fd: Option<u32>,
+) -> Result<(), ProtocolError> {
+    use std::io::Write;
+    use std::os::unix::fs::OpenOptionsExt;
+
+    match (path, fd) {
+        (Some(path), None) => {
+            let mut file = std::fs::OpenOptions::new()
+                .create_new(true)
+                .write(true)
+                .mode(0o600)
+                .open(path)
+                .map_err(|_| {
+                    ProtocolError::new(
+                        error_code::ACTION_REQUIRED,
+                        "failed to create secret output file",
+                    )
+                })?;
+            file.write_all(bytes).map_err(|_| {
+                ProtocolError::new(error_code::INTERNAL_ERROR, "failed to write secret output")
+            })
+        }
+        (None, Some(fd)) => {
+            if fd <= 2 {
+                return Err(ProtocolError::new(
+                    error_code::VALIDATION_FAILED,
+                    "secret output FD must not be stdin, stdout, or stderr",
+                ));
+            }
+            let mut file = std::fs::OpenOptions::new()
+                .write(true)
+                .open(format!("/proc/self/fd/{fd}"))
+                .map_err(|_| {
+                    ProtocolError::new(error_code::ACTION_REQUIRED, "secret output FD is invalid")
+                })?;
+            file.write_all(bytes).map_err(|_| {
+                ProtocolError::new(error_code::INTERNAL_ERROR, "failed to write secret output")
+            })
+        }
+        (None, None) => Err(ProtocolError::new(
+            error_code::ACTION_REQUIRED,
+            "secret response requires --secret-output or --secret-output-fd",
+        )),
+        _ => unreachable!("clap rejects conflicting secret sinks"),
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn emit_local_failure(
+    command: &str,
+    request_id: &str,
+    profile: &str,
+    error: ProtocolError,
+) -> Result<(), CliError> {
+    let exit_code = exit_code_for(&error.code);
+    let response = ResponseEnvelope::failure_parts(command, request_id, profile, error);
+    println!(
+        "{}",
+        serde_json::to_string(&response).unwrap_or_else(|_| {
+            "{\"schema_version\":1,\"ok\":false,\"command\":\"\",\"request_id\":\"\",\"profile\":\"\",\"error\":{\"code\":\"internal_error\",\"message\":\"failed to encode error\"}}".to_string()
+        })
+    );
+    Err(CliError::reported(exit_code))
 }
 
 #[cfg(test)]
@@ -255,5 +693,16 @@ mod tests {
         )
         .expect("accept consent");
         assert!(app_consent_satisfied(&load_app_consent_store(&path)));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn secret_output_rejects_standard_file_descriptors_without_writing() {
+        let sentinel = b"secret-standard-fd-sentinel";
+        for fd in 0..=2 {
+            let error = write_secret_output(sentinel, None, Some(fd)).expect_err("standard FD");
+            assert_eq!(error.code, error_code::VALIDATION_FAILED);
+            assert!(!error.to_string().contains("secret-standard-fd-sentinel"));
+        }
     }
 }

--- a/crates/kukuri-cli/src/protocol.rs
+++ b/crates/kukuri-cli/src/protocol.rs
@@ -1,0 +1,419 @@
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+
+pub const PROTOCOL_VERSION: u32 = 1;
+pub const SCHEMA_VERSION: u32 = 1;
+pub const MAX_FRAME_BYTES: usize = 1024 * 1024;
+pub const DEFAULT_TIMEOUT_MS: u64 = 30_000;
+pub const MAX_TIMEOUT_MS: u64 = 300_000;
+pub const DEFAULT_PAGE_LIMIT: u32 = 100;
+pub const MAX_PAGE_LIMIT: u32 = 500;
+
+pub mod error_code {
+    pub const INVALID_REQUEST: &str = "invalid_request";
+    pub const VALIDATION_FAILED: &str = "validation_failed";
+    pub const CONSENT_REQUIRED: &str = "consent_required";
+    pub const ACTION_REQUIRED: &str = "action_required";
+    pub const DAEMON_UNAVAILABLE: &str = "daemon_unavailable";
+    pub const PROTOCOL_MISMATCH: &str = "protocol_mismatch";
+    pub const PROFILE_IN_USE: &str = "profile_in_use";
+    pub const AUTHORIZATION_FAILED: &str = "authorization_failed";
+    pub const NOT_FOUND: &str = "not_found";
+    pub const CONFLICT: &str = "conflict";
+    pub const IDEMPOTENCY_CONFLICT: &str = "idempotency_conflict";
+    pub const IDEMPOTENCY_EXPIRED: &str = "idempotency_expired";
+    pub const OPERATION_OUTCOME_UNKNOWN: &str = "operation_outcome_unknown";
+    pub const NETWORK_UNAVAILABLE: &str = "network_unavailable";
+    pub const TIMEOUT: &str = "timeout";
+    pub const INTERRUPTED: &str = "interrupted";
+    pub const INTERNAL_ERROR: &str = "internal_error";
+    pub const BACKPRESSURE: &str = "backpressure";
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RequestEnvelope {
+    pub protocol_version: u32,
+    pub request_id: String,
+    pub command: String,
+    pub profile: String,
+    #[serde(default = "empty_object")]
+    pub payload: Value,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub idempotency_key: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timeout_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub secret_bytes: Option<u64>,
+    #[serde(default)]
+    pub accepts_secret_output: bool,
+}
+
+impl RequestEnvelope {
+    pub fn timeout_ms(&self) -> Result<u64, ProtocolError> {
+        let timeout = self.timeout_ms.unwrap_or(DEFAULT_TIMEOUT_MS);
+        if timeout == 0 || timeout > MAX_TIMEOUT_MS {
+            return Err(ProtocolError::new(
+                error_code::VALIDATION_FAILED,
+                format!("timeout_ms must be between 1 and {MAX_TIMEOUT_MS}"),
+            ));
+        }
+        Ok(timeout)
+    }
+}
+
+fn empty_object() -> Value {
+    json!({})
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ResponseEnvelope {
+    pub schema_version: u32,
+    pub ok: bool,
+    pub command: String,
+    pub request_id: String,
+    pub profile: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<ErrorBody>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub secret_bytes: Option<u64>,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub more: bool,
+}
+
+impl ResponseEnvelope {
+    pub fn success(request: &RequestEnvelope, data: Value) -> Self {
+        Self {
+            schema_version: SCHEMA_VERSION,
+            ok: true,
+            command: request.command.clone(),
+            request_id: request.request_id.clone(),
+            profile: request.profile.clone(),
+            data: Some(data),
+            error: None,
+            secret_bytes: None,
+            more: false,
+        }
+    }
+
+    pub fn failure(request: &RequestEnvelope, error: ProtocolError) -> Self {
+        Self::failure_parts(
+            request.command.clone(),
+            request.request_id.clone(),
+            request.profile.clone(),
+            error,
+        )
+    }
+
+    pub fn failure_parts(
+        command: impl Into<String>,
+        request_id: impl Into<String>,
+        profile: impl Into<String>,
+        error: ProtocolError,
+    ) -> Self {
+        Self {
+            schema_version: SCHEMA_VERSION,
+            ok: false,
+            command: command.into(),
+            request_id: request_id.into(),
+            profile: profile.into(),
+            data: None,
+            error: Some(ErrorBody {
+                code: error.code,
+                message: error.message,
+                details: error.details,
+            }),
+            secret_bytes: None,
+            more: false,
+        }
+    }
+
+    pub fn error_code(&self) -> Option<&str> {
+        self.error.as_ref().map(|error| error.code.as_str())
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ErrorBody {
+    pub code: String,
+    pub message: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub details: Option<Value>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ProtocolError {
+    pub code: String,
+    pub message: String,
+    pub details: Option<Value>,
+}
+
+impl ProtocolError {
+    pub fn new(code: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            code: code.into(),
+            message: message.into(),
+            details: None,
+        }
+    }
+
+    pub fn with_details(mut self, details: Value) -> Self {
+        self.details = Some(details);
+        self
+    }
+}
+
+impl fmt::Display for ProtocolError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "{}: {}", self.code, self.message)
+    }
+}
+
+impl std::error::Error for ProtocolError {}
+
+pub struct SecretInput(Vec<u8>);
+
+impl SecretInput {
+    pub fn new(bytes: Vec<u8>) -> Self {
+        Self(bytes)
+    }
+
+    pub fn expose(&self) -> &[u8] {
+        &self.0
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+impl fmt::Debug for SecretInput {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("SecretInput")
+            .field("bytes", &"<redacted>")
+            .finish()
+    }
+}
+
+pub struct SecretOutput(Vec<u8>);
+
+impl SecretOutput {
+    pub fn new(bytes: Vec<u8>) -> Self {
+        Self(bytes)
+    }
+
+    pub fn expose(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl fmt::Debug for SecretOutput {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("SecretOutput")
+            .field("bytes", &"<redacted>")
+            .finish()
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CommandEffect {
+    Read,
+    Write,
+    Destructive,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GuardRequirement {
+    HostReady,
+    Account,
+    Consent,
+    Audience,
+    Credential,
+    DomainAuthorization,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct CommandMetadata {
+    pub name: String,
+    pub effect: CommandEffect,
+    pub secret_input: bool,
+    pub secret_output: bool,
+    pub idempotency_required: bool,
+    pub streaming: bool,
+    pub guards: Vec<GuardRequirement>,
+    pub input_schema: Value,
+    pub output_schema: Value,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct CommandPage {
+    pub items: Vec<CommandMetadata>,
+    pub next_cursor: Option<String>,
+}
+
+pub fn exit_code_for(error_code: &str) -> i32 {
+    match error_code {
+        error_code::INVALID_REQUEST | error_code::VALIDATION_FAILED => 2,
+        error_code::DAEMON_UNAVAILABLE
+        | error_code::PROTOCOL_MISMATCH
+        | error_code::PROFILE_IN_USE => 3,
+        error_code::CONSENT_REQUIRED
+        | error_code::ACTION_REQUIRED
+        | error_code::AUTHORIZATION_FAILED => 4,
+        error_code::NOT_FOUND
+        | error_code::CONFLICT
+        | error_code::IDEMPOTENCY_CONFLICT
+        | error_code::IDEMPOTENCY_EXPIRED
+        | error_code::OPERATION_OUTCOME_UNKNOWN => 5,
+        error_code::NETWORK_UNAVAILABLE | error_code::TIMEOUT | error_code::BACKPRESSURE => 6,
+        error_code::INTERRUPTED => 130,
+        _ => 1,
+    }
+}
+
+pub fn protocol_schema() -> Value {
+    json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": "https://kukuri.app/schema/cli-protocol-v1.json",
+        "title": "Kukuri CLI protocol v1",
+        "oneOf": [
+            {"$ref": "#/$defs/request"},
+            {"$ref": "#/$defs/response"}
+        ],
+        "$defs": {
+            "request": {
+                "type": "object",
+                "required": ["protocol_version", "request_id", "command", "profile", "payload"],
+                "properties": {
+                    "protocol_version": {"const": PROTOCOL_VERSION},
+                    "request_id": {"type": "string", "minLength": 1},
+                    "command": {"type": "string", "minLength": 1},
+                    "profile": {"type": "string", "minLength": 1},
+                    "payload": {"type": "object"},
+                    "idempotency_key": {"type": "string", "format": "uuid"},
+                    "timeout_ms": {"type": "integer", "minimum": 1, "maximum": MAX_TIMEOUT_MS},
+                    "secret_bytes": {"type": "integer", "minimum": 0, "maximum": MAX_FRAME_BYTES}
+                    ,"accepts_secret_output": {"type": "boolean"}
+                },
+                "additionalProperties": false
+            },
+            "response": {
+                "type": "object",
+                "required": ["schema_version", "ok", "command", "request_id", "profile"],
+                "properties": {
+                    "schema_version": {"const": SCHEMA_VERSION},
+                    "ok": {"type": "boolean"},
+                    "command": {"type": "string"},
+                    "request_id": {"type": "string"},
+                    "profile": {"type": "string"},
+                    "data": {},
+                    "error": {"$ref": "#/$defs/error"},
+                    "secret_bytes": {"type": "integer", "minimum": 0, "maximum": MAX_FRAME_BYTES}
+                    ,"more": {"type": "boolean"}
+                },
+                "additionalProperties": false
+            },
+            "error": {
+                "type": "object",
+                "required": ["code", "message"],
+                "properties": {
+                    "code": {"type": "string"},
+                    "message": {"type": "string"},
+                    "details": {}
+                },
+                "additionalProperties": false
+            }
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn success_and_error_envelopes_have_stable_shape() {
+        let request = RequestEnvelope {
+            protocol_version: PROTOCOL_VERSION,
+            request_id: "req-1".to_string(),
+            command: "client.status".to_string(),
+            profile: "default".to_string(),
+            payload: json!({}),
+            idempotency_key: None,
+            timeout_ms: None,
+            secret_bytes: None,
+            accepts_secret_output: false,
+        };
+        assert_eq!(
+            serde_json::to_value(ResponseEnvelope::success(&request, json!({"ready": true})))
+                .expect("success json"),
+            json!({
+                "schema_version": 1,
+                "ok": true,
+                "command": "client.status",
+                "request_id": "req-1",
+                "profile": "default",
+                "data": {"ready": true}
+            })
+        );
+        assert_eq!(
+            serde_json::to_value(ResponseEnvelope::failure(
+                &request,
+                ProtocolError::new(error_code::CONSENT_REQUIRED, "consent is required")
+            ))
+            .expect("error json"),
+            json!({
+                "schema_version": 1,
+                "ok": false,
+                "command": "client.status",
+                "request_id": "req-1",
+                "profile": "default",
+                "error": {"code": "consent_required", "message": "consent is required"}
+            })
+        );
+    }
+
+    #[test]
+    fn secret_debug_is_always_redacted() {
+        let sentinel = "do-not-print-this-secret";
+        let input = SecretInput::new(sentinel.as_bytes().to_vec());
+        let output = SecretOutput::new(sentinel.as_bytes().to_vec());
+        assert!(!format!("{input:?}").contains(sentinel));
+        assert!(!format!("{output:?}").contains(sentinel));
+    }
+
+    #[test]
+    fn exit_codes_are_stable_by_error_class() {
+        assert_eq!(exit_code_for(error_code::VALIDATION_FAILED), 2);
+        assert_eq!(exit_code_for(error_code::DAEMON_UNAVAILABLE), 3);
+        assert_eq!(exit_code_for(error_code::CONSENT_REQUIRED), 4);
+        assert_eq!(exit_code_for(error_code::IDEMPOTENCY_CONFLICT), 5);
+        assert_eq!(exit_code_for(error_code::TIMEOUT), 6);
+        assert_eq!(exit_code_for(error_code::INTERRUPTED), 130);
+        assert_eq!(exit_code_for(error_code::INTERNAL_ERROR), 1);
+    }
+
+    #[test]
+    fn protocol_schema_has_a_golden_digest() {
+        let encoded = serde_json::to_vec(&protocol_schema()).expect("schema JSON");
+        assert_eq!(
+            blake3::hash(&encoded).to_hex().as_str(),
+            "65554f6e72dd166cfdb2b8a0a0acd86233efdfff94ccfac89a1c67dac90cec0a",
+            "protocol v1 schema changed without an explicit version decision"
+        );
+    }
+}

--- a/crates/kukuri-cli/src/registry.rs
+++ b/crates/kukuri-cli/src/registry.rs
@@ -1,0 +1,604 @@
+use std::{collections::BTreeSet, sync::Arc};
+
+use async_trait::async_trait;
+use kukuri_desktop_runtime::{ClientEventReceiver, ClientHost};
+use serde::Deserialize;
+use serde_json::{Value, json};
+
+use crate::protocol::{
+    CommandEffect, CommandMetadata, CommandPage, DEFAULT_PAGE_LIMIT, GuardRequirement,
+    MAX_PAGE_LIMIT, ProtocolError, SecretInput, SecretOutput, error_code, protocol_schema,
+};
+
+pub struct HandlerContext<'a> {
+    pub registry: &'a CommandRegistry,
+    pub host: Option<&'a Arc<ClientHost>>,
+    pub profile: &'a str,
+}
+
+pub enum CommandOutput {
+    Unary(Value),
+    Secret { data: Value, secret: SecretOutput },
+    Events(ClientEventReceiver),
+}
+
+#[async_trait]
+pub trait CommandHandler: Send + Sync {
+    async fn execute(
+        &self,
+        context: HandlerContext<'_>,
+        payload: Value,
+        secret: Option<&SecretInput>,
+    ) -> Result<CommandOutput, ProtocolError>;
+}
+
+pub struct CommandRegistration {
+    pub metadata: CommandMetadata,
+    pub handler: Arc<dyn CommandHandler>,
+}
+
+impl CommandRegistration {
+    pub fn new(metadata: CommandMetadata, handler: Arc<dyn CommandHandler>) -> Self {
+        Self { metadata, handler }
+    }
+}
+
+pub struct CommandRegistry {
+    entries: Vec<CommandRegistration>,
+}
+
+impl CommandRegistry {
+    pub fn builtin() -> Self {
+        Self::new(vec![
+            registration(
+                "protocol.schema",
+                false,
+                Vec::new(),
+                Arc::new(ProtocolSchemaHandler),
+                empty_object_schema(),
+                json!({"type": "object"}),
+            ),
+            registration(
+                "protocol.commands",
+                false,
+                Vec::new(),
+                Arc::new(ProtocolCommandsHandler),
+                json!({
+                    "type": "object",
+                    "properties": {
+                        "cursor": {"type": "string"},
+                        "limit": {"type": "integer", "minimum": 1, "maximum": MAX_PAGE_LIMIT}
+                    },
+                    "additionalProperties": false
+                }),
+                json!({"type": "object"}),
+            ),
+            registration(
+                "client.status",
+                false,
+                Vec::new(),
+                Arc::new(ClientStatusHandler),
+                empty_object_schema(),
+                json!({"type": "object"}),
+            ),
+            registration(
+                "events.watch",
+                true,
+                vec![GuardRequirement::HostReady],
+                Arc::new(EventsWatchHandler),
+                empty_object_schema(),
+                json!({"type": "object"}),
+            ),
+        ])
+        .expect("builtin command registry must be valid")
+    }
+
+    pub fn new(mut entries: Vec<CommandRegistration>) -> Result<Self, ProtocolError> {
+        entries.sort_by(|left, right| left.metadata.name.cmp(&right.metadata.name));
+        let mut names = BTreeSet::new();
+        for entry in &entries {
+            validate_command_schema(&entry.metadata.input_schema, &entry.metadata.name)?;
+            if entry
+                .metadata
+                .input_schema
+                .get("type")
+                .and_then(Value::as_str)
+                .is_some_and(|kind| kind != "object")
+            {
+                return invalid_schema(
+                    &entry.metadata.name,
+                    "input root type must be object when specified",
+                );
+            }
+            validate_command_schema(&entry.metadata.output_schema, &entry.metadata.name)?;
+            if entry.metadata.name.trim().is_empty() || !names.insert(entry.metadata.name.clone()) {
+                return Err(ProtocolError::new(
+                    error_code::INTERNAL_ERROR,
+                    "command registry contains an empty or duplicate name",
+                ));
+            }
+            if matches!(
+                entry.metadata.effect,
+                CommandEffect::Write | CommandEffect::Destructive
+            ) && !entry.metadata.idempotency_required
+            {
+                return Err(ProtocolError::new(
+                    error_code::INTERNAL_ERROR,
+                    format!(
+                        "mutating command `{}` must require idempotency",
+                        entry.metadata.name
+                    ),
+                ));
+            }
+            if entry.metadata.streaming
+                && (entry.metadata.secret_input || entry.metadata.secret_output)
+            {
+                return Err(ProtocolError::new(
+                    error_code::INTERNAL_ERROR,
+                    format!(
+                        "streaming command `{}` cannot carry secret frames",
+                        entry.metadata.name
+                    ),
+                ));
+            }
+            if entry.metadata.secret_output && entry.metadata.effect != CommandEffect::Read {
+                return Err(ProtocolError::new(
+                    error_code::INTERNAL_ERROR,
+                    format!(
+                        "secret-output command `{}` must be read-only",
+                        entry.metadata.name
+                    ),
+                ));
+            }
+        }
+        Ok(Self { entries })
+    }
+
+    pub fn get(&self, name: &str) -> Option<&CommandRegistration> {
+        self.entries
+            .binary_search_by_key(&name, |entry| entry.metadata.name.as_str())
+            .ok()
+            .map(|index| &self.entries[index])
+    }
+
+    pub fn page(&self, cursor: Option<&str>, limit: u32) -> Result<CommandPage, ProtocolError> {
+        if limit == 0 || limit > MAX_PAGE_LIMIT {
+            return Err(ProtocolError::new(
+                error_code::VALIDATION_FAILED,
+                format!("limit must be between 1 and {MAX_PAGE_LIMIT}"),
+            ));
+        }
+        let start = match cursor {
+            Some(cursor) => self
+                .entries
+                .iter()
+                .position(|entry| entry.metadata.name == cursor)
+                .map(|index| index + 1)
+                .ok_or_else(|| {
+                    ProtocolError::new(error_code::VALIDATION_FAILED, "invalid command cursor")
+                })?,
+            None => 0,
+        };
+        let end = (start + limit as usize).min(self.entries.len());
+        let items = self.entries[start..end]
+            .iter()
+            .map(|entry| entry.metadata.clone())
+            .collect();
+        let next_cursor =
+            (end < self.entries.len()).then(|| self.entries[end - 1].metadata.name.clone());
+        Ok(CommandPage { items, next_cursor })
+    }
+
+    pub fn schema_document(&self) -> Value {
+        let commands = self
+            .entries
+            .iter()
+            .map(|entry| {
+                (
+                    entry.metadata.name.clone(),
+                    json!({
+                        "input": entry.metadata.input_schema,
+                        "output": entry.metadata.output_schema,
+                    }),
+                )
+            })
+            .collect::<serde_json::Map<_, _>>();
+        json!({
+            "protocol": protocol_schema(),
+            "commands": commands,
+        })
+    }
+
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+}
+
+fn validate_command_schema(schema: &Value, command: &str) -> Result<(), ProtocolError> {
+    let object = schema.as_object().ok_or_else(|| {
+        ProtocolError::new(
+            error_code::INTERNAL_ERROR,
+            format!("command `{command}` has a non-object schema"),
+        )
+    })?;
+    const SUPPORTED: &[&str] = &[
+        "type",
+        "properties",
+        "required",
+        "additionalProperties",
+        "items",
+        "enum",
+        "const",
+        "minimum",
+        "maximum",
+        "minLength",
+        "maxLength",
+        "minItems",
+        "maxItems",
+        "title",
+        "description",
+        "default",
+        "examples",
+    ];
+    if let Some(keyword) = object.keys().find(|key| !SUPPORTED.contains(&key.as_str())) {
+        return Err(ProtocolError::new(
+            error_code::INTERNAL_ERROR,
+            format!("command `{command}` uses unsupported schema keyword `{keyword}`"),
+        ));
+    }
+    if let Some(kind) = object.get("type")
+        && !matches!(
+            kind.as_str(),
+            Some("string" | "integer" | "number" | "boolean" | "object" | "array" | "null")
+        )
+    {
+        return invalid_schema(command, "type must name a supported JSON type");
+    }
+    let properties = match object.get("properties") {
+        Some(Value::Object(properties)) => Some(properties),
+        Some(_) => return invalid_schema(command, "properties must be an object"),
+        None => None,
+    };
+    if let Some(required) = object.get("required")
+        && !required
+            .as_array()
+            .is_some_and(|items| items.iter().all(Value::is_string))
+    {
+        return invalid_schema(command, "required must be an array of strings");
+    }
+    if object
+        .get("additionalProperties")
+        .is_some_and(|value| !value.is_boolean())
+    {
+        return invalid_schema(command, "additionalProperties must be a boolean");
+    }
+    if object.get("items").is_some_and(|value| !value.is_object()) {
+        return invalid_schema(command, "items must be an object schema");
+    }
+    if object
+        .get("enum")
+        .is_some_and(|value| value.as_array().is_none_or(|items| items.is_empty()))
+    {
+        return invalid_schema(command, "enum must be a non-empty array");
+    }
+    for keyword in ["minimum", "maximum"] {
+        if object.get(keyword).is_some_and(|value| !value.is_number()) {
+            return invalid_schema(command, &format!("{keyword} must be a number"));
+        }
+    }
+    if let (Some(minimum), Some(maximum)) = (
+        object.get("minimum").and_then(Value::as_f64),
+        object.get("maximum").and_then(Value::as_f64),
+    ) && minimum > maximum
+    {
+        return invalid_schema(command, "minimum must not exceed maximum");
+    }
+    for (minimum_key, maximum_key) in [("minLength", "maxLength"), ("minItems", "maxItems")] {
+        if object
+            .get(minimum_key)
+            .is_some_and(|value| value.as_u64().is_none())
+            || object
+                .get(maximum_key)
+                .is_some_and(|value| value.as_u64().is_none())
+        {
+            return invalid_schema(
+                command,
+                "length and item bounds must be non-negative integers",
+            );
+        }
+        if let (Some(minimum), Some(maximum)) = (
+            object.get(minimum_key).and_then(Value::as_u64),
+            object.get(maximum_key).and_then(Value::as_u64),
+        ) && minimum > maximum
+        {
+            return invalid_schema(command, "a minimum bound must not exceed its maximum");
+        }
+    }
+    for keyword in ["title", "description"] {
+        if object.get(keyword).is_some_and(|value| !value.is_string()) {
+            return invalid_schema(command, &format!("{keyword} must be a string"));
+        }
+    }
+    if object
+        .get("examples")
+        .is_some_and(|value| !value.is_array())
+    {
+        return invalid_schema(command, "examples must be an array");
+    }
+    if let Some(properties) = properties {
+        for property in properties.values() {
+            validate_command_schema(property, command)?;
+        }
+    }
+    if let Some(items) = object.get("items") {
+        validate_command_schema(items, command)?;
+    }
+    Ok(())
+}
+
+fn invalid_schema<T>(command: &str, message: &str) -> Result<T, ProtocolError> {
+    Err(ProtocolError::new(
+        error_code::INTERNAL_ERROR,
+        format!("command `{command}` schema is invalid: {message}"),
+    ))
+}
+
+fn registration(
+    name: &str,
+    streaming: bool,
+    guards: Vec<GuardRequirement>,
+    handler: Arc<dyn CommandHandler>,
+    input_schema: Value,
+    output_schema: Value,
+) -> CommandRegistration {
+    CommandRegistration::new(
+        CommandMetadata {
+            name: name.to_string(),
+            effect: CommandEffect::Read,
+            secret_input: false,
+            secret_output: false,
+            idempotency_required: false,
+            streaming,
+            guards,
+            input_schema,
+            output_schema,
+        },
+        handler,
+    )
+}
+
+fn empty_object_schema() -> Value {
+    json!({"type": "object", "additionalProperties": false})
+}
+
+struct ProtocolSchemaHandler;
+
+#[async_trait]
+impl CommandHandler for ProtocolSchemaHandler {
+    async fn execute(
+        &self,
+        context: HandlerContext<'_>,
+        _payload: Value,
+        _secret: Option<&SecretInput>,
+    ) -> Result<CommandOutput, ProtocolError> {
+        Ok(CommandOutput::Unary(context.registry.schema_document()))
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CommandsRequest {
+    #[serde(default)]
+    cursor: Option<String>,
+    #[serde(default = "default_page_limit")]
+    limit: u32,
+}
+
+fn default_page_limit() -> u32 {
+    DEFAULT_PAGE_LIMIT
+}
+
+struct ProtocolCommandsHandler;
+
+#[async_trait]
+impl CommandHandler for ProtocolCommandsHandler {
+    async fn execute(
+        &self,
+        context: HandlerContext<'_>,
+        payload: Value,
+        _secret: Option<&SecretInput>,
+    ) -> Result<CommandOutput, ProtocolError> {
+        let request: CommandsRequest = serde_json::from_value(payload).map_err(|error| {
+            ProtocolError::new(error_code::VALIDATION_FAILED, error.to_string())
+        })?;
+        let page = context
+            .registry
+            .page(request.cursor.as_deref(), request.limit)?;
+        Ok(CommandOutput::Unary(serde_json::to_value(page).map_err(
+            |_| ProtocolError::new(error_code::INTERNAL_ERROR, "failed to encode command page"),
+        )?))
+    }
+}
+
+struct ClientStatusHandler;
+
+#[async_trait]
+impl CommandHandler for ClientStatusHandler {
+    async fn execute(
+        &self,
+        context: HandlerContext<'_>,
+        _payload: Value,
+        _secret: Option<&SecretInput>,
+    ) -> Result<CommandOutput, ProtocolError> {
+        let data = match context.host {
+            Some(host) => {
+                let runtime = host.runtime();
+                json!({
+                    "ready": true,
+                    "consent_required": false,
+                    "profile": context.profile,
+                    "account_database": runtime
+                        .db_path()
+                        .file_name()
+                        .and_then(|value| value.to_str()),
+                })
+            }
+            None => json!({
+                "ready": false,
+                "consent_required": true,
+                "profile": context.profile,
+            }),
+        };
+        Ok(CommandOutput::Unary(data))
+    }
+}
+
+struct EventsWatchHandler;
+
+#[async_trait]
+impl CommandHandler for EventsWatchHandler {
+    async fn execute(
+        &self,
+        context: HandlerContext<'_>,
+        _payload: Value,
+        _secret: Option<&SecretInput>,
+    ) -> Result<CommandOutput, ProtocolError> {
+        let host = context.host.ok_or_else(|| {
+            ProtocolError::new(
+                error_code::CONSENT_REQUIRED,
+                "application consent is required",
+            )
+        })?;
+        Ok(CommandOutput::Events(host.subscribe_events()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builtin_registry_is_sorted_unique_and_introspectable() {
+        let registry = CommandRegistry::builtin();
+        assert_eq!(registry.len(), 4);
+        let page = registry.page(None, 2).expect("first page");
+        assert_eq!(page.items.len(), 2);
+        let second = registry
+            .page(page.next_cursor.as_deref(), 2)
+            .expect("second page");
+        assert_eq!(second.items.len(), 2);
+        assert!(second.next_cursor.is_none());
+        assert_eq!(
+            page.items
+                .iter()
+                .chain(&second.items)
+                .map(|item| item.name.as_str())
+                .collect::<Vec<_>>(),
+            vec![
+                "client.status",
+                "events.watch",
+                "protocol.commands",
+                "protocol.schema"
+            ]
+        );
+        for item in page.items.into_iter().chain(second.items) {
+            assert!(registry.get(&item.name).is_some());
+        }
+    }
+
+    #[test]
+    fn mutating_secret_output_is_rejected() {
+        let metadata = CommandMetadata {
+            name: "fixture.invalid".to_string(),
+            effect: CommandEffect::Write,
+            secret_input: false,
+            secret_output: true,
+            idempotency_required: true,
+            streaming: false,
+            guards: Vec::new(),
+            input_schema: empty_object_schema(),
+            output_schema: json!({"type": "object"}),
+        };
+        let error = CommandRegistry::new(vec![CommandRegistration::new(
+            metadata,
+            Arc::new(ProtocolSchemaHandler),
+        )])
+        .err()
+        .expect("invalid registry");
+        assert!(error.message.contains("read-only"));
+    }
+
+    #[test]
+    fn unsupported_schema_keywords_are_rejected_at_registration() {
+        let metadata = CommandMetadata {
+            name: "fixture.invalid-schema".to_string(),
+            effect: CommandEffect::Read,
+            secret_input: false,
+            secret_output: false,
+            idempotency_required: false,
+            streaming: false,
+            guards: Vec::new(),
+            input_schema: json!({"type": "object", "oneOf": []}),
+            output_schema: empty_object_schema(),
+        };
+        let error = CommandRegistry::new(vec![CommandRegistration::new(
+            metadata,
+            Arc::new(ProtocolSchemaHandler),
+        )])
+        .err()
+        .expect("unsupported schema");
+        assert!(error.message.contains("unsupported schema keyword"));
+
+        for schema in [
+            json!({"type": "unsupported"}),
+            json!({"type": "object", "required": "field"}),
+            json!({"type": "integer", "minimum": "10"}),
+            json!({"type": "array", "items": true}),
+        ] {
+            let metadata = CommandMetadata {
+                name: "fixture.invalid-schema".to_string(),
+                effect: CommandEffect::Read,
+                secret_input: false,
+                secret_output: false,
+                idempotency_required: false,
+                streaming: false,
+                guards: Vec::new(),
+                input_schema: schema,
+                output_schema: empty_object_schema(),
+            };
+            let error = CommandRegistry::new(vec![CommandRegistration::new(
+                metadata,
+                Arc::new(ProtocolSchemaHandler),
+            )])
+            .err()
+            .expect("malformed schema");
+            assert!(error.message.contains("schema is invalid"));
+        }
+    }
+
+    #[test]
+    fn input_root_schema_must_match_the_object_payload_contract() {
+        let metadata = CommandMetadata {
+            name: "fixture.non-object-input".to_string(),
+            effect: CommandEffect::Read,
+            secret_input: false,
+            secret_output: false,
+            idempotency_required: false,
+            streaming: false,
+            guards: Vec::new(),
+            input_schema: json!({"type": "string"}),
+            output_schema: json!({"type": "string"}),
+        };
+        let error = CommandRegistry::new(vec![CommandRegistration::new(
+            metadata,
+            Arc::new(ProtocolSchemaHandler),
+        )])
+        .err()
+        .expect("non-object input root");
+        assert!(error.message.contains("input root type must be object"));
+    }
+}

--- a/crates/kukuri-cli/tests/daemon_linux.rs
+++ b/crates/kukuri-cli/tests/daemon_linux.rs
@@ -486,9 +486,36 @@ fn connection_limit_returns_correlated_backpressure() {
     wait_for_ready(&mut daemon, &socket);
 
     let stalled = (0..64)
-        .map(|_| UnixStream::connect(&socket).expect("stalled connection"))
+        .map(|index| {
+            let mut stream = UnixStream::connect(&socket).expect("stalled connection");
+            stream
+                .set_read_timeout(Some(Duration::from_secs(5)))
+                .expect("stalled connection timeout");
+            writeln!(
+                stream,
+                "{}",
+                serde_json::json!({
+                    "protocol_version": 1,
+                    "request_id": format!("stalled-{index}"),
+                    "command": "events.watch",
+                    "profile": "alpha",
+                    "payload": {},
+                    "timeout_ms": 300_000,
+                    "accepts_secret_output": false
+                })
+            )
+            .expect("subscribe stalled connection");
+            let mut response = String::new();
+            BufReader::new(stream.try_clone().expect("clone stalled connection"))
+                .read_line(&mut response)
+                .expect("stalled subscription response");
+            let response: serde_json::Value =
+                serde_json::from_str(&response).expect("stalled subscription envelope");
+            assert_eq!(response["ok"], true);
+            assert_eq!(response["more"], true);
+            stream
+        })
         .collect::<Vec<_>>();
-    thread::sleep(Duration::from_millis(300));
     let output = call(
         root.path(),
         "alpha",

--- a/crates/kukuri-cli/tests/daemon_linux.rs
+++ b/crates/kukuri-cli/tests/daemon_linux.rs
@@ -2,7 +2,7 @@
 
 use std::{
     fs,
-    io::{BufRead, BufReader},
+    io::{BufRead, BufReader, Write},
     os::unix::ffi::OsStrExt,
     os::unix::{fs::PermissionsExt, net::UnixStream},
     path::{Path, PathBuf},
@@ -106,10 +106,10 @@ fn custom_socket_path(root: &Path, app_data_dir: &Path) -> PathBuf {
 }
 
 fn wait_for_ready(child: &mut Child, path: &Path) {
-    let stdout = child.stdout.take().expect("daemon stdout");
+    let stderr = child.stderr.take().expect("daemon stderr");
     let (sender, receiver) = mpsc::channel();
     thread::spawn(move || {
-        let mut reader = BufReader::new(stdout);
+        let mut reader = BufReader::new(stderr);
         let mut line = String::new();
         let result = reader.read_line(&mut line).map(|_| line);
         let _ = sender.send(result);
@@ -128,6 +128,14 @@ fn wait_for_ready(child: &mut Child, path: &Path) {
         path.display()
     );
     UnixStream::connect(path).expect("connect daemon socket");
+}
+
+fn call(root: &Path, profile: &str, args: &[&str]) -> std::process::Output {
+    cli_command(root, profile)
+        .arg("call")
+        .args(args)
+        .output()
+        .expect("run CLI call")
 }
 
 fn terminate(mut child: Child) {
@@ -305,4 +313,281 @@ fn custom_app_data_rejects_systemd_actions() {
         "{}",
         String::from_utf8_lossy(&output.stderr)
     );
+}
+
+#[test]
+fn protocol_status_registry_and_errors_are_machine_readable() {
+    let root = tempfile::tempdir().expect("tempdir");
+    fs::create_dir_all(root.path().join("runtime")).expect("runtime root");
+    fs::create_dir_all(root.path().join("home")).expect("home");
+
+    let usage = call(root.path(), "alpha", &[]);
+    assert_eq!(usage.status.code(), Some(2));
+    let usage: serde_json::Value =
+        serde_json::from_slice(&usage.stdout).expect("usage error envelope");
+    assert_eq!(usage["error"]["code"], "invalid_request");
+
+    let unavailable = call(root.path(), "alpha", &["client.status"]);
+    assert_eq!(unavailable.status.code(), Some(3));
+    let unavailable: serde_json::Value =
+        serde_json::from_slice(&unavailable.stdout).expect("unavailable envelope");
+    assert_eq!(unavailable["error"]["code"], "daemon_unavailable");
+
+    accept_consent(root.path(), "alpha");
+    let socket = socket_path(root.path(), "alpha");
+    let mut daemon = spawn_daemon(root.path(), "alpha");
+    wait_for_ready(&mut daemon, &socket);
+
+    let status = call(root.path(), "alpha", &["client.status"]);
+    assert!(
+        status.status.success(),
+        "{}",
+        String::from_utf8_lossy(&status.stderr)
+    );
+    assert_eq!(
+        status.stdout.iter().filter(|byte| **byte == b'\n').count(),
+        1
+    );
+    let status: serde_json::Value =
+        serde_json::from_slice(&status.stdout).expect("status envelope");
+    assert_eq!(status["schema_version"], 1);
+    assert_eq!(status["ok"], true);
+    assert_eq!(status["data"]["ready"], true);
+
+    let commands = call(root.path(), "alpha", &["protocol.commands"]);
+    assert!(commands.status.success());
+    let commands: serde_json::Value =
+        serde_json::from_slice(&commands.stdout).expect("commands envelope");
+    assert_eq!(
+        commands["data"]["items"].as_array().expect("items").len(),
+        4
+    );
+
+    let schema = call(root.path(), "alpha", &["protocol.schema"]);
+    assert!(schema.status.success());
+    let schema: serde_json::Value =
+        serde_json::from_slice(&schema.stdout).expect("schema envelope");
+    assert_eq!(
+        schema["data"]["protocol"]["$defs"]["request"]["type"],
+        "object"
+    );
+
+    let invalid_timeout = call(
+        root.path(),
+        "alpha",
+        &["client.status", "--timeout-ms", "0"],
+    );
+    assert_eq!(invalid_timeout.status.code(), Some(2));
+    let invalid_timeout: serde_json::Value =
+        serde_json::from_slice(&invalid_timeout.stdout).expect("timeout envelope");
+    assert_eq!(invalid_timeout["error"]["code"], "validation_failed");
+
+    let mismatch = call(
+        root.path(),
+        "alpha",
+        &["client.status", "--protocol-version", "99"],
+    );
+    assert_eq!(mismatch.status.code(), Some(3));
+    let mismatch: serde_json::Value =
+        serde_json::from_slice(&mismatch.stdout).expect("mismatch envelope");
+    assert_eq!(mismatch["error"]["code"], "protocol_mismatch");
+
+    let timeout = call(
+        root.path(),
+        "alpha",
+        &["events.watch", "--timeout-ms", "200"],
+    );
+    assert_eq!(timeout.status.code(), Some(6));
+    let timeout_line = String::from_utf8_lossy(&timeout.stdout)
+        .lines()
+        .last()
+        .expect("timeout envelope")
+        .to_string();
+    let timeout: serde_json::Value =
+        serde_json::from_str(&timeout_line).expect("parse timeout envelope");
+    assert_eq!(timeout["error"]["code"], "timeout");
+
+    let mut raw = UnixStream::connect(&socket).expect("raw protocol connection");
+    raw.set_read_timeout(Some(Duration::from_secs(1)))
+        .expect("read timeout");
+    writeln!(
+        raw,
+        "{}",
+        serde_json::json!({
+            "protocol_version": 1,
+            "request_id": "preflight-secret",
+            "command": "events.watch",
+            "profile": "alpha",
+            "payload": {},
+            "timeout_ms": 2000,
+            "secret_bytes": 64,
+            "accepts_secret_output": false
+        })
+    )
+    .expect("request header");
+    let mut line = String::new();
+    BufReader::new(raw)
+        .read_line(&mut line)
+        .expect("preflight response before secret body");
+    let preflight: serde_json::Value = serde_json::from_str(&line).expect("preflight envelope");
+    assert_eq!(preflight["error"]["code"], "validation_failed");
+
+    let standard_fd = call(
+        root.path(),
+        "alpha",
+        &["client.status", "--secret-output-fd", "1"],
+    );
+    assert_eq!(standard_fd.status.code(), Some(2));
+    let standard_fd: serde_json::Value =
+        serde_json::from_slice(&standard_fd.stdout).expect("standard FD rejection envelope");
+    assert_eq!(standard_fd["error"]["code"], "validation_failed");
+
+    let input_path = root.path().join("request.json");
+    fs::write(&input_path, b"{}").expect("request file");
+    fs::set_permissions(&input_path, fs::Permissions::from_mode(0o644))
+        .expect("public request permissions");
+    let public_input = call(
+        root.path(),
+        "alpha",
+        &[
+            "client.status",
+            "--input",
+            input_path.to_str().expect("input path"),
+        ],
+    );
+    assert_eq!(public_input.status.code(), Some(2));
+    fs::set_permissions(&input_path, fs::Permissions::from_mode(0o600))
+        .expect("private request permissions");
+    assert!(
+        call(
+            root.path(),
+            "alpha",
+            &[
+                "client.status",
+                "--input",
+                input_path.to_str().expect("input path"),
+            ],
+        )
+        .status
+        .success()
+    );
+
+    terminate(daemon);
+}
+
+#[test]
+fn connection_limit_returns_correlated_backpressure() {
+    let root = tempfile::tempdir().expect("tempdir");
+    fs::create_dir_all(root.path().join("runtime")).expect("runtime root");
+    fs::create_dir_all(root.path().join("home")).expect("home");
+    accept_consent(root.path(), "alpha");
+    let socket = socket_path(root.path(), "alpha");
+    let mut daemon = spawn_daemon(root.path(), "alpha");
+    wait_for_ready(&mut daemon, &socket);
+
+    let stalled = (0..64)
+        .map(|_| UnixStream::connect(&socket).expect("stalled connection"))
+        .collect::<Vec<_>>();
+    thread::sleep(Duration::from_millis(300));
+    let output = call(
+        root.path(),
+        "alpha",
+        &["client.status", "--timeout-ms", "2000"],
+    );
+    assert_eq!(output.status.code(), Some(6));
+    let response: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("backpressure envelope");
+    assert_eq!(response["error"]["code"], "backpressure");
+
+    drop(stalled);
+    terminate(daemon);
+}
+
+#[test]
+fn event_watch_sigint_returns_a_parseable_interrupted_error() {
+    let root = tempfile::tempdir().expect("tempdir");
+    fs::create_dir_all(root.path().join("runtime")).expect("runtime root");
+    fs::create_dir_all(root.path().join("home")).expect("home");
+    accept_consent(root.path(), "alpha");
+    let socket = socket_path(root.path(), "alpha");
+    let mut daemon = spawn_daemon(root.path(), "alpha");
+    wait_for_ready(&mut daemon, &socket);
+
+    let watcher = cli_command(root.path(), "alpha")
+        .args(["call", "events.watch"])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn event watch");
+    thread::sleep(Duration::from_millis(500));
+    let result = unsafe { libc::kill(watcher.id() as i32, libc::SIGINT) };
+    assert_eq!(result, 0, "send SIGINT");
+    let output = watcher.wait_with_output().expect("wait event watch");
+    assert_eq!(output.status.code(), Some(130));
+    let last = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .last()
+        .expect("interrupted envelope")
+        .to_string();
+    let response: serde_json::Value = serde_json::from_str(&last).expect("parse interrupted error");
+    assert_eq!(response["error"]["code"], "interrupted");
+
+    terminate(daemon);
+}
+
+#[test]
+fn secret_input_is_owner_only_and_never_echoed() {
+    let root = tempfile::tempdir().expect("tempdir");
+    fs::create_dir_all(root.path().join("runtime")).expect("runtime root");
+    fs::create_dir_all(root.path().join("home")).expect("home");
+    accept_consent(root.path(), "alpha");
+    let socket = socket_path(root.path(), "alpha");
+    let mut daemon = spawn_daemon(root.path(), "alpha");
+    wait_for_ready(&mut daemon, &socket);
+
+    let sentinel = "do-not-echo-secret-sentinel";
+    let secret_path = root.path().join("secret.txt");
+    fs::write(&secret_path, sentinel).expect("write secret");
+    fs::set_permissions(&secret_path, fs::Permissions::from_mode(0o600)).expect("protect secret");
+    let output = call(
+        root.path(),
+        "alpha",
+        &[
+            "client.status",
+            "--secret-input",
+            secret_path.to_str().expect("secret path"),
+        ],
+    );
+    assert_eq!(output.status.code(), Some(2));
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(!combined.contains(sentinel));
+    let response: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("secret rejection envelope");
+    assert_eq!(response["error"]["code"], "validation_failed");
+
+    fs::set_permissions(&secret_path, fs::Permissions::from_mode(0o644))
+        .expect("relax secret permissions");
+    let permission_error = call(
+        root.path(),
+        "alpha",
+        &[
+            "client.status",
+            "--secret-input",
+            secret_path.to_str().expect("secret path"),
+        ],
+    );
+    assert_eq!(permission_error.status.code(), Some(2));
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&permission_error.stdout),
+        String::from_utf8_lossy(&permission_error.stderr)
+    );
+    assert!(!combined.contains(sentinel));
+
+    terminate(daemon);
 }

--- a/docs/adr/0049-linux-gui-cli-control-plane.md
+++ b/docs/adr/0049-linux-gui-cli-control-plane.md
@@ -55,7 +55,7 @@ canonical sourceを変更しない。一方で、CLI profileの購読期待状�
 - Gossip Hint 必要有無: 不要
 - Blob 必要有無: 不要。大容量mediaはprotocolへbase64で埋め込まず、明示したローカルfile／blob参照を返す
 - SQLite projection 必要有無: 不要
-- 必須 contract: Unix socketのみ、runtime directory 0700、socket 0600、接続元UID一致、TCP listen 0件、版管理されたJSON／NDJSON、stdout／stderr分離、型付きerror、容量／timeout／backpressure上限、remote contentと制御情報の分離
+- 必須 contract: Unix socketのみ、runtime directory 0700、socket 0600、接続元UID一致、TCP listen 0件、版管理されたJSON／NDJSON、stdout／stderr分離、型付きerror、容量／timeout／backpressure上限、remote contentと制御情報の分離。v1は通常frameとsecret frameを各1 MiB以下、既定timeoutを30秒、指定可能な上限を5分、同時接続を64件以下とする。timeoutは接続、frame入出力、dispatcher、event stream全体へ適用する。stream継続はresponseの`more`で示す。secret frameはrequest headerのschema／profile／version／guardと出力先宣言を検証した後、相関付きの受信許可を返してからだけ送受信する
 - 必須 scenario: 正常／不正なenvelope、protocol不一致、常駐プロセス不在、timeout／SIGINT、低速な購読側、上限超過入力、接続元UID不一致、secret／untrusted contentの漏えい検査
 
 ### command登録簿と操作安全情報
@@ -69,7 +69,7 @@ canonical sourceを変更しない。一方で、CLI profileの購読期待状�
 - Gossip Hint 必要有無: 不要
 - Blob 必要有無: 不要
 - SQLite projection 必要有無: 不要
-- 必須 contract: read／write／destructive／secret-bearing／idempotency-required metadataをdispatcherと同じ定義から生成する。操作可否は既存のaccount、同意、audience、credential、domain authorizationで判定する
+- 必須 contract: read／write／destructive／secret-bearing／idempotency-required metadataをdispatcherと同じ定義から生成する。操作可否は既存のaccount、同意、audience、credential、domain authorizationで判定する。command schemaのv1検証subsetは`type`、`properties`、`required`、`additionalProperties`、`items`、`enum`、`const`、数値／文字列／配列のmin/max制約とannotationに限定し、未対応keywordは登録時に拒否する。request payloadの契約に合わせ、input schemaのroot `type`は未指定または`object`に限定する
 - 必須 scenario: command登録簿とdispatcherの不一致、既存domain authorizationによる許可／拒否、argv／payload／remote contentを制御情報として誤解釈しないこと
 
 ### 永続的な冪等性台帳
@@ -83,7 +83,7 @@ canonical sourceを変更しない。一方で、CLI profileの購読期待状�
 - Gossip Hint 必要有無: 不要
 - Blob 必要有無: 不要
 - SQLite projection 必要有無: 必要。profile内のSQLite台帳をcanonicalなlocal stateとして使い、domain SQLite projectionや共有replicaへ混ぜない
-- 必須 contract: command、profile、request idempotency key、canonical payload digestを結び、同一payloadの再実行／異なるpayloadとの競合／実行中停止による結果不明／保持期限切れを区別する。secret-bearing request／resultの平文copyは保存せず、既存domain resultへの参照または秘密情報を含まないresultだけを保持する
+- 必須 contract: command、profile、request idempotency key、canonical payload digestを結び、同一payloadの再実行／異なるpayloadとの競合／実行中停止による結果不明／保持期限切れを区別する。v1のkeyはUUIDv7、許容clock skewは5分、terminal recordは30日、profile／accountあたり最大10,000件とする。上限到達時は最古の完了済みrecordだけを整理し、未確定recordは自動削除しない。secret-bearing request／resultの平文copyは保存せず、secretを含む照合には台帳固有saltによるkeyed digestを使い、既存domain resultへの参照または秘密情報を含まないresultだけを保持する。backup復元時刻から許容clock skewまでの欠落keyは新規実行せず`operation_outcome_unknown`とし、それより未来のkeyは拒否する
 - 必須 scenario: 初回実行、同一payloadの再実行、異なるpayloadとの競合、commit前後の停止、restart、backup／restore、保持期限切れ、同時重複、secret-bearing mutation
 
 ## Decision

--- a/docs/progress/2026-09-05-issue-887-cli-protocol-v1.md
+++ b/docs/progress/2026-09-05-issue-887-cli-protocol-v1.md
@@ -10,6 +10,7 @@ Scope revisionは`2026-09-04-issue-887-cli-protocol-v1`。#886の共通`ClientHo
 - `CommandRegistry`の一つのentryにhandler、input/output schema、read／write／destructive、secret input/output、idempotency、stream、guard metadataを保持する。`protocol.schema`と`protocol.commands`はdispatcherと同じ登録簿だけを参照する。
 - dispatcherはdecode／schema validation、profile／version、command lookup、product guard、secret frame受信、idempotency claim、handlerの順で処理する。未同意時の`events.watch`はsecretを含むbodyの受信前に拒否し、`client.status`とintrospectionはruntimeを開始せず利用できる。domain guard evaluatorは注入可能な境界を持つ。
 - CLIの`call`は通常入力をstdin／owner-only file／FDから上限付きで受け、成功・失敗ともstdoutへJSONを一つ出す。event streamだけをNDJSONとし、responseの`more`で継続を判定する。SIGINT時も`interrupted` envelopeと終了code 130を返す。daemon不在、protocol mismatch、usage、invalid input、timeoutも型付きerrorへ変換する。
+- daemonはSIGINT／SIGTERM receiverをreadiness通知前に登録し、通知直後の停止要求も取りこぼさずgraceful shutdownする。
 - secretは通常JSON payloadとは別の長さ付きframeを通し、headerのpreflightに成功した相関付き受信許可後だけ送信する。専用の`SecretInput`／`SecretOutput`は通常の`Serialize`を実装せず、`Debug`を常にredactする。sourceはstdin／FD／owner-only file、sinkは事前宣言した標準FD以外のFD／新規0600 fileに限定する。secret出力commandはread-onlyとし、secret-bearing handlerのerror detailを外部へ出さず、secret outputと同じbytesを通常JSONへ含めず、stdout／stderr／ledgerへ平文を出さない。
 - profile／account／command／UUIDv7 key／canonical payload digestを結ぶ専用SQLite ledgerを追加した。mutationを直列化してin-progressを先にcommitし、同一payloadはsanitized resultを再生、異payloadは`idempotency_conflict`、未完了は`operation_outcome_unknown`とし、自動再実行しない。
 - secretを含むpayload照合はledger固有saltのkeyed BLAKE3 digestだけを保存する。terminal recordは30日、profile／accountごとに最大10,000件とし、上限到達時は最古の完了済みrecordだけを整理する。未確定recordは自動削除しない。
@@ -41,6 +42,7 @@ Scope revisionは`2026-09-04-issue-887-cli-protocol-v1`。#886の共通`ClientHo
 - Windows: `cargo test -p kukuri-desktop-runtime host::idempotency --lib`（9件成功）
 - Windows: `cargo test -p kukuri-desktop-runtime encrypted_device_backup_restores_one_account_as_one_file --lib`（成功）
 - Linux: `cargo test -p kukuri-cli`（38件成功）
+- Linux: readiness直後のSIGTERM／再起動境界test（10回連続成功）
 - Windows／Linux: 対象crateの`cargo clippy --all-targets -- -D warnings`（成功）
 - `cargo xtask check`、`cargo xtask test`、`cargo xtask e2e-smoke`、`cargo xtask oversized-files`、`git diff --check`（成功）
 - Risk Cの独立監査は、secret、guard順序、schema／dispatcher整合、接続上限、冪等性、backup／restore、#888との責務境界を再確認し、PASSと判定した。

--- a/docs/progress/2026-09-05-issue-887-cli-protocol-v1.md
+++ b/docs/progress/2026-09-05-issue-887-cli-protocol-v1.md
@@ -43,6 +43,7 @@ Scope revisionは`2026-09-04-issue-887-cli-protocol-v1`。#886の共通`ClientHo
 - Windows: `cargo test -p kukuri-desktop-runtime encrypted_device_backup_restores_one_account_as_one_file --lib`（成功）
 - Linux: `cargo test -p kukuri-cli`（38件成功）
 - Linux: readiness直後のSIGTERM／再起動境界test（10回連続成功）
+- Linux: 64接続の購読開始を確認した接続上限／backpressure境界test（5回連続成功）
 - Windows／Linux: 対象crateの`cargo clippy --all-targets -- -D warnings`（成功）
 - `cargo xtask check`、`cargo xtask test`、`cargo xtask e2e-smoke`、`cargo xtask oversized-files`、`git diff --check`（成功）
 - Risk Cの独立監査は、secret、guard順序、schema／dispatcher整合、接続上限、冪等性、backup／restore、#888との責務境界を再確認し、PASSと判定した。

--- a/docs/progress/2026-09-05-issue-887-cli-protocol-v1.md
+++ b/docs/progress/2026-09-05-issue-887-cli-protocol-v1.md
@@ -1,0 +1,46 @@
+# Issue #887 CLI protocol v1と安全なI/O
+
+## Scope
+
+Scope revisionは`2026-09-04-issue-887-cli-protocol-v1`。#886の共通`ClientHost`と認証済みUnix socketを利用し、版管理されたprotocol、command登録簿、dispatcher、安全なsecret I/O、durable idempotency ledgerを実装する。全domain commandのmappingは#888が所有するため、本Issueのproduction登録簿はprotocol introspection、client status、event streamに限定する。
+
+## 実装結果
+
+- `kukuri-cli`をlibrary／binary構成にし、protocol v1のrequest、success、error、stream envelope、安定error／exit code、JSON Schema、pagination、timeout、frame上限を共通型へ集約した。
+- `CommandRegistry`の一つのentryにhandler、input/output schema、read／write／destructive、secret input/output、idempotency、stream、guard metadataを保持する。`protocol.schema`と`protocol.commands`はdispatcherと同じ登録簿だけを参照する。
+- dispatcherはdecode／schema validation、profile／version、command lookup、product guard、secret frame受信、idempotency claim、handlerの順で処理する。未同意時の`events.watch`はsecretを含むbodyの受信前に拒否し、`client.status`とintrospectionはruntimeを開始せず利用できる。domain guard evaluatorは注入可能な境界を持つ。
+- CLIの`call`は通常入力をstdin／owner-only file／FDから上限付きで受け、成功・失敗ともstdoutへJSONを一つ出す。event streamだけをNDJSONとし、responseの`more`で継続を判定する。SIGINT時も`interrupted` envelopeと終了code 130を返す。daemon不在、protocol mismatch、usage、invalid input、timeoutも型付きerrorへ変換する。
+- secretは通常JSON payloadとは別の長さ付きframeを通し、headerのpreflightに成功した相関付き受信許可後だけ送信する。専用の`SecretInput`／`SecretOutput`は通常の`Serialize`を実装せず、`Debug`を常にredactする。sourceはstdin／FD／owner-only file、sinkは事前宣言した標準FD以外のFD／新規0600 fileに限定する。secret出力commandはread-onlyとし、secret-bearing handlerのerror detailを外部へ出さず、secret outputと同じbytesを通常JSONへ含めず、stdout／stderr／ledgerへ平文を出さない。
+- profile／account／command／UUIDv7 key／canonical payload digestを結ぶ専用SQLite ledgerを追加した。mutationを直列化してin-progressを先にcommitし、同一payloadはsanitized resultを再生、異payloadは`idempotency_conflict`、未完了は`operation_outcome_unknown`とし、自動再実行しない。
+- secretを含むpayload照合はledger固有saltのkeyed BLAKE3 digestだけを保存する。terminal recordは30日、profile／accountごとに最大10,000件とし、上限到達時は最古の完了済みrecordだけを整理する。未確定recordは自動削除しない。
+- 存在するidempotency ledgerをdevice backupへ含め、台帳を含まない旧backupでもrestore validation時に台帳とrestore markerを生成する。復元時刻から5分のclock skewまでに作成された欠落keyは新規mutationとして扱わず、それより未来のkeyも拒否する。socket、lock、PID、session、token、endpoint secretは従来どおりbackup対象外である。
+
+## 固定surfaceとtransitionの対応
+
+| ID | 実装／test |
+| --- | --- |
+| `INV-1` | `CallArgs`、bounded JSON／secret frame、stdin／file／FD、stdout envelope、exit-code test |
+| `INV-2` | `CommandRegistry`、`Dispatcher`、guard-before-handler test、Unix socket process test |
+| `INV-3` | `SecretInput`／`SecretOutput`、専用frame、0600 source/sink、sentinel leak test |
+| `INV-4` | `IdempotencyLedger`、mutation mutex、keyed canonical digest、replay／conflict／crash／restore test |
+| `INV-5` | `protocol.schema`／`protocol.commands`、registry uniqueness／pagination／metadata test |
+| `TR-1` | success／error envelope、invalid JSON／schema／command test |
+| `TR-2` | ready host statusとfixture mutation success test |
+| `TR-3` | consent guard拒否時のmutation counter 0件 test |
+| `TR-4` | durable same-key replay test |
+| `TR-5` | different-payload conflict、restart中in-progress、restore marker test |
+| `TR-6` | daemon unavailable、protocol mismatch、実timeout、SIGINT、oversized／partial frame、接続上限／backpressure処理 |
+
+## #888への境界
+
+#888は既存Tauri commandを複製せず、`CommandRegistration`へdomain handlerとv1対応subset内のDTO schemaを追加し、注入可能な非同期`GuardEvaluator`を既存product guardへ接続する。write／destructive commandはUUIDv7 idempotency keyを必須とし、secret-bearing commandは専用secret frameを使う。`apps/desktop/src-tauri/src/lib.rs`の登録と既存GUI result/error semanticsは#887では変更していない。
+
+## Validation
+
+- Windows: `cargo test -p kukuri-cli --lib`（21件成功）
+- Windows: `cargo test -p kukuri-desktop-runtime host::idempotency --lib`（9件成功）
+- Windows: `cargo test -p kukuri-desktop-runtime encrypted_device_backup_restores_one_account_as_one_file --lib`（成功）
+- Linux: `cargo test -p kukuri-cli`（38件成功）
+- Windows／Linux: 対象crateの`cargo clippy --all-targets -- -D warnings`（成功）
+- `cargo xtask check`、`cargo xtask test`、`cargo xtask e2e-smoke`、`cargo xtask oversized-files`、`git diff --check`（成功）
+- Risk Cの独立監査は、secret、guard順序、schema／dispatcher整合、接続上限、冪等性、backup／restore、#888との責務境界を再確認し、PASSと判定した。


### PR DESCRIPTION
## 概要

- 版管理されたJSON／NDJSON protocol v1、schema、command登録簿、dispatcherを追加
- secret専用frameと相関付き事前検証、owner-only file／FD、安全なerror処理を追加
- UUIDv7を使う永続的な冪等性台帳とbackup／restore整合を追加
- timeout、SIGINT、protocol不一致、接続上限／backpressureを型付きerrorへ統一

## 境界

- 基準commit: `41e97089b1c32d7e57571bfc34cac8f5b6e04e1f`
- 全domain commandのmappingと既存product guardへの接続は #888
- 既存Tauri command登録とGUIのresult／error semanticsは変更していません
- Risk Cの独立監査: PASS

## 検証

- `cargo xtask check`
- `cargo xtask test`（Rust 836件、harness 22件、frontend 1,093件）
- `cargo xtask e2e-smoke`
- `cargo xtask oversized-files`
- Linux `cargo test -p kukuri-cli`（38件）
- Windows／Linuxの対象crate `cargo clippy --all-targets -- -D warnings`
- `git diff --check`

Closes #887
