### PR TITLE
chore(release): prepare v0.2.0-preview.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3133,7 +3133,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-app-api"
-version = "0.1.8"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3164,7 +3164,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-blob-service"
-version = "0.1.8"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3182,7 +3182,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cli"
-version = "0.1.8"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3203,7 +3203,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-cli"
-version = "0.1.8"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3225,7 +3225,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-core"
-version = "0.1.8"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3259,7 +3259,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-e2e"
-version = "0.1.8"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3292,7 +3292,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-indexer"
-version = "0.1.8"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3322,7 +3322,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-iroh-relay"
-version = "0.1.8"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "iroh-relay",
@@ -3336,7 +3336,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-operator"
-version = "0.1.8"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -3353,7 +3353,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-protocol"
-version = "0.1.8"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "kukuri-cn-safety",
@@ -3366,14 +3366,14 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-runtime-support"
-version = "0.1.8"
+version = "0.2.0"
 dependencies = [
  "tracing-subscriber",
 ]
 
 [[package]]
 name = "kukuri-cn-safety"
-version = "0.1.8"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "kukuri-cn-safety",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-safety-arachnid"
-version = "0.1.8"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "kukuri-cn-safety",
@@ -3401,7 +3401,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-safety-runtime"
-version = "0.1.8"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3420,7 +3420,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-safety-vlm"
-version = "0.1.8"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -3436,7 +3436,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-trust"
-version = "0.1.8"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3450,7 +3450,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-user-api"
-version = "0.1.8"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -3486,7 +3486,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-core"
-version = "0.1.8"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "argon2",
@@ -3507,7 +3507,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-desktop-runtime"
-version = "0.1.8"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3546,7 +3546,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-docs-sync"
-version = "0.1.8"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3571,7 +3571,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-harness"
-version = "0.1.8"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -3598,7 +3598,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-iroh-node"
-version = "0.1.8"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -3617,7 +3617,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-metaverse-host"
-version = "0.1.8"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "kukuri-core",
@@ -3628,7 +3628,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-store"
-version = "0.1.8"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3645,7 +3645,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-test-support"
-version = "0.1.8"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "thiserror 2.0.20",
@@ -3654,7 +3654,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-transport"
-version = "0.1.8"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8104,7 +8104,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.1.8"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "base64 0.23.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 license = "MIT"
-version = "0.1.8"
+version = "0.2.0"
 
 [workspace.dependencies]
 anyhow = "1.0.104"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kukuri-desktop",
   "private": true,
