### PR TITLE
docs: complete preview.2 release and VM rollout records

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -11,12 +11,12 @@ kukuri は、興味のある話題から人やコミュニティにつながる�
 > [!IMPORTANT]
 > 現在の kukuri は、テスター向けの **Builder Preview** です。一般公開の安定版ではありません。
 
-**[最新の Windows プレビューをダウンロード](https://github.com/KingYoSun/kukuri/releases/latest)**
+**[最新の Windows／Linux プレビューをダウンロード](https://github.com/KingYoSun/kukuri/releases/latest)**
 
 | 環境 | 現在の対応状況 |
 | --- | --- |
 | Windows 10 / 11 | 最新の GitHub Release から NSIS インストーラーを配布 |
-| Linux | AppImage／Deb（x86_64）、CLI（x86_64・aarch64）は対象Releaseの成果物一覧を確認。未公開の場合はソースから起動 |
+| Linux | AppImage／Deb（x86_64）、CLI（x86_64・aarch64）を[v0.2.0-preview.2](https://github.com/KingYoSun/kukuri/releases/tag/v0.2.0-preview.2)で同時公開 |
 | macOS | 現在パッケージは未提供 |
 
 プレビューのインストーラーは未署名の場合があります。その場合は Windows SmartScreen の警告が表示されることがあるため、実行前にリリースノートを確認してください。

--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ kukuri is a topic-first P2P social app. Find a topic you care about, join a publ
 > [!IMPORTANT]
 > kukuri is currently a **Builder Preview for testers**, not a stable general release.
 
-**[Download the latest Windows Preview](https://github.com/KingYoSun/kukuri/releases/latest)**
+**[Download the latest Windows / Linux Preview](https://github.com/KingYoSun/kukuri/releases/latest)**
 
 | Platform | Current support |
 | --- | --- |
 | Windows 10 / 11 | NSIS installer from the latest GitHub Release |
-| Linux | AppImage / Deb (x86_64), CLI (x86_64, aarch64): check the selected Release's assets; use source-run if not yet published |
+| Linux | AppImage / Deb (x86_64), CLI (x86_64, aarch64), published together in [v0.2.0-preview.2](https://github.com/KingYoSun/kukuri/releases/tag/v0.2.0-preview.2) |
 | macOS | No package is currently provided |
 
 Preview installers may be unsigned. Windows SmartScreen can therefore show a warning; check the release notes before running the installer.

--- a/docs/progress/2026-09-07-issue-890-linux-release-integration.md
+++ b/docs/progress/2026-09-07-issue-890-linux-release-integration.md
@@ -2,8 +2,8 @@
 
 ## 現在の判定
 
-- 実装中。Scope revision `2026-09-07-issue-890-linux-release-integration-v2`、区分C。
-- 基準commit `fe156251e400ea6d0bc83384683bdd0b343b5e57`。承認済みのコミット・PR・CI／独立監査後マージまで進める。実Releaseのversion／tag／公開範囲は未確定で、公開済みとはしない。
+- 実装・公開の検証完了。現Scope revision `2026-09-07-issue-890-linux-release-integration-v4`、区分C。以下の実装時の記録は当時の結果として保持する。
+- 実装merge `c4616fc706b94150ac6c2ac06aec68bc1c2b0f5a`（PR #904）、Deb追加`016b91588a1a82eb86f19b63397e9d6fedd94b62`（PR #906）。公開source `af2cf56b52e1d2802ac92af6b99090e260dfc48d`から[v0.2.0-preview.2](https://github.com/KingYoSun/kukuri/releases/tag/v0.2.0-preview.2)をlatest公開し、WindowsとLinux4本体を含む全21資材を確認した。
 - 条件・INV-1〜8／TR-1〜7は[Issue #890](https://github.com/KingYoSun/kukuri/issues/890)。#889の実機・CI・監査を再利用し、全OS連携の再検証はしない。
 
 ## 変更境界と修正前の事実
@@ -53,3 +53,32 @@
 - 公開／署名／集約: PR実装PASS。担当7 groupは適合7・不適合0・未分類0。Python13 tests、PowerShell集約／wrapperに加え、upload digest不一致・upload中tag移動・公開済み不完全Releaseでも公開PATCH 0回を確認。blocker 0。
 - native source／CLI／文書: 実装コードPASS。static31件、Ubuntu94 source packages／303構成filesを独立再照合し、runtime inventoryとの差集合0。x86_64実archive smoke成功。固定headのrelease runbookに非実在command名1件があり、文書を含む判定はFAIL（6 group中適合5・不適合1・未分類0）。両OS共通の`cargo xtask desktop-package`へ統一する1行deltaを独立確認しPASS、修正後は適合6・不適合0・未分類0。
 - 監査後の変更は上記文書1行と本記録のみ。コードsurfaceは固定headと同じ。後続headの差分一致をPR commentへ記録する。CI未完了・aarch64実行未確認・実配布署名／公開未実施は留保し、Issue完了PASSとは区別する。
+
+## 最終公開証拠（v0.2.0-preview.2）
+
+詳細は[全体公開・VM記録](2026-09-07-v0.2.0-preview.1-release-rollout.md)。旧留保のうち、最終署名・native source・aarch64実行・公開は次で解消した。
+
+| 条件／inventory／transition | 最終証拠 |
+| --- | --- |
+| AC-1・6、INVAR-1・2、INV-2/5/6/7、TR-1/6 | Release `384062770`、全21files、5本体、Windows／AppImage／Debの3manifest entries。source・version・hash・鍵一致、公開後stable manifestと5本体／checksum／provenanceの実download照合PASS |
+| AC-2〜4、INVAR-4、INV-2/4/8、TR-1/3/7 | Release run `34109294504`のLinux製品検証、Windows／Linux package、CLI x86_64／aarch64の実archive・schema／専用daemon smoke成功。AppImage／Deb更新・保持は#889/#905の不変surface証拠を採用 |
+| AC-1・5・6、INV-5/7、TR-5/6 | 同runの実verifierで3形式の正常bytes受理と1byte改変拒否。Ubuntu92 exact sourcesの297files、static31filesの実archiveとhashを独立照合。Deb payloadと外側runtimeの対応もPASS |
+| AC-4・8、全INVAR、INV-1/3/5/6、TR-2/4/5 | 既存入力／secret／欠落・改変／禁止publish tests維持。Fast `34109293103`全9jobs PASS、PR #909と#911はCI・独立監査PASS。集約smokeの終了値誤判定だけを同source／同runで再実行し、全検証成功前に公開していない。元Release CIのFAILは保持 |
+| AC-7、INV-8、TR-7 | README en／ja・quickstart・Linux CLIを実公開状態へ同期。CLI専用profile／foreground開始・status・schema・終了の例と未確認OS条件は維持 |
+
+最終候補の独立監査は6群すべて適合、不適合0／未分類0／blocker0。親#885の条件はこの公開だけで自動完了とせず、子の実装・監査・承認済みsupport範囲を別途対応付ける。
+
+## 親 #885 の統合証拠
+
+親条件を子のCloseだけで判定せず、別担当が各最終headとmergeのtree一致、公開sourceの祖先であること、以下の契約・検証を独立確認した。親INV-1〜5／TR-1〜7は未分類0、具体的な製品・公開blocker0。
+
+| 親条件 | 子・実装・採用証拠 |
+| --- | --- |
+| AC-1 | #886／PR #897、merge `41e97089`。共通host、profile単一owner、同意前非起動、restart／shutdown境界 |
+| AC-2 | #887／PR #898、merge `6f89fae0`のprotocol／安全なI/Oと、#888／PR #901、merge `a1c2696b`の承認済み台帳撤去・1入力1実行。旧idempotency台帳を現条件へ戻さない |
+| AC-3 | #888／PR #901。131対象と理由付き除外、78tests、実CLI／複数daemon／public・private・DM・Live・Game・Domeの独立監査 |
+| AC-4 | #889／PR #903、merge `fe156251`。Ubuntu22.04 build、Ubuntu24.04代表実機、自動境界tests。追加Ubuntu22.04／Debian12実機・XWaylandは2026-09-06利用者回答と#889 AC-2の延期を維持。Debは追加承認された#905／PR #906を採用 |
+| AC-5 | #890／PR #904、Deb PR #906、配布修正PR #909と公開source af2、今回の全21assetsと公開後検査 |
+| INVAR-1〜3 | #886〜888のconsent／secret／profile／audience／P2P監査、#889／905の更新保持、#890のWindows・公開境界 |
+
+親本文の旧未完了表示・全追加OS実機条件・Deb対象外表記は、既承認の子条件と追加依頼に同期する。support保証の追加や品質条件の免除ではない。最終docsと本文同期のdelta監査後にCloseを判定する。

--- a/docs/progress/2026-09-07-v0.2.0-preview.1-release-rollout.md
+++ b/docs/progress/2026-09-07-v0.2.0-preview.1-release-rollout.md
@@ -2,8 +2,8 @@
 
 ## Current status
 
-- In progress。初回の全クライアントlatest公開・CN公開・VM更新依頼に加え、2026-09-07に利用者が配布修正後の`v0.2.0-preview.2`公開とCN／VMの同版への同期を承認。
-- 基準main: `73273ef5efbfaeaa26bbb6163dc9804410500553`。本体versionは`0.2.0`を維持し、新しい公開tagを`v0.2.0-preview.2`とする。既存`v0.2.0-preview.1`のGit／CN tagsは保持する。
+- 全クライアントlatest・CN公開とVM同期は検証・独立監査を含め完了。2026-09-07の承認に従い、[v0.2.0-preview.2](https://github.com/KingYoSun/kukuri/releases/tag/v0.2.0-preview.2)を公開した。
+- 公開source: `af2cf56b52e1d2802ac92af6b99090e260dfc48d`。本体versionは`0.2.0`。既存`v0.2.0-preview.1`のGit／CN tagsと旧資材は保持した。
 - リスク区分C、Scope revision: `2026-09-07-v0.2.0-preview.2-release-rollout-v2`。AC-R1〜5／INVAR-R1〜4は維持し、最終公開対象tagを更新する。
 - クライアントの固定AC／INVARと公開境界は#890＋#905を採用する。#905までの製品・実機・独立監査は不変部分の証拠として再利用する。
 
@@ -76,3 +76,24 @@ INVAR-R1: secret値をlog／artifact／argvへ出さない。INVAR-R2: 同source
 - T2／INV-R2、AC-R1、INVAR-R2/4内の再実行として独立限定確認を実施。未変更のWindows／Linux集約smokeを独立`pwsh -File`で実行し、ともに全assertionとexit0を確認。未実行だったthird-party notices smokeもPASS。元CIを成功扱いせず、残る集約・実署名・完全draft・公開後検証は固定sourceの未変更scriptと同一run資材で実行する。tag移動、別run混在、再署名、guard免除は行わない。
 
 再発修正の対象pathはLinux smoke、workflow回帰test、本runbookと作業記録のみ。callerはRelease集約job／Release Contracts／runbookの手動検証。正常完了→exit0、assertion失敗→例外／非0の境界を保ち、製品・実資材集約・署名・publisher・source collectorには変更しない。修正PRのCIと独立delta監査、最終公開候補の実検証は別々に記録する。
+
+## 最終クライアント公開
+
+- PR #911はRelease Contracts `34120279165`と全checks成功、[head独立監査PASS](https://github.com/KingYoSun/kukuri/pull/911#issuecomment-5570423513)後に`335f0e5bef513cd6384fc10b0caae555f00ec0ef`へmerge。監査headとのtree一致を確認。これは検証driverとdocsだけの追随修正であり、公開source／tagはaf2のまま。
+- 同じRelease run `34109294504`の6artifacts（Windows、Linux GUI、CLI2arch、実verifier、changelog）だけから、af2と不変の集約scriptで全21filesを作成。全4package metadataとverifier sourceが一致し、実3entryの正常受理・1byte改変拒否はPASS。
+- 独立候補監査は6群すべて適合、不適合0／未分類0／blocker0。同run／source、完全性、実署名、native資料、再実行、完全draftを検査。Ubuntu92 exact sourcesの297files、static31filesを実archiveからhash照合し、libgcryptは実bundleと同じ`1.9.4-3ubuntu3.3`。runtime inventoryとDeb payloadも一致した。
+- 既存publisherは完全draft `384062770`へ21assetsをuploadし、全GitHub SHA-256 digestを照合した。Windowsの初回cp932 decode失敗はtagの読取り時でwrite前。`python -X utf8`で同資材を再実行した。
+- GitHubのtag GETは完全draftにも404を返したため、再開時だけ正確なtag GETを既知ID `384062770`のreadへ置き換え、ID／tag／draftを照合した。元`publish()`の完全性・notes・全asset digest・公開直前source再照合は不変。独立dry-runで予定writeは同IDへの公開PATCHだけ、POST／upload／deleteは0。実行時もそれ以外のwriteを拒否し、資材作り直し・置換・重複draft作成はしていない。
+- 同IDを`draft=false`／`prerelease=false`／`make_latest=true`で公開。未変更`verify_public_preview.py`で安定manifestと5本体／checksum／provenanceの公開URLを取得し、`stable_manifest=passed`、`public_files=7`、source=af2を確認した。native大容量archiveは公開前のupload digest全件照合を採用する。
+- 自動changelog PR #910は生成sectionとの一致とdocs-only差分・check成功を確認して`ea0c5d3a333423148b9c5278b5fa9a1527bc8b91`へmerge。公開資材のnotesは変更していない。
+
+## preview.2 VM同期結果
+
+- CN4version digestsを既存operator config／tfvarsへ同期し、他の設定・node ID・法務入力・admin actor・通知channelを保持した。現preview.1とのCN製品コード／schema差分は0。旧4digestsと更新直前backupは非公開運用記録へ保管した。
+- 既存backup serviceは12:11:44 UTCに成功。object／generation／sizeを確認。独立preflight監査で、41resources中VMの`metadata_startup_script`だけが置換理由、他40resources／8outputs・machine／network／SA／2PDs・通知8policiesは不変と確認した。
+- 限定metadata-only同期後、desired／server SHA-256は`f58f73a3d722dcfa7332de475aa409cdfcca94fff9b195f5402ce665f3fdfc29`で一致。新しいsafe planの独立監査は41resources全no-op／置換0／8outputs不変。safeだけをapplyし、0 added／0 changed／0 destroyed、最終planはNo changes。置換を含む旧planはapplyしていない。
+- 新4imagesをpullして全OCI revision=af2を照合。新旧imageを保持して残り4.3GB、volume／PD／DBを削除・置換していない。startupは12:23:07〜12:23:41 UTC、exit0／bootstrap complete。API／indexer healthy、relay running、CLI imageを含む4refsは新versionに対応する。
+- 12:24:25 UTCのreadinessは`ready=true fail=0 unknown=0`、worker稼働・public scopes4・sync／ingest fresh・scan_errors0・truth0／projection0・恒久blob保存無効・relation analysis成功。Postgres／ArcadeDB／Caddyは既存containerが継続稼働、Valkeyは通常startupで再作成されversion8.1.10を維持した。
+- migration24件はすべて成功済み、法務7文書／必須2／snapshot `56e3a6caff94ccbaf9a431b845cc0c4e160cd1678aaab5fdaeb8e9e65b05f769`は不変。公開health／relay ping／両manifest／法務7URLsは200。旧検証投稿は残っていない。
+- 今回は新しいlive media試験として扱わず、不変CN code／schema／config／法務に対するpreview.1の実署名auth・同意拒否／現snapshot受理・benign media非残留・独立監査証拠を採用。新revisionの稼働／readiness／publicを追加照合した。
+- 最終CN独立delta監査はAC-R2〜4／対応INVARでPASS、blocker0。backup generation／size、稼働4refs、24migrations、法務、readiness／public、旧投稿0を独立確認。VM上の今回の検証helper2本だけを絶対pathで確認して削除し、不在を確認した。ローカルsourceと運用証拠、旧images／backupは保持している。

--- a/docs/runbooks/linux-cli.md
+++ b/docs/runbooks/linux-cli.md
@@ -1,8 +1,8 @@
 # Linux CLIの利用
 
-Linux CLIの配布対象はx86_64／aarch64。`kukuri-cli_<version>_<target>.tar.gz`を展開し、
-`bin/kukuri-cli --version`で版を確認する。配布開始・取得先はReleaseの成果物一覧を正とし、
-この手順の追加だけを公開済みの意味にしない。
+Linux CLIの配布対象はx86_64／aarch64。[v0.2.0-preview.2](https://github.com/KingYoSun/kukuri/releases/tag/v0.2.0-preview.2)で両archを公開済み。
+`kukuri-cli_<version>_<target>.tar.gz`を展開し、`bin/kukuri-cli --version`で版を確認する。
+別の版を使う場合も、取得先と提供archはそのReleaseの成果物一覧を確認する。
 
 GUIとは異なるCLI専用profileを使用する。日常GUIの保存先を`KUKURI_APP_DATA_DIR`で共有しない。
 必要な同意内容と年齢条件は本人が確認してから、次の明示操作を行う。

--- a/docs/runbooks/mvp-user-quickstart.md
+++ b/docs/runbooks/mvp-user-quickstart.md
@@ -3,12 +3,12 @@
 ## 対象
 
 - Builder Previewを試すデスクトップ利用者向け
-- 現在のパッケージ版はWindows向け
-- Linuxは対象ReleaseにAppImage／Debがあれば利用可能。Debの導入・署名付き更新・削除は[Deb手順](linux-deb.md)を参照。未掲載の場合はソース起動を使用する。CLIは[専用手順](linux-cli.md)を参照
+- Windows NSIS、Linux x86_64 AppImage／Debを[v0.2.0-preview.2](https://github.com/KingYoSun/kukuri/releases/tag/v0.2.0-preview.2)で公開済み
+- Linuxは[AppImage手順](linux-appimage-smoke.md)または[Debの導入・署名付き更新・削除手順](linux-deb.md)を参照。CLI x86_64／aarch64も同Releaseで配布し、[専用手順](linux-cli.md)を参照
 
 ## 3分で試す
 
-1. [最新のGitHub Release](https://github.com/KingYoSun/kukuri/releases/latest)からWindowsインストーラーを取得して起動する。
+1. [最新のGitHub Release](https://github.com/KingYoSun/kukuri/releases/latest)から自分の環境向けのWindowsインストーラーまたはLinux AppImage／Debを取得し、上記の形式別手順に従って起動する。
 2. 初回起動後、設定を開かずに数秒待ち、コミュニティノードが「準備完了」になるのを待つ。
 3. 2番目のプロフィールカラムを開き、「プロフィールを編集」から表示名、ユーザー名、自己紹介、必要なら画像を設定する。
 4. 先頭のタイムラインカラムへ戻り、最初から用意されたトピックのどれかを開く。


### PR DESCRIPTION
## 対象
Refs #907, Refs #890, Refs #885
Scope: 2026-09-07-v0.2.0-preview.2-release-rollout-v2 / #890 v4 / #885 single-request-execution
公開・rollout区分Cの最終証拠同期。変更は6docsのみ、product／CI／署名／publisher／CN／運用設定変更なし。

## 完了した実作業
- v0.2.0-preview.2 / source af2cf56b52e1d2802ac92af6b99090e260dfc48d / Release384062770 latest公開。5本体を含む21assets、3実署名・改変拒否、native Ubuntu92exact/297files+static31hash、全uploaddigest、公開後stablemanifest/5本体+2meta一致。
- 元Release34109294504のsmoke終了値誤判定FAILを保持し、同source／同runの未変更smoke・後続工程再実行PASSを区別。PR911再発fixはCI/独立監査後merge済み。draft tagGET404は既知IDのreadlookupだけ補完し元publish全guard維持、POST/upload/delete禁止の同ID PATCHで公開。候補独立監査6群全適合/blocker0。
- CN4version/latest refsは同source。freshbackup／preflight独立review／metadata-only同期／serverhash一致／freshsafe独立review／apply0/0/0／startupsuccess／readiness正常／公開legal正常／設定・DB保持／CN最終独立delta監査PASS。検証helper2本だけ削除、旧imagesとbackup保持。
- 親885は各子の実装・CI・監査と公開を独立対応付け、INV5/TR7全分類、blocker0。既承認OS延期・Deb追加へ本文同期済み。子890のINV8/TR7も全分類。

## Docs変更とvalidation
README en/jaとquickstart/LinuxCLIの未公開表示を実公開へ同期。#890/releaseprogressへ公開・失敗切り分け・同run再開・VM結果・親統合の証拠を記録。全58relative linksとgit diff --check PASS。docs-onlyのため不変製品suiteは重複実行しません。最終head独立delta監査とchecks後merge、tree照合しIssueを条件別Closeします。