### PR TITLE
[codex][fix] Preset取得待ちでもroom一覧の読込みを継続する

### DIFF
--- a/crates/app-api/src/dome_hosting.rs
+++ b/crates/app-api/src/dome_hosting.rs
@@ -57,7 +57,7 @@ impl AppService {
         let preset = self
             .fetch_dome_preset_manifest(&instance.preset_ref)
             .await?
-            .context("Dome preset manifest is unavailable")?;
+            .ok_or(DomeReadUnavailable::Preset)?;
         let records = self
             .list_dome_hosting_records(&replica, &input.instance_id)
             .await?;
@@ -911,7 +911,7 @@ impl AppService {
         let preset = self
             .fetch_dome_preset_manifest(&instance.preset_ref)
             .await?
-            .context("Dome preset manifest is unavailable")?;
+            .ok_or(DomeReadUnavailable::Preset)?;
         Ok(DomeHostingView {
             instance_id: instance.instance_id.clone(),
             state,

--- a/crates/app-api/src/game.rs
+++ b/crates/app-api/src/game.rs
@@ -59,6 +59,16 @@ impl AppService {
         let mut items = Vec::with_capacity(rows.len());
         for row in rows {
             let dome_hosting = if let Some(metaverse) = row.metaverse.as_ref() {
+                // Context rows and owner Presets arrive on different replicas. Keep
+                // the row for a later refresh, but do not expose an unverified Dome.
+                // Invalid references/signatures still propagate through `?`.
+                if self
+                    .fetch_dome_preset_manifest(&metaverse.preset_ref)
+                    .await?
+                    .is_none()
+                {
+                    continue;
+                }
                 Some(
                     self.get_dome_hosting(
                         metaverse.spatial_context.clone(),

--- a/crates/app-api/src/game.rs
+++ b/crates/app-api/src/game.rs
@@ -59,24 +59,23 @@ impl AppService {
         let mut items = Vec::with_capacity(rows.len());
         for row in rows {
             let dome_hosting = if let Some(metaverse) = row.metaverse.as_ref() {
-                // Context rows and owner Presets arrive on different replicas. Keep
-                // the row for a later refresh, but do not expose an unverified Dome.
-                // Invalid references/signatures still propagate through `?`.
-                if self
-                    .fetch_dome_preset_manifest(&metaverse.preset_ref)
-                    .await?
-                    .is_none()
+                // Resolve readiness from the canonical Instance, not the cached ref.
+                // A pending Preset keeps its row for refresh; invalid data still fails.
+                match self
+                    .get_dome_hosting(metaverse.spatial_context.clone(), &metaverse.instance_id)
+                    .await
                 {
-                    continue;
+                    Ok(hosting) => Some(hosting.state),
+                    Err(error)
+                        if matches!(
+                            error.downcast_ref::<DomeReadUnavailable>(),
+                            Some(DomeReadUnavailable::Preset)
+                        ) =>
+                    {
+                        continue;
+                    }
+                    Err(error) => return Err(error),
                 }
-                Some(
-                    self.get_dome_hosting(
-                        metaverse.spatial_context.clone(),
-                        &metaverse.instance_id,
-                    )
-                    .await?
-                    .state,
-                )
             } else {
                 None
             };

--- a/crates/app-api/src/service/live_game_support.rs
+++ b/crates/app-api/src/service/live_game_support.rs
@@ -1,5 +1,22 @@
 use super::*;
 
+#[derive(Debug)]
+pub(crate) enum DomeReadUnavailable {
+    Preset,
+    Envelope,
+}
+
+impl std::fmt::Display for DomeReadUnavailable {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(match self {
+            Self::Preset => "Dome preset manifest is unavailable",
+            Self::Envelope => "signed Dome envelope is unavailable",
+        })
+    }
+}
+
+impl std::error::Error for DomeReadUnavailable {}
+
 impl AppService {
     pub async fn fetch_metaverse_blob_bytes(&self, hash: &str) -> Result<Option<Vec<u8>>> {
         self.services
@@ -199,14 +216,26 @@ impl AppService {
         {
             anyhow::bail!("Dome Preset reference does not match its manifest");
         }
-        let signed: DomePresetManifestV1 = fetch_verified_dome_envelope(
+        let signed: DomePresetManifestV1 = match fetch_verified_dome_envelope(
             self.services.docs_sync.as_ref(),
             &replica,
             &state.last_envelope_id,
             "dome-preset",
             &manifest.owner_pubkey,
         )
-        .await?;
+        .await
+        {
+            Ok(signed) => signed,
+            Err(error)
+                if matches!(
+                    error.downcast_ref::<DomeReadUnavailable>(),
+                    Some(DomeReadUnavailable::Envelope)
+                ) =>
+            {
+                return Ok(None);
+            }
+            Err(error) => return Err(error),
+        };
         if signed != manifest {
             anyhow::bail!("signed Dome Preset content does not match its manifest blob");
         }
@@ -615,7 +644,7 @@ pub(crate) async fn fetch_verified_dome_envelope<T: DeserializeOwned>(
         .next()
         .map(|record| serde_json::from_slice(&record.value))
         .transpose()?
-        .ok_or_else(|| anyhow::anyhow!("signed Dome envelope is unavailable"))?;
+        .ok_or(DomeReadUnavailable::Envelope)?;
     envelope.verify()?;
     if envelope.id != *envelope_id
         || envelope.kind != expected_kind

--- a/crates/app-api/src/service/mod.rs
+++ b/crates/app-api/src/service/mod.rs
@@ -128,7 +128,7 @@ mod errors;
 mod gossip_subscription_support;
 mod hydration_support;
 mod live_game_support;
-pub(crate) use live_game_support::fetch_verified_dome_envelope;
+pub(crate) use live_game_support::{DomeReadUnavailable, fetch_verified_dome_envelope};
 mod metaverse_room_event_support;
 mod notifications_support;
 mod object_persistence_support;

--- a/crates/app-api/src/tests/dome_listing.rs
+++ b/crates/app-api/src/tests/dome_listing.rs
@@ -250,3 +250,111 @@ async fn invalid_preset_signature_is_an_error_not_pending() {
         .await
         .expect_err("invalid signature must fail, not be skipped");
 }
+
+#[tokio::test]
+async fn missing_preset_envelope_keeps_other_rooms_and_recovers_after_delivery() {
+    let f = fixture().await;
+    let replica = author_replica_id(f.preset.owner_pubkey.as_str());
+    let record = f
+        .docs
+        .query_replica(&replica, DocQuery::Exact(preset_key(&f.preset)))
+        .await
+        .expect("state")
+        .pop()
+        .expect("state record");
+    let state: DomePresetStateDocV1 = serde_json::from_slice(&record.value).expect("decode state");
+    let key = format!("envelopes/{}", state.last_envelope_id.as_str());
+    let signed = f
+        .docs
+        .query_replica(&replica, DocQuery::Exact(key.clone()))
+        .await
+        .expect("signed envelope")
+        .pop()
+        .expect("envelope");
+    f.docs
+        .apply_doc_op(
+            &replica,
+            DocOp::DeletePrefix {
+                prefix: key.clone(),
+            },
+        )
+        .await
+        .expect("delay envelope");
+    assert_pending_then_available(&f).await;
+    f.docs
+        .apply_doc_op(
+            &replica,
+            DocOp::SetBytes {
+                key,
+                value: signed.value,
+            },
+        )
+        .await
+        .expect("deliver envelope");
+    assert_eq!(
+        f.app
+            .list_game_rooms(TOPIC)
+            .await
+            .expect("complete rooms")
+            .len(),
+        2
+    );
+}
+
+#[tokio::test]
+async fn current_instance_preset_controls_readiness_even_with_an_old_cache_row() {
+    let f = fixture().await;
+    let old_row = f
+        .store
+        .list_topic_game_rooms(TOPIC)
+        .await
+        .expect("rows")
+        .into_iter()
+        .find(|row| row.room_id == f.dome_id)
+        .expect("Dome row");
+    let mut customization = old_row
+        .metaverse
+        .as_ref()
+        .expect("state")
+        .dome
+        .customization
+        .clone();
+    customization.environment.fog_density_micros += 1;
+    f.app
+        .update_metaverse_room(
+            TOPIC,
+            &f.dome_id,
+            UpdateMetaverseRoomInput {
+                status: old_row.status.clone(),
+                customization,
+            },
+        )
+        .await
+        .expect("new revision");
+    let current = f
+        .app
+        .list_game_rooms(TOPIC)
+        .await
+        .expect("new rooms")
+        .into_iter()
+        .find(|row| row.room_id == f.dome_id)
+        .expect("new Dome")
+        .metaverse
+        .expect("new state");
+    assert_eq!(current.preset_ref.revision, f.preset.revision + 1);
+    f.store
+        .upsert_game_room_cache(old_row)
+        .await
+        .expect("lagging derived cache");
+    *f.blobs.held_hash.lock().await = Some(BlobHash::new(current.preset_ref.manifest_blob_hash));
+    assert_pending_then_available(&f).await;
+    *f.blobs.held_hash.lock().await = None;
+    assert_eq!(
+        f.app
+            .list_game_rooms(TOPIC)
+            .await
+            .expect("complete rooms")
+            .len(),
+        2
+    );
+}

--- a/crates/app-api/src/tests/dome_listing.rs
+++ b/crates/app-api/src/tests/dome_listing.rs
@@ -1,0 +1,252 @@
+use super::*;
+use kukuri_core::{BlobHash, DomePresetRefV1};
+
+#[derive(Default)]
+struct DelayedPresetBlob {
+    inner: MemoryBlobService,
+    held_hash: TokioMutex<Option<BlobHash>>,
+}
+
+#[async_trait]
+impl BlobService for DelayedPresetBlob {
+    async fn put_blob(&self, bytes: Vec<u8>, mime: &str) -> Result<StoredBlob> {
+        self.inner.put_blob(bytes, mime).await
+    }
+    async fn fetch_blob(&self, hash: &BlobHash) -> Result<Option<Vec<u8>>> {
+        if self.held_hash.lock().await.as_ref() == Some(hash) {
+            return Ok(None);
+        }
+        self.inner.fetch_blob(hash).await
+    }
+    async fn pin_blob(&self, hash: &BlobHash) -> Result<()> {
+        self.inner.pin_blob(hash).await
+    }
+    async fn blob_status(&self, hash: &BlobHash) -> Result<BlobStatus> {
+        self.inner.blob_status(hash).await
+    }
+    async fn import_peer_ticket(&self, ticket: &str) -> Result<()> {
+        self.inner.import_peer_ticket(ticket).await
+    }
+}
+
+const TOPIC: &str = "kukuri:topic:pending-dome-preset";
+
+struct Fixture {
+    app: AppService,
+    docs: Arc<MemoryDocsSync>,
+    blobs: Arc<DelayedPresetBlob>,
+    store: Arc<MemoryStore>,
+    dome_id: String,
+    game_id: String,
+    preset: DomePresetRefV1,
+}
+
+async fn fixture() -> Fixture {
+    let store = Arc::new(MemoryStore::default());
+    let docs = Arc::new(MemoryDocsSync::default());
+    let blobs = Arc::new(DelayedPresetBlob::default());
+    let transport = Arc::new(FakeTransport::new("listing", FakeNetwork::default()));
+    let app = app_service_from_dependencies(
+        store.clone(),
+        store.clone(),
+        transport.clone(),
+        transport,
+        docs.clone(),
+        blobs.clone(),
+        generate_keys(),
+    );
+    let dome_id = app
+        .create_metaverse_room(
+            TOPIC,
+            CreateMetaverseRoomInput {
+                title: "Dome awaiting preset".into(),
+                description: String::new(),
+                max_peers: Some(4),
+            },
+        )
+        .await
+        .expect("create Dome");
+    let game_id = app
+        .create_game_room(
+            TOPIC,
+            CreateGameRoomInput {
+                title: "available game".into(),
+                description: String::new(),
+                participants: vec!["Alice".into(), "Bob".into()],
+            },
+        )
+        .await
+        .expect("create game");
+    let preset = app
+        .list_game_rooms(TOPIC)
+        .await
+        .expect("initial rooms")
+        .into_iter()
+        .find(|room| room.room_id == dome_id)
+        .expect("Dome row")
+        .metaverse
+        .expect("Dome state")
+        .preset_ref;
+    Fixture {
+        app,
+        docs,
+        blobs,
+        store,
+        dome_id,
+        game_id,
+        preset,
+    }
+}
+
+fn preset_key(preset: &DomePresetRefV1) -> String {
+    format!(
+        "metaverse/dome-presets/{}/revisions/{:020}",
+        preset.preset_id, preset.revision
+    )
+}
+
+async fn assert_pending_then_available(f: &Fixture) {
+    let rooms = f
+        .app
+        .list_game_rooms(TOPIC)
+        .await
+        .expect("pending preset must not fail room listing");
+    assert_eq!(
+        rooms
+            .iter()
+            .map(|room| room.room_id.as_str())
+            .collect::<Vec<_>>(),
+        vec![f.game_id.as_str()]
+    );
+    // Pending is a read result, not removal of the canonical/projection record.
+    assert_eq!(
+        f.store
+            .list_topic_game_rooms(TOPIC)
+            .await
+            .expect("stored rooms")
+            .len(),
+        2
+    );
+}
+
+#[tokio::test]
+async fn missing_preset_state_keeps_other_rooms_and_recovers_after_delivery() {
+    let f = fixture().await;
+    let replica = author_replica_id(f.preset.owner_pubkey.as_str());
+    let key = preset_key(&f.preset);
+    let record = f
+        .docs
+        .query_replica(&replica, DocQuery::Exact(key.clone()))
+        .await
+        .expect("preset state")
+        .pop()
+        .expect("state record");
+    f.docs
+        .apply_doc_op(
+            &replica,
+            DocOp::DeletePrefix {
+                prefix: key.clone(),
+            },
+        )
+        .await
+        .expect("delay state");
+    assert_pending_then_available(&f).await;
+    f.docs
+        .apply_doc_op(
+            &replica,
+            DocOp::SetBytes {
+                key,
+                value: record.value,
+            },
+        )
+        .await
+        .expect("deliver state");
+    let rooms = f.app.list_game_rooms(TOPIC).await.expect("delivered rooms");
+    assert_eq!(rooms.len(), 2);
+    assert!(
+        rooms
+            .iter()
+            .any(|room| room.room_id == f.dome_id && room.dome_hosting.is_some())
+    );
+}
+
+#[tokio::test]
+async fn missing_preset_blob_keeps_other_rooms_and_recovers_after_delivery() {
+    let f = fixture().await;
+    *f.blobs.held_hash.lock().await = Some(BlobHash::new(f.preset.manifest_blob_hash.clone()));
+    assert_pending_then_available(&f).await;
+    *f.blobs.held_hash.lock().await = None;
+    let rooms = f.app.list_game_rooms(TOPIC).await.expect("delivered rooms");
+    assert_eq!(rooms.len(), 2);
+    assert!(
+        rooms
+            .iter()
+            .any(|room| room.room_id == f.dome_id && room.dome_hosting.is_some())
+    );
+}
+
+#[tokio::test]
+async fn mismatched_preset_reference_is_an_error_not_pending() {
+    let f = fixture().await;
+    let replica = author_replica_id(f.preset.owner_pubkey.as_str());
+    let key = preset_key(&f.preset);
+    let record = f
+        .docs
+        .query_replica(&replica, DocQuery::Exact(key.clone()))
+        .await
+        .expect("preset state")
+        .pop()
+        .expect("state record");
+    let mut state: serde_json::Value = serde_json::from_slice(&record.value).expect("decode");
+    state["revision"] = serde_json::json!(f.preset.revision + 1);
+    f.docs
+        .apply_doc_op(&replica, DocOp::SetJson { key, value: state })
+        .await
+        .expect("mismatch state");
+    let error = f
+        .app
+        .list_game_rooms(TOPIC)
+        .await
+        .expect_err("invalid reference must fail");
+    assert!(error.to_string().contains("does not match its reference"));
+}
+
+#[tokio::test]
+async fn invalid_preset_signature_is_an_error_not_pending() {
+    let f = fixture().await;
+    let replica = author_replica_id(f.preset.owner_pubkey.as_str());
+    let state_record = f
+        .docs
+        .query_replica(&replica, DocQuery::Exact(preset_key(&f.preset)))
+        .await
+        .expect("preset state")
+        .pop()
+        .expect("state record");
+    let state: DomePresetStateDocV1 =
+        serde_json::from_slice(&state_record.value).expect("decode state");
+    let key = format!("envelopes/{}", state.last_envelope_id.as_str());
+    let record = f
+        .docs
+        .query_replica(&replica, DocQuery::Exact(key.clone()))
+        .await
+        .expect("envelope")
+        .pop()
+        .expect("signed envelope");
+    let mut envelope: KukuriEnvelope =
+        serde_json::from_slice(&record.value).expect("decode envelope");
+    envelope.content = "tampered preset".into();
+    f.docs
+        .apply_doc_op(
+            &replica,
+            DocOp::SetJson {
+                key,
+                value: serde_json::to_value(envelope).expect("encode"),
+            },
+        )
+        .await
+        .expect("tamper");
+    f.app
+        .list_game_rooms(TOPIC)
+        .await
+        .expect_err("invalid signature must fail, not be skipped");
+}

--- a/crates/app-api/src/tests/mod.rs
+++ b/crates/app-api/src/tests/mod.rs
@@ -57,6 +57,7 @@ mod capability_registry_snapshot;
 mod direct_messages;
 mod dome_connections;
 mod dome_hosting;
+mod dome_listing;
 mod dome_move;
 mod game;
 mod live;

--- a/docs/progress/2026-09-08-927-dome-preset-listing.md
+++ b/docs/progress/2026-09-08-927-dome-preset-listing.md
@@ -5,22 +5,22 @@
 - Scope revision `2026-09-08-872-H-04-v1`、区分C、before `ac9946d66aaf197204f669a10701fac8a13877e9`。
 - Context replicaのroom rowとauthor replicaのPreset state/blobは別々に到着する（ADR 0035/0036）。`list_game_rooms_scoped`はroom row到着だけで`get_dome_hosting`を呼び、Preset取得が`None`の段階も一覧全体のerrorにしていた。
 - 既存実iroh testはpeer ticket相互import→Dome作成→受信側room発見→event送受信を検証する。初回一覧のPreset未到達で141行がpanicし、event送信へ到達しなかった。fixtureの置換やwait/assertionの緩和は行わない。
-- 修正はscope/mute/Active判定後、各DomeのPresetが取得・検証できるか確認し、`None`だけその回の一覧から除外する。保存rowを削除せず次回refreshで再評価。検証errorは`?`で伝播し、不正reference/signatureを取得待ちへ落とさない。通常gameはそのまま返す。
-- `get_dome_hosting`とowner authorityの契約、wire/schema/署名形式、P2P三経路は変更しない。既存hosting_viewでも同Presetを検証するためcache済みの読み取りは重なるが、このfixへ構造整理を混ぜない。
+- 修正はscope/mute/Active判定後、`get_dome_hosting`がcanonical Instanceから解決するPresetの取得待ちだけ、その回の一覧から除外する。保存rowを削除せず次回refreshで再評価。cache rowの旧Preset refをauthorityとして判定しない。不正reference/signatureは従来errorを伝播し、通常gameは返す。
+- privateな`DomeReadUnavailable`でPreset/署名envelope欠落を識別し、文字列比較や任意errorの握り潰しをしない。`fetch_dome_preset_manifest`だけは署名entry未到達も`None`へ返し、Instance/Move/Connectionの共有署名helper利用者は従来のerrorを維持する。owner hostingの直接取得は引き続き未検証Presetを成功として返さない。wire/schema/署名形式、P2P三経路は不変。
 
 ## 作業とAC / INVAR
 
 | 作業 | 対応 | 証拠 |
 | --- | --- | --- |
 | T1 原因と変更前再現 | AC-1、INV-1/2、TR-1 | Nightly2件、既存game.rs141のWindows再現、source call path、下記新規失敗test |
-| T2 最小修正と回帰 | AC-2/3、INV-2/3、TR-1/2/3 | game.rsの取得待ち判定のみ、dome_listing4 tests、元iroh test全assertionをそのまま通す |
+| T2 最小修正と回帰 | AC-2/3、INV-2/3、TR-1/2/3 | 一覧での取得待ち判定と内部missing error分類、dome_listing6 tests、元iroh test全assertionをそのまま通す |
 | T3 検証・独立監査・merge | AC-4、INVAR-1/2 | targeted/slow、必須Rust CI、connectivity、PR head独立監査、merge tree照合 |
 
 ## Inventoryと逆引き
 
 - `list_game_rooms` → `list_game_rooms_scoped`の公開/privately scoped入口。Tauri `commands/live_game.rs` → runtime `sync_live_api.rs`、CLI登録handler、harness、testsから呼ばれる。
-- `list_game_rooms_scoped` → scope subscriptions / allowed channel / muted author / Active instance filter → `fetch_dome_preset_manifest` → author docs query / blob fetch / state-ref一致 / manifest validation / envelope署名とowner一致 → `get_dome_hosting` → view。
-- `fetch_dome_preset_manifest`の既存callerはowner hosting開始、hosting_view、Dome move。これらのerror policyは不変。新規callerはroom listingのみ。
+- `list_game_rooms_scoped` → scope subscriptions / allowed channel / muted author / Active instance filter → `get_dome_hosting` → canonical Instance → `fetch_dome_preset_manifest` → author docs query / blob fetch / state-ref一致 / manifest validation / envelope署名とowner一致 → view。呼出入口の増加なし。
+- `fetch_dome_preset_manifest`のcallerはowner hosting開始、hosting_view、Dome move。取得不能は既存のOption境界、InvalidはErrのまま。`fetch_verified_dome_envelope`の全callerはPreset/Instance/Move、Connection proposal/agreement/selection。PresetだけmissingをOptionへ分類し、他はErrを維持する。
 - sensitive sinkは既存docs/blob読み取り・取得とhosting projection。新規の永続mutation・index削除・権限拡張は0。既存scope/filter後に判定し、拒否データを成功として表示しない。
 - 再列挙: `rg -n 'list_game_rooms_scoped|list_game_rooms\(|fetch_dome_preset_manifest' crates apps/desktop/src-tauri`。worktreeはCodeGraph indexなし、rootのCodeGraphでsource確認後、worktreeの直接読取と完全symbol検索で補完。
 
@@ -31,6 +31,7 @@
 - 最小修正後: 同4 tests PASS（0.02秒）、既存実iroh testは無変更でPASS（0.32秒、196 filtered）。新規テストによる件数増加以外の既存assertion/feature gate変更なし。
 - `missing_preset_state_keeps_other_rooms_and_recovers_after_delivery` / `missing_preset_blob_keeps_other_rooms_and_recovers_after_delivery`: 通常gameを返し、保存room2件維持、配信後にDome hosting付きで2件へ復帰。
 - `mismatched_preset_reference_is_an_error_not_pending` / `invalid_preset_signature_is_an_error_not_pending`: metadata改変・署名内容改変のerrorを維持。
+- 独立監査の初回`08b403b3`は署名entry未到達の漏れでFAIL。追加した`missing_preset_envelope_keeps_other_rooms_and_recovers_after_delivery`と`current_instance_preset_controls_readiness_even_with_an_old_cache_row`は同headの製品でともにFAIL（既存4件PASS）。missing分類とcanonical Instanceでの取得待ち判定に修正後、6件すべてPASS（0.02秒）。現在headで独立delta監査を行う。
 - mandatory: `cargo xtask rust-test`、`cargo xtask app-api-slow-test`、`cargo xtask scenario community_node_public_connectivity`。全結果と監査対象SHAはPR/Issueへ記録し、未完をPASSへ読み替えない。
 
 ## 差し戻し

--- a/docs/progress/2026-09-08-927-dome-preset-listing.md
+++ b/docs/progress/2026-09-08-927-dome-preset-listing.md
@@ -1,0 +1,38 @@
+# Issue #927: Preset取得待ちによるDome一覧失敗
+
+## 固定範囲と原因
+
+- Scope revision `2026-09-08-872-H-04-v1`、区分C、before `ac9946d66aaf197204f669a10701fac8a13877e9`。
+- Context replicaのroom rowとauthor replicaのPreset state/blobは別々に到着する（ADR 0035/0036）。`list_game_rooms_scoped`はroom row到着だけで`get_dome_hosting`を呼び、Preset取得が`None`の段階も一覧全体のerrorにしていた。
+- 既存実iroh testはpeer ticket相互import→Dome作成→受信側room発見→event送受信を検証する。初回一覧のPreset未到達で141行がpanicし、event送信へ到達しなかった。fixtureの置換やwait/assertionの緩和は行わない。
+- 修正はscope/mute/Active判定後、各DomeのPresetが取得・検証できるか確認し、`None`だけその回の一覧から除外する。保存rowを削除せず次回refreshで再評価。検証errorは`?`で伝播し、不正reference/signatureを取得待ちへ落とさない。通常gameはそのまま返す。
+- `get_dome_hosting`とowner authorityの契約、wire/schema/署名形式、P2P三経路は変更しない。既存hosting_viewでも同Presetを検証するためcache済みの読み取りは重なるが、このfixへ構造整理を混ぜない。
+
+## 作業とAC / INVAR
+
+| 作業 | 対応 | 証拠 |
+| --- | --- | --- |
+| T1 原因と変更前再現 | AC-1、INV-1/2、TR-1 | Nightly2件、既存game.rs141のWindows再現、source call path、下記新規失敗test |
+| T2 最小修正と回帰 | AC-2/3、INV-2/3、TR-1/2/3 | game.rsの取得待ち判定のみ、dome_listing4 tests、元iroh test全assertionをそのまま通す |
+| T3 検証・独立監査・merge | AC-4、INVAR-1/2 | targeted/slow、必須Rust CI、connectivity、PR head独立監査、merge tree照合 |
+
+## Inventoryと逆引き
+
+- `list_game_rooms` → `list_game_rooms_scoped`の公開/privately scoped入口。Tauri `commands/live_game.rs` → runtime `sync_live_api.rs`、CLI登録handler、harness、testsから呼ばれる。
+- `list_game_rooms_scoped` → scope subscriptions / allowed channel / muted author / Active instance filter → `fetch_dome_preset_manifest` → author docs query / blob fetch / state-ref一致 / manifest validation / envelope署名とowner一致 → `get_dome_hosting` → view。
+- `fetch_dome_preset_manifest`の既存callerはowner hosting開始、hosting_view、Dome move。これらのerror policyは不変。新規callerはroom listingのみ。
+- sensitive sinkは既存docs/blob読み取り・取得とhosting projection。新規の永続mutation・index削除・権限拡張は0。既存scope/filter後に判定し、拒否データを成功として表示しない。
+- 再列挙: `rg -n 'list_game_rooms_scoped|list_game_rooms\(|fetch_dome_preset_manifest' crates apps/desktop/src-tauri`。worktreeはCodeGraph indexなし、rootのCodeGraphでsource確認後、worktreeの直接読取と完全symbol検索で補完。
+
+## 変更前後の証拠
+
+- 既存test before: `cargo test -p kukuri-app-api --features iroh-integration-tests metaverse_room_events_replicate_between_iroh_peers -- --nocapture` → exit101、1 FAIL/192 filtered、0.30秒。Nightly33988557825/34056551815と同じ `Dome preset manifest is unavailable`。
+- 新規`dome_listing` before（製品未変更）: 4件中2 FAIL/2 PASS。state未到達とblob未到達が同じerrorを再現。不正reference/署名拒否は既にPASS。
+- 最小修正後: 同4 tests PASS（0.02秒）、既存実iroh testは無変更でPASS（0.32秒、196 filtered）。新規テストによる件数増加以外の既存assertion/feature gate変更なし。
+- `missing_preset_state_keeps_other_rooms_and_recovers_after_delivery` / `missing_preset_blob_keeps_other_rooms_and_recovers_after_delivery`: 通常gameを返し、保存room2件維持、配信後にDome hosting付きで2件へ復帰。
+- `mismatched_preset_reference_is_an_error_not_pending` / `invalid_preset_signature_is_an_error_not_pending`: metadata改変・署名内容改変のerrorを維持。
+- mandatory: `cargo xtask rust-test`、`cargo xtask app-api-slow-test`、`cargo xtask scenario community_node_public_connectivity`。全結果と監査対象SHAはPR/Issueへ記録し、未完をPASSへ読み替えない。
+
+## 差し戻し
+
+このfix PRのみrevert。データ/schema移行なし。追加の再現testは原因追跡の証拠として保持し、既存testのskip/削除/期待値緩和はしない。


### PR DESCRIPTION
Refs #927。未同期のDome preset/envelopeが一つあるとMetaverse room一覧全体が失敗する問題を修正しました。欠落をtyped outcomeで区別し、そのroomだけを保留します。不正な参照・署名などのerrorは伝播させます。

- 種別 `fix`、区分C、Scope revision `2026-09-08-872-H-04-v1`。
- [計画・AC/INVAR・対象境界・検証・rollback記録](docs/progress/2026-09-08-927-dome-preset-listing.md)。詳細な独立監査とdeltaはPR commentsに保持。
- 修正前に既存実iroh testの失敗を再現。6つの欠落/不正/参照更新contractを追加し、既存test本体を変えずslow feature全199 tests PASS、独立delta監査PASS。
- 最終head `de3dec2a2d24699aa54be232d57fc645a7242b50` の全13 checks SUCCESS。必要な独立監査とCIを満たしてmergeしました。
- merge `2229fefaa479064bf8080bc55e2984acf025fc66` と監査対象のpath/surface一致を確認し、[Issue #927](https://github.com/KingYoSun/kukuri/issues/927)の現在判定をCompleteへ同期・Close済み。
