### PR TITLE
[codex][fix] Refresh libgcrypt before collecting matching release sources

### DIFF
--- a/.github/workflows/kukuri-linux-package.yml
+++ b/.github/workflows/kukuri-linux-package.yml
@@ -63,9 +63,11 @@ jobs:
       - name: Linux build dependencies
         run: |
           sudo apt-get update
+          # Refresh the runner's preinstalled libgcrypt too: superseded binary
+          # versions can outlive their exact source entry in the current APT index.
           sudo apt-get install -y pkg-config libdbus-1-dev libglib2.0-dev libgtk-3-dev \
             libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev patchelf \
-            libfuse2 file desktop-file-utils dbus binutils python3
+            libfuse2 libgcrypt20 file desktop-file-utils dbus binutils python3
       - uses: pnpm/action-setup@v4
         with:
           version: 10.16.1

--- a/docs/progress/2026-09-07-v0.2.0-preview.1-release-rollout.md
+++ b/docs/progress/2026-09-07-v0.2.0-preview.1-release-rollout.md
@@ -1,10 +1,10 @@
-# v0.2.0-preview.1 公開・Community Node更新
+# v0.2.0-preview 公開・Community Node更新
 
 ## Current status
 
-- In progress。2026-09-07に利用者が全クライアントのlatest Release、Community Node release、既存VM更新を明示依頼。
-- 基準main: `016b91588a1a82eb86f19b63397e9d6fedd94b62`。本体versionは既存規約の`0.2.0`、公開tagは`v0.2.0-preview.1`。
-- リスク区分C、Scope revision: `2026-09-07-v0.2.0-preview.1-release-rollout-v1`。
+- In progress。初回の全クライアントlatest公開・CN公開・VM更新依頼に加え、2026-09-07に利用者が配布修正後の`v0.2.0-preview.2`公開とCN／VMの同版への同期を承認。
+- 基準main: `73273ef5efbfaeaa26bbb6163dc9804410500553`。本体versionは`0.2.0`を維持し、新しい公開tagを`v0.2.0-preview.2`とする。既存`v0.2.0-preview.1`のGit／CN tagsは保持する。
+- リスク区分C、Scope revision: `2026-09-07-v0.2.0-preview.2-release-rollout-v2`。AC-R1〜5／INVAR-R1〜4は維持し、最終公開対象tagを更新する。
 - クライアントの固定AC／INVARと公開境界は#890＋#905を採用する。#905までの製品・実機・独立監査は不変部分の証拠として再利用する。
 
 ## 完了条件と境界
@@ -38,3 +38,31 @@ INVAR-R1: secret値をlog／artifact／argvへ出さない。INVAR-R2: 同source
 - 既存low-cost VMはIAP経由で到達。主要containerは稼働し、backup／readiness／monitor／relation timersはactive、Docker領域は15GB空き。
 - 現稼働Community Node revisionは`29605af7882c06db6b2db7dd6dcae163ad088919`。新しい配布sourceとのmigration／設定差分を更新前に確認する。secret値、日常profile、DB内容は取得していない。
 - 公開・VM変更はまだ行っていない。運用結果、CI／監査、最終source／digestの根拠は本作業のIssueへ記録し、完了判定を追跡する。
