### PR TITLE
[codex][contract] 通知の取得モードと禁止副作用を固定する

### DIFF
--- a/apps/desktop/src/shell/data/notificationLoaders.contract.test.tsx
+++ b/apps/desktop/src/shell/data/notificationLoaders.contract.test.tsx
@@ -1,0 +1,246 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import type { DesktopApi, NotificationView, RuntimeEvent } from '@/lib/api';
+import { createDesktopMockApi } from '@/mocks/desktopApiMock';
+import { useDesktopShellSectionLoaders } from '@/shell/data/loaders/useDesktopShellSectionLoaders';
+import { columnIdentityId, openTransientColumn } from '@/shell/slices/workspace';
+import { createShellHookHarness, resetWindowHash } from '@/shell/testSupport/renderShellHook';
+import { useDesktopShellData } from '@/shell/useDesktopShellData';
+
+const { listenMock } = vi.hoisted(() => ({ listenMock: vi.fn() }));
+vi.mock('@tauri-apps/api/event', () => ({ listen: listenMock }));
+
+const translate = (key: string) => key;
+const unread: NotificationView = {
+  notification_id: 'private-reply', kind: 'reply', actor_pubkey: 'b'.repeat(64), actor_picture_asset: null,
+  source_envelope_id: 'reply-envelope', source_replica_id: 'private-replica',
+  topic_id: 'kukuri:topic:general', channel_id: 'members', object_id: 'reply',
+  thread_root_object_id: 'root', preview_text: 'private preview', content_labels: ['adult'],
+  created_at: 11, received_at: 12, read_at: null,
+};
+const read: NotificationView = {
+  notification_id: 'read-dm', kind: 'direct_message', actor_pubkey: 'c'.repeat(64), actor_picture_asset: null,
+  dm_id: 'conversation', message_id: 'message', preview_text: 'older message',
+  created_at: 5, received_at: 6, read_at: 7,
+};
+
+beforeEach(() => {
+  resetWindowHash();
+  vi.useFakeTimers();
+  vi.setSystemTime(100_000);
+  listenMock.mockReset().mockResolvedValue(() => undefined);
+  delete (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__;
+  vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('visible');
+});
+
+afterEach(() => {
+  delete (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__;
+});
+
+async function flush(milliseconds = 0) {
+  await act(async () => { await vi.advanceTimersByTimeAsync(milliseconds); });
+}
+
+function mountData(api: DesktopApi) {
+  const harness = createShellHookHarness({ hash: '/timeline?topic=kukuri%3Atopic%3Ageneral' });
+  const workspace = harness.store.getState().workspaceState;
+  // このsuiteはbadge更新を測る。背景inboxの独立したsection取得は別testで確認する。
+  harness.store.getState().patchState({
+    workspaceState: { ...workspace, columns: workspace.columns.filter(c => c.kind !== 'notifications') },
+    notifications: [read], notificationStatus: { unread_count: 9 },
+  });
+  const args = {
+    api, translate,
+    loadTopicsRequestRef: { current: new Map<string, number>() },
+    remoteObjectUrlRef: { current: new Map<string, string>() },
+    draftPreviewUrlRef: { current: new Map<string, string>() },
+    directMessageDraftPreviewUrlRef: { current: new Map<string, string>() },
+    mediaFetchAttemptRef: { current: new Map<string, number>() },
+    draftSequenceRef: { current: 0 },
+  };
+  const hook = renderHook(() => useDesktopShellData(args), { wrapper: harness.wrapper });
+  return { ...harness, hook };
+}
+
+function mountInbox() {
+  const api = createDesktopMockApi({ notifications: [unread, read] });
+  const harness = createShellHookHarness();
+  harness.store.getState().patchState({
+    notifications: [read], notificationStatus: { unread_count: 9 },
+    notificationPanelState: { status: 'loading', error: null },
+    notificationAutoReadError: 'previous read failure',
+  });
+  const loadReactionCatalogData = vi.fn().mockResolvedValue(undefined);
+  const hook = renderHook(() => useDesktopShellSectionLoaders({
+    api, storeApi: harness.store, translate, loadReactionCatalogData,
+  }), { wrapper: harness.wrapper });
+  return { api, ...harness, hook };
+}
+
+describe('notification badge contract (#919 TR-1/2/3/8)', () => {
+  test('hidden mount, interval and runtime event issue no notification requests', async () => {
+    vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('hidden');
+    (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__ = {};
+    let receive: ((event: { payload: RuntimeEvent }) => void) | undefined;
+    listenMock.mockImplementation(async (_name: string, callback: typeof receive) => {
+      receive = callback;
+      return () => { receive = undefined; };
+    });
+    const api = createDesktopMockApi({ notifications: [unread] });
+    const status = vi.spyOn(api, 'getNotificationStatus');
+    const list = vi.spyOn(api, 'listNotifications');
+    const mark = vi.spyOn(api, 'markAllNotificationsRead');
+    const { hook, store } = mountData(api);
+    await flush(60_000);
+    expect(receive).toBeDefined();
+    await act(async () => { receive?.({ payload: { type: 'notification_status_changed' } }); });
+    expect(status).not.toHaveBeenCalled();
+    expect(list).not.toHaveBeenCalled();
+    expect(mark).not.toHaveBeenCalled();
+    expect(store.getState().notifications).toEqual([read]);
+    expect(store.getState().notificationStatus).toEqual({ unread_count: 9 });
+    hook.unmount();
+  });
+
+  test.each([0, 1])('outside inbox, badge count %i controls list fetch without marking read', async count => {
+    const api = createDesktopMockApi();
+    vi.spyOn(api, 'getNotificationStatus').mockResolvedValue({ unread_count: count });
+    const list = vi.spyOn(api, 'listNotifications').mockResolvedValue([unread, read]);
+    const mark = vi.spyOn(api, 'markAllNotificationsRead');
+    const { hook, store } = mountData(api);
+    const panel = store.getState().notificationPanelState;
+    await flush();
+    expect(list).toHaveBeenCalledTimes(count ? 1 : 0);
+    expect(store.getState().notifications).toEqual(count ? [unread, read] : [read]);
+    expect(store.getState().notificationStatus).toEqual({ unread_count: count });
+    expect(store.getState().notificationPanelState).toEqual(panel);
+    expect(mark).not.toHaveBeenCalled();
+    hook.unmount();
+  });
+
+  test.each(['status', 'list'])('badge %s failure keeps previous rows and does not set inbox error', async failure => {
+    const api = createDesktopMockApi();
+    const status = vi.spyOn(api, 'getNotificationStatus').mockResolvedValue({ unread_count: 2 });
+    const list = vi.spyOn(api, 'listNotifications').mockResolvedValue([unread]);
+    (failure === 'status' ? status : list).mockRejectedValue(new Error('offline'));
+    const mark = vi.spyOn(api, 'markAllNotificationsRead');
+    const { hook, store } = mountData(api);
+    const panel = store.getState().notificationPanelState;
+    await flush();
+    expect(store.getState().notificationStatus).toEqual({ unread_count: failure === 'status' ? 9 : 2 });
+    expect(store.getState().notifications).toEqual([read]);
+    expect(store.getState().notificationPanelState).toEqual(panel);
+    expect(list).toHaveBeenCalledTimes(failure === 'status' ? 0 : 1);
+    expect(mark).not.toHaveBeenCalled();
+    hook.unmount();
+  });
+
+  test.each([0, 1])('active inbox badge count %i skips list; section change resets timer and event callback', async count => {
+    (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__ = {};
+    let receive: ((event: { payload: RuntimeEvent }) => void) | undefined;
+    const unsubscribe = vi.fn();
+    listenMock.mockImplementation(async (_name: string, callback: typeof receive) => {
+      receive = callback;
+      return () => { receive = undefined; unsubscribe(); };
+    });
+    const api = createDesktopMockApi();
+    const status = vi.spyOn(api, 'getNotificationStatus').mockResolvedValue({ unread_count: count });
+    const list = vi.spyOn(api, 'listNotifications').mockResolvedValue([read]);
+    const mark = vi.spyOn(api, 'markAllNotificationsRead');
+    const { hook, store } = mountData(api);
+    await flush(30_000);
+    status.mockClear();
+    act(() => {
+      store.getState().patchState({ workspaceState: openTransientColumn(store.getState().workspaceState, {
+        id: 'contract-inbox', kind: 'notifications', pinned: false,
+      }) });
+    });
+    await flush();
+    // 新sectionのinbox取得とは別にbadgeの即時refreshも行う。
+    expect(status).toHaveBeenCalledTimes(2);
+    status.mockClear(); list.mockClear(); mark.mockClear();
+    await flush(30_000);
+    expect(status).not.toHaveBeenCalled();
+    await flush(30_000);
+    expect(status).toHaveBeenCalledTimes(1);
+    await act(async () => { receive?.({ payload: { type: 'notification_status_changed' } }); });
+    expect(status).toHaveBeenCalledTimes(2);
+    expect(list).not.toHaveBeenCalled();
+    expect(mark).not.toHaveBeenCalled();
+    expect(store.getState().notifications).toEqual([read]);
+    expect(listenMock).toHaveBeenCalledTimes(1);
+    hook.unmount();
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+    expect(receive).toBeUndefined();
+    await flush(60_000);
+    expect(status).toHaveBeenCalledTimes(2);
+    const remount = mountData(api);
+    await flush();
+    expect(listenMock).toHaveBeenCalledTimes(2);
+    remount.hook.unmount();
+    expect(unsubscribe).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('notification inbox contract (#919 TR-4/5/6/7)', () => {
+  test('background refresh preserves mixed private/adult/read payloads without read mutation', async () => {
+    const { api, hook, store } = mountInbox();
+    const mark = vi.spyOn(api, 'markAllNotificationsRead');
+    await act(async () => { await hook.result.current.loadNotificationsSection({ markAsRead: false }); });
+    expect(mark).not.toHaveBeenCalled();
+    expect(store.getState().notifications).toEqual([unread, read]);
+    expect(await api.listNotifications()).toEqual([unread, read]);
+    expect(store.getState().notificationStatus).toEqual({ unread_count: 1 });
+    expect(store.getState().notificationPanelState).toEqual({ status: 'ready', error: null });
+    hook.unmount();
+  });
+
+  test.each(['default', 'batch'])('%s inbox read marks only unread rows and repeat load has no extra mutation', async mode => {
+    const { api, hook, store } = mountInbox();
+    const mark = vi.spyOn(api, 'markAllNotificationsRead');
+    if (mode === 'batch') {
+      act(() => { store.getState().patchState({ workspaceState: openTransientColumn(store.getState().workspaceState, {
+        id: columnIdentityId('notifications'), kind: 'notifications', pinned: false,
+      }) }); });
+    }
+    const load = () => mode === 'batch'
+      ? hook.result.current.loadShellSections('kukuri:topic:general')
+      : hook.result.current.loadNotificationsSection();
+    await act(async () => { await load(); });
+    expect(mark).toHaveBeenCalledTimes(1);
+    expect(store.getState().notifications).toEqual([{ ...unread, read_at: 100_000 }, read]);
+    expect(store.getState().notificationAutoReadError).toBeNull();
+    expect(store.getState().notificationStatus).toEqual({ unread_count: 0 });
+    await act(async () => { await load(); });
+    expect(mark).toHaveBeenCalledTimes(1);
+    expect(store.getState().notifications).toEqual([{ ...unread, read_at: 100_000 }, read]);
+    hook.unmount();
+  });
+
+  test.each(['status', 'list'])('inbox %s failure keeps both previous results and forbids marking read', async failure => {
+    const { api, hook, store } = mountInbox();
+    vi.spyOn(api, failure === 'status' ? 'getNotificationStatus' : 'listNotifications')
+      .mockRejectedValue(new Error('offline'));
+    const mark = vi.spyOn(api, 'markAllNotificationsRead');
+    await act(async () => { await hook.result.current.loadNotificationsSection(); });
+    expect(mark).not.toHaveBeenCalled();
+    expect(store.getState().notificationStatus).toEqual({ unread_count: 9 });
+    expect(store.getState().notifications).toEqual([read]);
+    expect(store.getState().notificationPanelState).toEqual({ status: 'error', error: 'offline' });
+    hook.unmount();
+  });
+
+  test('read failure keeps unread data with ready panel and separate auto-read error', async () => {
+    const { api, hook, store } = mountInbox();
+    const mark = vi.spyOn(api, 'markAllNotificationsRead').mockRejectedValue(new Error('read failed'));
+    await act(async () => { await hook.result.current.loadNotificationsSection(); });
+    expect(mark).toHaveBeenCalledTimes(1);
+    expect(store.getState().notifications).toEqual([unread, read]);
+    expect(await api.listNotifications()).toEqual([unread, read]);
+    expect(store.getState().notificationStatus).toEqual({ unread_count: 1 });
+    expect(store.getState().notificationPanelState).toEqual({ status: 'ready', error: null });
+    expect(store.getState().notificationAutoReadError).toBe('read failed');
+    hook.unmount();
+  });
+});

--- a/docs/progress/2026-09-08-919-notification-contract.md
+++ b/docs/progress/2026-09-08-919-notification-contract.md
@@ -1,0 +1,51 @@
+# Issue #919: 通知取得モードの変更前contract
+
+## 範囲と開始条件
+
+- Issue: #919、Scope revision `2026-09-08-872-F-1C-v1`、リスクC。
+- 変更前commit: `ac9946d66aaf197204f669a10701fac8a13877e9`。後続#920の製品変更より前に実行する。
+- ユーザーは#919〜#928について、各Issueの必須CI・独立監査成功後のmergeまで承認済み。#928にも依頼どおり独立監査を行う。
+- 本Issueの製品コード、IPC、DB、既存test、UI描画変更は0。新規testと本記録のみ。
+- 正本はIssueのAC-1〜4、INVAR-1/2、INV-1〜7、TR-1〜8、ADR 0023、DESIGN、ADR 0014。未定義のcancel/retryは追加しない。
+
+## 作業と受入条件
+
+| 作業 | AC / INVAR | 対象・証拠 | 依存 |
+| --- | --- | --- | --- |
+| T1 既存保護と入口確認 | AC-1、INVAR-1 | data hook/section loader/event bridge、全通知API callerと動的登録、既存16 testsのbaseline | なし |
+| T2 不足する禁止I/O・state contract | AC-2/3、INVAR-1/2 | `apps/desktop/src/shell/data/notificationLoaders.contract.test.tsx`。TR別対応は下表 | T1 |
+| T3 変更前製品で検証・記録 | AC-4、INVAR-1/2 | targeted + `cargo xtask desktop-ui-check`。source diffと既存assertion不変 | T2 |
+| T4 独立監査・CI・merge | AC-1〜4、INVAR-1/2 | 固定PR headの別担当監査、CI、merge tree照合。結果はIssue/PRで保持 | T3 |
+
+## Inventoryとcontract対応
+
+製品inventory変更は0。CodeGraphでuseDesktopShellData/effects/section loaders/event bridgeを読み、macro/event登録と次の全caller検索を補完する。
+
+```powershell
+rg -n 'getNotificationStatus|listNotifications|markNotificationRead|markAllNotificationsRead|loadNotificationsSection|refreshNotificationStatus' apps/desktop/src
+rg -n 'mark_all_notifications_read|notification_status_changed' apps/desktop/src-tauri crates/desktop-runtime crates/app-api
+```
+
+| INV / TR | 今回追加する観測 / 既存証拠 |
+| --- | --- |
+| INV-1/2、TR-1 | `hidden mount, interval and runtime event issue no notification requests`。status/list/markすべて0、state保持 |
+| INV-1/2、TR-2 | `outside inbox, badge count ...`と`active inbox badge count ...`。inside/outside × count0/1、list条件・mark0、既存payload保持 |
+| INV-1/2、TR-3 | `badge ... failure keeps previous rows ...`。status failure/list failureを区別、部分成功のstatusだけ反映、panel不変 |
+| INV-3/4/6、TR-4/7 | `... inbox read marks only unread rows ...`。defaultとbatch入口、mixed read_at/payload、既読時の追加mutation0。既存data hookのloadTopics testも維持 |
+| INV-3/5、TR-5 | `background refresh preserves mixed private/adult/read payloads ...`。list/unread/read_at保持・mark0。page manual refreshとbackground columnは既存notifications integration |
+| INV-3/6、TR-6 | `inbox ... failure keeps both previous results ...`、`read failure keeps unread data ...`。取得失敗とmark失敗で保持state/errorの違い、mock保存値も確認 |
+| INV-1/2、TR-8 | `active inbox badge count ... resets timer and event callback`。section変更の即時refresh、旧interval解除、新60秒周期、最新event callback、unmount/remountでlistener解除 |
+| INV-7、TR-7 | 新規mixed fixtureのprivate channel/DM/adult labels/順序保持。表示・クリック・OS activation・focusは既存notifications/notificationFocus/osNotificationActivation/adultContentGating integration |
+
+テストはpublic data facadeとsection loaderを使い、effects内部helperをmockしない。badge測定では背景inbox Columnだけをfixtureから除き、独立したsection取得と混同しない。inboxの永続read処理は既存AppService contractが所有し、本Issueはfrontend API呼出とstate/mock保存値を観測する。
+
+## 実行記録
+
+- before: `npx pnpm@10.16.1 --dir apps/desktop test src/shell/useDesktopShellData.test.tsx src/shell/data/loaders/useDesktopShellSectionLoaders.test.tsx src/shell/data/useRuntimeEventBridge.test.ts` → 3 files / 16 tests PASS、3.67秒。
+- 初回の新規testで、mockが補完する`actor_picture_asset: null`をfixtureに持たせていない差を検出。既存mockの入力正規化に合わせてfixtureを明示し、製品変更は行っていない。
+- targeted: 同commandに新規notificationLoaders.contract.test.tsxを加えて4 files / 29 tests PASS、4.14秒。全frontend gate結果とPR headは実行後に追記する。Linuxのvisual比較はCIで確認し、Windows smokeを比較PASSと扱わない。
+
+## 差し戻し・残存条件
+
+test-only PRを単独revert可能。#920に着手後は保護網だけを外さず先に#920を戻す。
+並行要求の完了順やunmount時の新しい進行中要求取消しは対象外。CIや独立監査未完の段階を完了扱いしない。


### PR DESCRIPTION
Refs #919。通知のbadge/inbox取得を集約する前に、hidden・section変更・partial failure・既読操作の観測を固定しました。製品コードは変更していません。

- 種別 `contract`、区分C、Scope revision `2026-09-08-872-F-1C-v1`。
- [計画・AC/INVAR・対象境界・検証・rollback記録](docs/progress/2026-09-08-919-notification-contract.md)。詳細な独立監査とdeltaはPR commentsに保持。
- 追加13 testsを含む対象29 tests、desktop-ui-check、独立監査PASS。
- 最終head `f68baddce8fca68242fea1d8d8f9b97c7d2da966` の全11 checks SUCCESS。必要な独立監査とCIを満たしてmergeしました。
- merge `0410261bb8091829db6b5cd8f1feb66791aaf327` と監査対象のpath/surface一致を確認し、[Issue #919](https://github.com/KingYoSun/kukuri/issues/919)の現在判定をCompleteへ同期・Close済み。
