### PR TITLE
fix(release): preserve successful smoke exit in CI

### DIFF
--- a/docs/progress/2026-09-07-v0.2.0-preview.1-release-rollout.md
+++ b/docs/progress/2026-09-07-v0.2.0-preview.1-release-rollout.md
@@ -66,3 +66,13 @@ INVAR-R1: secret値をlog／artifact／argvへ出さない。INVAR-R2: 同source
 - 使い捨てJammyの実APT検証で、`libgcrypt20`だけを`.2`→`.3`へ更新（1 upgrade、0 new／remove、他55 packagesは未更新）。exact `.3` sourceの4 filesを取得し、既存`verify_dsc`でsource identity・size・SHA256を検証した。
 - Python release contractsは計24 tests PASS（assets、CLI archive、workflow、publisher、native compliance、public verifier、Deb）。PowerShellのWindows／Linux集約と署名ラッパーのcontractsもPASS。ラッパーstubの成功は最終資材の実署名検証の代替にはしない。
 - `cargo xtask release-check v0.2.0-preview.2`と`git diff --check`はPASS。package CI／修正headの独立監査／新tagの実Releaseは後続工程。
+
+## preview.2 の実行と集約工程の再開
+
+- PR #909は全3checksと独立delta監査PASS後にmerge。監査headとmerge treeの一致を確認し、source `af2cf56b52e1d2802ac92af6b99090e260dfc48d`へ新tag `v0.2.0-preview.2`を固定した。Fast run `34109293103`は全9jobs PASS。
+- CN version run `34109293494`／latest run `34109296047`は全4images PASS。registryの8参照は同sourceのOCI revision。VMはクライアント完全候補の確認まで、検証済みpreview.1を保持する。
+- Release run `34109294504`は全platform build、Linux製品検証、native対応source収集、署名verifier生成、changelogに成功。集約job `101731701618`の最初のPowerShell smoke呼出しで停止し、元CIの結論はFAIL、publishは未実行。
+- Linux fixtureは改変資材を期待どおり拒否し、全assertionが成功していたが、残った`LASTEXITCODE=1`をGitHub wrapperが引き継いだ。CI相当の呼出しを追加した`test_asset_smoke_reports_success_to_the_ci_pwsh_wrapper`は修正前FAIL。Linux smokeの全assertion／cleanup後に`exit 0`を追加して5 workflow tests PASSとなった。実検証の拒否条件は変えていない。
+- T2／INV-R2、AC-R1、INVAR-R2/4内の再実行として独立限定確認を実施。未変更のWindows／Linux集約smokeを独立`pwsh -File`で実行し、ともに全assertionとexit0を確認。未実行だったthird-party notices smokeもPASS。元CIを成功扱いせず、残る集約・実署名・完全draft・公開後検証は固定sourceの未変更scriptと同一run資材で実行する。tag移動、別run混在、再署名、guard免除は行わない。
+
+再発修正の対象pathはLinux smoke、workflow回帰test、本runbookと作業記録のみ。callerはRelease集約job／Release Contracts／runbookの手動検証。正常完了→exit0、assertion失敗→例外／非0の境界を保ち、製品・実資材集約・署名・publisher・source collectorには変更しない。修正PRのCIと独立delta監査、最終公開候補の実検証は別々に記録する。

--- a/docs/runbooks/release.md
+++ b/docs/runbooks/release.md
@@ -45,6 +45,8 @@ python scripts/release/test_verify_public_preview.py
 
 `Kukuri Release Contracts`は上記にworkflowの構文・guard検査を加える（PyYAML 6.0.3）。ラッパーfixtureはroutingの検査で、実署名検証の代替ではない。
 
+期待するnative commandの失敗を捕捉するPowerShell smokeは、全assertionとcleanupの後に成功終了を明示する。GitHubの`pwsh` wrapperは残った`LASTEXITCODE`を終了値に使うため、成功メッセージだけで合格とせず、同じ呼出しとfooterを回帰testで検査する。
+
 ## Workflowとsource固定
 
 1. 承認したsourceに新しいtagを作成・pushする。tag pushは既定でdraftまで。
