### PR TITLE
[codex][docs] capabilityの凍結境界を現行の提供状態へ同期する

### DIFF
--- a/REFACTORING.md
+++ b/REFACTORING.md
@@ -220,8 +220,13 @@ PR共通欄は `.github/PULL_REQUEST_TEMPLATE.md` を使い、本書の「記録
    `crates/desktop-runtime/src/community_node/manifest_support.rs` +
    `crates/cn-operator/tests/manifest_golden.rs`(**この 2 ファイルを触る PR は
    `cargo xtask rust-test` の round-trip テストと `cn-test` の golden の両方を実行する**)。
-8. **cn-operator の `Availability::Planned` 3 capability**: 昇格は ADR 0027 §2.9 の条件付き
-   decision であり、リファクタで表明を変えない。
+8. **cn-operator の capability 提供状態と公開条件**: `community_index` / `moderation` /
+   `community_local_trust` は #616 の readiness / fail-closed gate を経て #617 で
+   `Availability::Available` へ移行済み（[ADR 0025](docs/adr/0025-community-node-indexing-foundation.md)
+   2026-08-16改訂、`crates/cn-operator/src/capability.rs::availability`）。提供可能であることと
+   個々の配備で有効・公開であることは区別し、設定と有効な readiness 記録の条件を維持する。
+   ADR 0027 §2.9 の昇格条件は当時の判断として保持する。将来向けの `Planned` 区分を削除せず、
+   リファクタで availability、manifest の表明、operator の有効化条件を変えない。
 9. **Tauri IPC 契約**(`crates/app-api/src/views.rs` ⇔ `apps/desktop/src/lib/api/types.ts`):
    同一バイナリ内契約のため両側同時変更なら改名可能だが、片側変更は silent break。
    固定: 高頻度 8 型グループは共有 fixture(apps/desktop/src/lib/api/__fixtures__/views/)を

--- a/docs/adr/0027-deterministic-moderation-critical-safety.md
+++ b/docs/adr/0027-deterministic-moderation-critical-safety.md
@@ -3,6 +3,12 @@
 ## Status
 Draft
 
+2026-09-08補足（#928）: 本文の`community_index` / `moderation` / `community_local_trust`を
+`Availability::Planned`とする記述と§2.9の昇格判断は起草時の記録である。
+3 capabilityは#616の実行時readiness / fail-closed gateを経て#617で`Available`へ移行済み。
+現在の提供状態と配備ごとの公開条件は[ADR 0025](0025-community-node-indexing-foundation.md)の
+2026-08-16改訂を参照する。以下の当時の判断とcritical safetyの条件自体は変更しない。
+
 ## Date
 2026-06-30
 

--- a/docs/progress/2026-09-08-928-capability-freeze-docs.md
+++ b/docs/progress/2026-09-08-928-capability-freeze-docs.md
@@ -1,0 +1,16 @@
+# Issue #928: capabilityの現行状態と凍結境界の説明同期
+
+- 種別docs、区分A、Scope revision `2026-09-08-872-C-CN-3-v1`。
+- before `ac9946d66aaf197204f669a10701fac8a13877e9`。
+- REFACTORING凍結境界8はPlanned3件と記載していたが、`cn-operator/src/capability.rs::availability`は全件Availableを返す。`lib.rs`、ADR 0025の2026-08-16改訂、#617の`23a7284e`と不一致だった。
+
+| AC / INVAR | 作業と確認 |
+| --- | --- |
+| AC-1 | 凍結境界8を現行Available、配備ごとの設定/readinessと区別する説明へ同期。将来向けPlannedの区分と公開契約の凍結は維持 |
+| AC-2 | ADR 0027の旧Planned/昇格条件本文を保存し、冒頭へ起草時記録である旨と後継ADR 0025へのリンクを追記。AGENTS/PLANS/docs README/runbooks/.githubに同じ旧3件指示の引用なし |
+| AC-3 | `git diff --check`、記載path/commandとリンクを確認、`cargo xtask oversized-files`を実行 |
+| INVAR-1 | 差分はREFACTORING/ADR補足/本記録のみ。製品・manifest値・有効化条件・法務/同意/送信規則・既存testは無変更 |
+
+既存`cn-operator/tests/manifest_golden.rs`と`generate.rs`のavailable_enabled/planned_enabled空、disabled表示、`generated_docs_contain_no_planned_wording_after_promotion`を根拠として確認。文書同期で製品testの変更は不要。
+独立監査は区分Aの最低条件ではないが、今回ユーザーが全10Issueについて指定したため固定PR headで行う。結果とCI/merge対象はIssue/PRへ記録する。文書のみのためFastのpath triggerに該当しない場合も、未実行を成功とは表記しない。
+Rollbackは本Issueの文書PRの単独revert。過去ADR本文の書換え、availabilityの巻戻し、Planned削除は行わない。


### PR DESCRIPTION
Refs #928。REFACTORING.mdが3 capabilityをPlannedと記していた不一致を、実装済みのAvailable状態へ同期しました。提供可能であることと、個々の配備で有効・公開になるreadiness条件を区別し、製品状態や過去ADRの判断は変更していません。

- 種別 `docs`、区分A、Scope revision `2026-09-08-872-C-CN-3-v1`。
- [計画・AC/INVAR・対象境界・検証・rollback記録](docs/progress/2026-09-08-928-capability-freeze-docs.md)。詳細な独立監査とdeltaはPR commentsに保持。
- 記述・参照・diff check・oversized PASS、独立監査PASS。docs-onlyのため製品CIはpath filterで非起動。
- 最終head `c1670fdb164dd442639b4bef61a02cc254e049d0` の全1 checks SUCCESS。必要な独立監査とCIを満たしてmergeしました。
- merge `36e3732edfb68e0637a60e7badf4c778d0530e4d` と監査対象のpath/surface一致を確認し、[Issue #928](https://github.com/KingYoSun/kukuri/issues/928)の現在判定をCompleteへ同期・Close済み。