+
+## preview.1 の実施結果（当時の記録）
+
+- PR #908は全17checksと独立監査PASS後にmerge。source `73273ef5efbfaeaa26bbb6163dc9804410500553`と監査headのtree一致を確認し、`v0.2.0-preview.1`を作成した。
+- CN main／tagの4images公開、registry revision照合、既存VMのmetadata-only更新・fresh backup・migration・実検証・独立完了監査・検証用資材のcleanupは完了。VM／PDの置換なし。詳細は[#907のCN完了記録](https://github.com/KingYoSun/kukuri/issues/907#issuecomment-5567654508)。
+- クライアントRelease run `34094348428`はLinux対応source収集で失敗し、公開に到達しなかった。Windows／CLI／製品検証とAppImage／Deb本体smokeは成功。未完成Linux資材はupload・公開していない。
+- 原因はrunner既存`libgcrypt20=1.9.4-3ubuntu3.2`と現APT source indexの不一致。使い捨てJammy containerでもinstalled `.2`／candidate `.3`、source indexはbaseと`.3`のみ、exact `.2`取得不能を再現した。同じtag／sourceと既存guardで解決する既存再開入口がないことを独立確認し、次tagへの変更承認を得た。
+
+## preview.2 修正と再公開計画
+
+製品コード、Rust／npm依存、DB schema、署名・公開guardは変更しない。Linux workflowの既存依存installで`libgcrypt20`を明示要求し、既存の古い間接依存を現候補へ更新してからAppImageを作る。collectorは実同梱物に対応するexact source／DSC size・hash検証を維持する。全OSのupgradeやsource不一致の代替許可は行わない。
+
+| Task／surface／transition | 対応条件 | 変更・検証 |
+| --- | --- | --- |
+| T1a／INV-R2：runnerの旧間接依存→現候補→bundle→exact source | AC-R1、INVAR-R2/4 | `.github/workflows/kukuri-linux-package.yml`とworkflow contract。修正前失敗test、使い捨てJammyで`.2`→`.3`とexact source／DSC成功、source不一致の既存拒否testを維持 |
+| T1b／INV-R1：修正PR→CI／delta監査→main→新tag | AC-R1/2/5、INVAR-R1/2 | workflow／release contracts、Linux package CI、独立公開境界監査後merge。旧tag／旧資材は変更せず、新sourceへpreview.2を固定 |
+| T2/T3／INV-R2/3：新run→完全資材→公開 | AC-R1/2、INVAR-R1/2 | 全5本体・3 updater entriesの同一新runから署名／source／hashを確認しlatest公開。新CN versionとlatestも同sourceでregistry照合。workflow path filterによりmain CN buildが起きなければ既存dispatchを使用 |
+| T4/T5／INV-R4/5：既存preview.1 VM→preview.2 | AC-R3/4、INVAR-R3/4 | CNコード／migrationの不変deltaを確認して既存証拠を採用。fresh backup／plan review／非置換更新／稼働revision・readiness・public／必要なlive確認。旧3migrationの初回移行を反復しない |
+| T6 | AC-R5、全INVAR | 公開後検証と最終delta監査、#907／#890／親#885の条件別証拠とdocsを更新し、完了対象だけClose |
+
+必須validationは変更pathに限定したworkflow parser／release contracts、実APT再現のbefore/after、`release-check`、`git diff --check`と対象CI。製品コード不変のため、成功済みの製品全suite・初回CN法務migration／GUI更新実機matrixをローカルで全面反復しない。新Release workflowに組み込まれた製品検証はそのまま実行する。
+
+### 修正のtargeted validation
+
+- 追加workflow contract `test_linux_refreshes_preinstalled_libgcrypt_before_bundling`は修正前FAIL、明示install追加後PASS。既存署名secret／source固定／全platform必須の3 workflow testsもPASS。
+- 使い捨てJammyの実APT検証で、`libgcrypt20`だけを`.2`→`.3`へ更新（1 upgrade、0 new／remove、他55 packagesは未更新）。exact `.3` sourceの4 filesを取得し、既存`verify_dsc`でsource identity・size・SHA256を検証した。
+- Python release contractsは計24 tests PASS（assets、CLI archive、workflow、publisher、native compliance、public verifier、Deb）。PowerShellのWindows／Linux集約と署名ラッパーのcontractsもPASS。ラッパーstubの成功は最終資材の実署名検証の代替にはしない。
+- `cargo xtask release-check v0.2.0-preview.2`と`git diff --check`はPASS。package CI／修正headの独立監査／新tagの実Releaseは後続工程。

--- a/docs/runbooks/release.md
+++ b/docs/runbooks/release.md
@@ -87,6 +87,8 @@ Linux配布署名jobは最終AppImageのruntime inventoryを採取し、`native_
 
 収集は使い捨てCI runnerで`deb-src`を有効にして行う。開発端末のAPT設定を変える必要はない。取得・照合・notice生成の失敗時は配布packageを完成扱いにしない。`--verify-static-only`／`--verify-ubuntu-only`は部品検査で、公開条件を満たした結果ではない。最終archiveには対応source、patch、build／再リンク手順、共有libraryの差し替え手順を含める。詳細は[同梱物の引渡し条件](./linux-appimage-runtime-evidence.md)。
 
+runnerに既存の間接依存がある場合、依存packageのinstallだけではそのlibraryが更新されないことがある。Linux workflowは`libgcrypt20`も明示installし、現APT indexに対応する候補へ更新してからbundleを作る（#907）。exact sourceが取得できない場合は別版sourceで代替せず停止する。runner既存版とAPT候補／source indexを使い捨て環境で比較し、変更済みbundleを同一候補へ混在させない。
+
 ## Changelog
 
 `update-changelog.ps1`はprevious tagから対象tagまでのcommitを分類し、PRリンク付きsectionを作る。`changelog` jobは固定sourceをfull historyでcheckoutし、tag SHAを再照合する。`kukuri-changelog-section` artifactをRelease notesへ埋め込む。

--- a/scripts/release/test_release_workflow.py
+++ b/scripts/release/test_release_workflow.py
@@ -1,5 +1,6 @@
 """Check the actual workflow DAG and secret/source boundaries; no GitHub writes."""
 import pathlib
+import shlex
 import unittest
 
 import yaml
@@ -13,6 +14,16 @@ def workflow(name):
 
 
 class WorkflowTests(unittest.TestCase):
+    def test_linux_refreshes_preinstalled_libgcrypt_before_bundling(self):
+        steps = workflow("kukuri-linux-package.yml")["jobs"]["linux-appimage"]["steps"]
+        dependencies = next(step for step in steps if step.get("name") == "Linux build dependencies")
+        bundle = next(step for step in steps if step.get("name") == "Build and verify AppImage and Deb")
+        self.assertLess(steps.index(dependencies), steps.index(bundle))
+        commands = dependencies["run"].replace("\\\n", " ").splitlines()
+        installs = [shlex.split(command) for command in commands if command.strip().startswith("sudo apt-get install ")]
+        self.assertTrue(any("libgcrypt20" in command and "--no-upgrade" not in command for command in installs),
+                        "refresh the runner's preinstalled libgcrypt20 before collecting exact matching source")
+
     def test_publish_requires_every_platform_and_validation(self):
         jobs = workflow("kukuri-release.yml")["jobs"]
 


### PR DESCRIPTION
## 対象

Refs #907, #890

Scope revision: `2026-09-07-v0.2.0-preview.2-release-rollout-v2`。リスク区分C（配布・署名／公開境界）。利用者は既存preview.1 tagsを保持し、修正後をpreview.2で全クライアント・CN・VMへ揃える方針を承認済みです。

## 不具合と最小修正

旧Release run34094348428のLinux job101667195772は、同梱済みlibgcrypt20=1.9.4-3ubuntu3.2に対応するsourceを現APT indexから取得できず失敗しました。使い捨てJammyでもinstalled `.2`／candidate `.3`、source indexに旧`.2`なしを再現しています。

既存のLinuxビルド依存installに`libgcrypt20`を明示し、runnerに既存の古い間接依存を現候補へ更新してからbundleを作ります。OS全体のupgrade、別版sourceによる代替、collector／署名／publisher guardの緩和はありません。

4変更path: Linux workflow、workflow regression contract、release runbook、既存rollout progress。製品コード・Rust/npm依存・schema・keys・CN設定は不変。

## AC／INVAR・surface

AC-R1、INVAR-R2/4: runner旧依存→明示更新→bundle→exact source。登録点はLinux workflowのPR/reusable/dispatch共通jobで、配布鍵は既存event/signing guardの内側です。source collectorからpublisherまでの拒否境界は不変です。inventory／全T1〜T6と残る公開・CN／VM工程は [rollout記録](https://github.com/KingYoSun/kukuri/blob/e10895bb18918fd77fa8fcd7ded2f1f68ffd1518/docs/progress/2026-09-07-v0.2.0-preview.1-release-rollout.md) に集約しています。

## 検証

- 新workflow regression: 修正前FAIL→修正後PASS。workflow全4tests PASS。
- 実APT before/after: libgcrypt20だけ`.2`→`.3`、1upgrade/0new/0remove/他55未更新。exact source4filesを取得し既存verify_dscのidentity/size/SHA256 PASS。
- Python release contracts計24tests PASS（assets/CLI/workflow/publisher/native/public verifier/Deb）。
- PowerShell Windows/Linux集約・署名ラッパーcontracts PASS。実資材の署名検証は新Release runで別に実施します。
- release-check v0.2.0-preview.2、git diff --check PASS。
- package CIとPR head独立delta監査は実行待ち。製品全suiteのローカル重複は行わず、既存CIと新Release workflowの検証は維持します。

このPRだけで公開完了とはしません。全CI＋独立監査PASS後にmergeし、新tag/sourceから全資材を作り直します。既存tag/assetの置換や旧run資材混在は禁止。Issueは実公開／VM同期／最終検証の後で条件別にCloseします。