@@ -106,6 +108,8 @@ python scripts/release/publish_preview.py --input <same-run-assets> --tag v0.1.8
 ```
 
 公開承認後に同じcommandの`--draft false`で公開する。`GH_TOKEN`は環境変数で供給し、引数や記録へ値を書かない。公開前に同一候補の実署名検証成功が必要。build／smoke／署名／完全性の失敗を手動公開で迂回しない。
+
+全platform buildが成功し資材が揃っていても、集約前の呼出しwrapperで停止した場合は原因を切り分ける。wrapperだけの終了値誤判定と独立確認できた場合、未変更smokeを独立した`pwsh -NoProfile -File <script>`で再実行し、全assertionと終了値0を要求する。その後、未実行工程を固定sourceの未変更scriptと同一runの全platform／changelog／verifier資材だけで完遂する。verifierのsource一致、3entryの実署名・改変拒否、完全性・upload digest・公開後検証は省略しない。元CIのFAILは保持し、ローカル再実行の結果を工程別に記録する。実buildや検証assertionの失敗にはこの扱いを適用しない。
 
 ```powershell
 ./scripts/release/test-published-updater-signature.ps1 -Tag v0.1.8-preview.2 -Platforms windows-x86_64,linux-x86_64,linux-x86_64-deb -InputDir <same-run-assets> -PublicKeyFile <same-run-assets>/windows-x86_64-updater-key.pub

--- a/scripts/release/test-create-preview-assets-linux.ps1
+++ b/scripts/release/test-create-preview-assets-linux.ps1
@@ -94,3 +94,7 @@ try {
   if (-not $resolved.StartsWith($tempRoot, [StringComparison]::OrdinalIgnoreCase)) { throw 'Unsafe cleanup path' }
   if (Test-Path -LiteralPath $resolved) { Remove-Item -LiteralPath $resolved -Recurse -Force }
 }
+
+# The expected native-command rejection leaves LASTEXITCODE=1. Report success
+# only after every assertion and cleanup completed, including when called by CI.
+exit 0

--- a/scripts/release/test_release_workflow.py
+++ b/scripts/release/test_release_workflow.py
@@ -1,6 +1,7 @@
 """Check the actual workflow DAG and secret/source boundaries; no GitHub writes."""
 import pathlib
 import shlex
+import subprocess
 import unittest
 
 import yaml
@@ -14,6 +15,17 @@ def workflow(name):
 
 
 class WorkflowTests(unittest.TestCase):
+    def test_asset_smoke_reports_success_to_the_ci_pwsh_wrapper(self):
+        result = subprocess.run([
+            "pwsh", "-NoProfile", "-Command",
+            "$ErrorActionPreference = 'Stop'; "
+            "& ./scripts/release/test-create-preview-assets.ps1; "
+            "& ./scripts/release/test-create-preview-assets-linux.ps1; "
+            "if (Test-Path variable:\\LASTEXITCODE) { exit $LASTEXITCODE }",
+        ], cwd=ROOT, capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=120)
+        self.assertIn("Linux + Windows assembly contracts passed", result.stdout)
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
     def test_linux_refreshes_preinstalled_libgcrypt_before_bundling(self):
         steps = workflow("kukuri-linux-package.yml")["jobs"]["linux-appimage"]["steps"]
         dependencies = next(step for step in steps if step.get("name") == "Linux build dependencies")


### PR DESCRIPTION
## 対象
Refs #907, Refs #890
Scope revision: 2026-09-07-v0.2.0-preview.2-release-rollout-v2 / risk C

## 原因と修正
Release run34109294504の全platform build／native source収集は成功しましたが、集約前smokeの期待するnative rejectionがLASTEXITCODE=1を残しGitHub pwsh wrapperへ伝播しました。全assertionとcleanup後にexit0を明示し、CI相当wrapperの回帰testで修正前FAIL→修正後PASSを確認しました。

対象4path: Linux smoke／workflow回帰test／release runbook／既存progress。callerはRelease集約、Release Contracts、runbookの手動検証。正常完了→exit0、assertion失敗→例外／非0を保持。AC-R1/5、INVAR-R2/4、T2/INV-R2に対応します。製品、集約、collector、実署名、publisherは無変更、固定release source af2cf56b52e1d2802ac92af6b99090e260dfc48d／tagは移動しません。

## 検証
- 追加test修正前FAIL、修正後workflow5tests PASS
- 未変更Windows/Linux smokeの独立pwsh -Fileで全assertion／exit0 PASS
- 未実行だったthird-party notices smoke PASS
- git diff --check PASS
- CI／head独立delta監査は後続

元CI FAILは保持し、同runの未変更signed資材で未実行工程を完遂するローカル再実行を別記録します。署名／source／完全性の検証省略はありません。詳細はdocs/progress/2026-09-07-v0.2.0-preview.1-release-rollout.md。製品code不変のため製品全suiteの重複実行はしません。