-  "version": "0.1.8",
+  "version": "0.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -3849,7 +3849,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-app-api"
-version = "0.1.8"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3873,7 +3873,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-blob-service"
-version = "0.1.8"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3890,7 +3890,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-protocol"
-version = "0.1.8"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "kukuri-cn-safety",
@@ -3902,7 +3902,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-safety"
-version = "0.1.8"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "serde",
@@ -3912,7 +3912,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-core"
-version = "0.1.8"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "argon2",
@@ -3932,7 +3932,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-desktop-runtime"
-version = "0.1.8"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3961,7 +3961,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-desktop-tauri"
-version = "0.1.8"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "ashpd",
@@ -3991,7 +3991,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-docs-sync"
-version = "0.1.8"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4014,7 +4014,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-iroh-node"
-version = "0.1.8"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -4032,7 +4032,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-metaverse-host"
-version = "0.1.8"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "kukuri-core",
@@ -4043,7 +4043,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-store"
-version = "0.1.8"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4057,7 +4057,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-transport"
-version = "0.1.8"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kukuri-desktop-tauri"
-version = "0.1.8"
+version = "0.2.0"
 edition = "2024"
 default-run = "kukuri-desktop-tauri"
 

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "kukuri",
-  "version": "0.1.8",
+  "version": "0.2.0",
   "identifier": "app.kukuri.desktop",
   "build": {
     "beforeDevCommand": "npx pnpm@10.16.1 vite --host 127.0.0.1 --port 5173 --strictPort",

--- a/docs/progress/2026-09-07-v0.2.0-preview.1-release-rollout.md
+++ b/docs/progress/2026-09-07-v0.2.0-preview.1-release-rollout.md
@@ -1,0 +1,40 @@
+# v0.2.0-preview.1 公開・Community Node更新
+
+## Current status
+
+- In progress。2026-09-07に利用者が全クライアントのlatest Release、Community Node release、既存VM更新を明示依頼。
+- 基準main: `016b91588a1a82eb86f19b63397e9d6fedd94b62`。本体versionは既存規約の`0.2.0`、公開tagは`v0.2.0-preview.1`。
+- リスク区分C、Scope revision: `2026-09-07-v0.2.0-preview.1-release-rollout-v1`。
+- クライアントの固定AC／INVARと公開境界は#890＋#905を採用する。#905までの製品・実機・独立監査は不変部分の証拠として再利用する。
+
+## 完了条件と境界
+
+| ID | 条件 |
+| --- | --- |
+| AC-R1 | Windows NSIS、Linux AppImage／Deb、CLI x86_64／aarch64の5本体と署名・checksum・manifest・notice／必要sourceを同一sourceからlatest Releaseへ公開し、3 updater entriesと公開URLを検査する |
+| AC-R2 | 同一sourceのCommunity Node4 images（user-api／iroh-relay／cli／indexer）をversion tagで公開し、registry digest／OCI revisionを確認。latestも同sourceへ対応させる |
+| AC-R3 | VM更新前のbackup object／generation／size、旧4digestを保管し、Terraform差分をreview。意図しないVM／PD置換とデータ損失を避ける |
+| AC-R4 | 稼働digest／revision、startup、container／timer、readiness、公開API／relay／manifest、runbookのbenign media・truth／projection・非残留確認を完了する |
+| AC-R5 | version PR／CI／独立監査／公開／rollout証拠を対応付けて完了判定し、#890と親#885はそれぞれの条件を満たす場合だけCloseする |
+
+INVAR-R1: secret値をlog／artifact／argvへ出さない。INVAR-R2: 同source／version／digestと完全候補のみ公開、既存asset非置換。INVAR-R3: GUI／VMのidentity・DB・volume・PD・admission／安全性設定を保持。INVAR-R4: 失敗を成功扱いせず、旧digestとbackupを根拠に既存復旧手順を使う。DBを安易に上書きしない。
+
+対象外は新OS／arch、製品機能追加、secret rotate、公開範囲・権限変更、新サービス管理、DB／volume削除、無条件VM置換。同じtagの別run資材を混在させない。
+
+## 作業・検証
+
+| Task／inventory | 条件 | 入口→処理→sinkと検証 |
+| --- | --- | --- |
+| T1／INV-R1 | AC-R1/2 | version4入口・first-party locks→release-check／CI／delta監査→main／新tag。source・version不一致は公開前拒否 |
+| T2／INV-R2 | AC-R1 | 既存tag workflow→GUI/CLI署名・arch smoke・集約→完全draft→検証後latest。#890 INV1〜8＋#905 Deb差分を採用 |
+| T3／INV-R3 | AC-R2 | 同一sourceのimage workflow→GHCR4images→registryでdigest/revision確認。smoke用imageを本番digestにしない |
+| T4／INV-R4 | AC-R3 | 現revision／migration差分・backup→config/tfvars→plan review。未承認replaceで停止、metadata-onlyはrunbook限定in-place手順 |
+| T5／INV-R5 | AC-R4 | review済み更新→startup→readiness／public／live検証。失敗は旧digestとbackupで復旧判断 |
+| T6 | AC-R5／全INVAR | 最終source／資材／公開結果／VM差分を独立監査し、Issueと運用証拠へ集約。機密性のあるbackup／plan詳細は公開せずローカル運用記録に保持 |
+
+## 初期確認
+
+- 新tagはremoteに存在しないことを確認した。version4入口とCargo locksのfirst-party分だけを0.2.0へ同期し、`cargo xtask release-check v0.2.0-preview.1`はPASS（asset64filesも検査済み）。依存versionの更新は行っていない。
+- 既存low-cost VMはIAP経由で到達。主要containerは稼働し、backup／readiness／monitor／relation timersはactive、Docker領域は15GB空き。
+- 現稼働Community Node revisionは`29605af7882c06db6b2db7dd6dcae163ad088919`。新しい配布sourceとのmigration／設定差分を更新前に確認する。secret値、日常profile、DB内容は取得していない。
+- 公開・VM変更はまだ行っていない。運用結果、CI／監査、最終source／digestの根拠は本作業のIssueへ記録し、完了判定を追跡する。


### PR DESCRIPTION
Refs #907, #890.

## 範囲

利用者承認済みの`v0.2.0-preview.1`全クライアントlatest公開・Community Node release・既存VM更新に向け、本体version4入口とCargo locksのfirst-party分のみを`0.2.0`へ同期します。第三者依存・製品コード・公開／VM設定は変更しません。

Scope revision: `2026-09-07-v0.2.0-preview.1-release-rollout-v1`。区分C。固定AC／INVAR／inventoryと計画は [作業記録](docs/progress/2026-09-07-v0.2.0-preview.1-release-rollout.md) に集約しています。

`cargo xtask release-check v0.2.0-preview.1`はPASS（version4入口、asset64files）。version／lock差分の独立監査と必須CI成功後にmergeし、そのsourceへ新tagを固定します。公開・VM更新の成功は本PRのmergeだけでは判定せず、#907／#890で追跡します。

クライアント5本体・3 updater entriesとDeb更新の検証は#905、既存release pipelineは#890の不変部分の証拠を採用します。VMの現稼働sourceとの差分・backup・Terraform plan・稼働確認は既存production rollout runbookに従います。
