### PR TITLE
[codex][contract] CN Dome transferの途中失敗とretryを固定する

### DIFF
--- a/crates/desktop-runtime/src/tests/community_node/dome_hosting.rs
+++ b/crates/desktop-runtime/src/tests/community_node/dome_hosting.rs
@@ -1,7 +1,21 @@
 use super::super::*;
 use kukuri_cn_protocol::CONSENT_REQUIRED_CODE;
 
+mod transfer_contract;
+
 async fn dome_runtime() -> (
+    DesktopRuntime,
+    String,
+    Arc<MockManagedCommunityNodeState>,
+    tokio::task::JoinHandle<()>,
+    tempfile::TempDir,
+) {
+    dome_runtime_with_routes(Router::new()).await
+}
+
+async fn dome_runtime_with_routes(
+    extra_routes: Router,
+) -> (
     DesktopRuntime,
     String,
     Arc<MockManagedCommunityNodeState>,
@@ -38,7 +52,8 @@ async fn dome_runtime() -> (
             "/v1/dome-hosting/session/resync",
             post(mock_managed_dome_resync),
         )
-        .with_state(state.clone());
+        .with_state(state.clone())
+        .merge(extra_routes);
     let server = tokio::spawn(async move {
         axum::serve(listener, app).await.expect("mock server");
     });

--- a/crates/desktop-runtime/src/tests/community_node/dome_hosting/transfer_contract.rs
+++ b/crates/desktop-runtime/src/tests/community_node/dome_hosting/transfer_contract.rs
@@ -1,0 +1,548 @@
+use super::*;
+use kukuri_app_api::{CreateMetaverseRoomInput, DomeLayoutCommitOutcome, SubmitDomeSessionInput};
+use kukuri_cn_protocol::{
+    DOME_HOSTING_ACTIVATE_PATH, DOME_HOSTING_ASSIGNMENTS_PATH, DOME_HOSTING_LAYOUT_CANDIDATE_PATH,
+    DomeHostingActivationRequest, DomeHostingAssignmentRequest, DomeHostingAssignmentResponse,
+    DomeHostingLayoutCandidateRequest, DomeHostingLayoutCandidateResponse,
+    DomeHostingStatusResponse,
+};
+use kukuri_core::{
+    DomeHostingStateKindV1, DomeLayoutCandidateV1, DomeSessionInputKindV1,
+    MetaversePersistentPropV1, MetaversePrimitive, SpatialContextV1, TopicId,
+    accept_dome_hosting_lease, build_signed_dome_layout_candidate,
+    verify_signed_dome_hosting_lease,
+};
+
+// 0 success / 1 assignment HTTP failure / 2 invalid signed acceptance / 3 activation HTTP failure.
+struct TransferNode {
+    keys: KukuriKeys,
+    failure: AtomicUsize,
+    changed_layout: AtomicBool,
+    assignments: Mutex<Vec<DomeHostingAssignmentRequest>>,
+    acceptances: Mutex<Vec<kukuri_core::SignedDomeHostingAcceptanceV1>>,
+    activations: Mutex<Vec<DomeHostingActivationRequest>>,
+    candidates: AtomicUsize,
+}
+
+impl TransferNode {
+    fn new() -> Arc<Self> {
+        Arc::new(Self {
+            keys: KukuriKeys::generate(),
+            failure: AtomicUsize::new(0),
+            changed_layout: AtomicBool::new(false),
+            assignments: Mutex::new(Vec::new()),
+            acceptances: Mutex::new(Vec::new()),
+            activations: Mutex::new(Vec::new()),
+            candidates: AtomicUsize::new(0),
+        })
+    }
+    fn routes(self: &Arc<Self>) -> Router {
+        Router::new()
+            .route(DOME_HOSTING_ASSIGNMENTS_PATH, post(assign))
+            .route(DOME_HOSTING_ACTIVATE_PATH, post(activate))
+            .route(DOME_HOSTING_LAYOUT_CANDIDATE_PATH, post(candidate))
+            .with_state(self.clone())
+    }
+    async fn counts(&self) -> (usize, usize) {
+        (
+            self.assignments.lock().await.len(),
+            self.activations.lock().await.len(),
+        )
+    }
+}
+
+async fn assign(
+    State(node): State<Arc<TransferNode>>,
+    headers: HeaderMap,
+    Json(request): Json<DomeHostingAssignmentRequest>,
+) -> Result<Json<DomeHostingAssignmentResponse>, StatusCode> {
+    assert!(
+        headers
+            .get(AUTHORIZATION)
+            .expect("authenticated assignment")
+            .to_str()
+            .unwrap()
+            .starts_with("Bearer ")
+    );
+    verify_signed_dome_hosting_lease(&request.signed_lease, &request.instance_manifest)
+        .expect("owner-signed binding");
+    assert_eq!(
+        request.instance_manifest.preset_ref.revision,
+        request.preset_manifest.revision
+    );
+    assert_eq!(
+        request.instance_manifest.preset_ref.owner_pubkey,
+        request.preset_manifest.owner_pubkey
+    );
+    node.assignments.lock().await.push(request.clone());
+    if node.failure.load(Ordering::SeqCst) == 1 {
+        return Err(StatusCode::SERVICE_UNAVAILABLE);
+    }
+    let session = format!("node-session-{}", request.signed_lease.lease.epoch);
+    let mut signed_acceptance = accept_dome_hosting_lease(
+        &node.keys,
+        &request.signed_lease,
+        session.clone(),
+        Utc::now().timestamp_millis(),
+    )
+    .expect("node-signed acceptance");
+    if node.failure.load(Ordering::SeqCst) == 2 {
+        signed_acceptance.acceptance.session_id = "tampered-session".into();
+    }
+    node.acceptances
+        .lock()
+        .await
+        .push(signed_acceptance.clone());
+    Ok(Json(DomeHostingAssignmentResponse {
+        signed_acceptance,
+        state: DomeHostingStateKindV1::Transferring,
+        session_id: session,
+    }))
+}
+
+async fn activate(
+    State(node): State<Arc<TransferNode>>,
+    Json(request): Json<DomeHostingActivationRequest>,
+) -> Result<Json<DomeHostingStatusResponse>, StatusCode> {
+    request
+        .signed_activation
+        .envelope
+        .verify()
+        .expect("owner-signed activation");
+    let last = node
+        .assignments
+        .lock()
+        .await
+        .last()
+        .cloned()
+        .expect("assigned first");
+    let activation = &request.signed_activation.activation;
+    assert_eq!(request.instance_id, last.instance_manifest.instance_id);
+    assert_eq!(activation.lease_epoch, last.signed_lease.lease.epoch);
+    let accepted = node
+        .acceptances
+        .lock()
+        .await
+        .last()
+        .cloned()
+        .expect("acceptance");
+    assert_eq!(
+        activation.host_acceptance_envelope_id,
+        accepted.envelope.id.as_str()
+    );
+    node.activations.lock().await.push(request.clone());
+    if node.failure.load(Ordering::SeqCst) == 3 {
+        return Err(StatusCode::SERVICE_UNAVAILABLE);
+    }
+    Ok(Json(DomeHostingStatusResponse {
+        instance_id: request.instance_id,
+        state: DomeHostingStateKindV1::CommunityNodeHosted,
+        lease_epoch: activation.lease_epoch,
+        session_id: Some(accepted.acceptance.session_id),
+        participants: 0,
+        sleeping: true,
+        signed_heartbeat: None,
+        expires_at: last.signed_lease.lease.expires_at,
+        resource_budget: Default::default(),
+        resource_metrics: Default::default(),
+    }))
+}
+
+fn prop() -> MetaversePersistentPropV1 {
+    MetaversePersistentPropV1 {
+        prop_id: "contract-cube".into(),
+        asset_ref: None,
+        primitive_fallback: MetaversePrimitive::Cube,
+        position: [120, 100, 120],
+        rotation: [0, 0, 0],
+        scale: [100, 100, 100],
+        visual_only: false,
+        interactions: Vec::new(),
+        collider: None,
+    }
+}
+
+async fn candidate(
+    State(node): State<Arc<TransferNode>>,
+    Json(request): Json<DomeHostingLayoutCandidateRequest>,
+) -> Json<DomeHostingLayoutCandidateResponse> {
+    node.candidates.fetch_add(1, Ordering::SeqCst);
+    let current = node
+        .assignments
+        .lock()
+        .await
+        .last()
+        .cloned()
+        .expect("assigned");
+    let lease = &current.signed_lease.lease;
+    let persistent_props = if node.changed_layout.load(Ordering::SeqCst) {
+        vec![prop()]
+    } else {
+        current
+            .preset_manifest
+            .dome
+            .customization
+            .persistent_props
+            .clone()
+    };
+    Json(DomeHostingLayoutCandidateResponse {
+        signed_candidate: build_signed_dome_layout_candidate(
+            &node.keys,
+            lease,
+            DomeLayoutCandidateV1 {
+                operation_id: request.operation_id,
+                instance_id: request.instance_id,
+                instance_generation: lease.instance_generation,
+                lease_epoch: lease.epoch,
+                session_id: format!("node-session-{}", lease.epoch),
+                host_pubkey: node.keys.public_key(),
+                base_manifest_revision: current.preset_manifest.revision,
+                snapshot_sequence: 1,
+                captured_at: Utc::now().timestamp_millis(),
+                persistent_props,
+            },
+        )
+        .expect("signed candidate"),
+    })
+}
+
+async fn create_owner(runtime: &DesktopRuntime) -> (SpatialContextV1, String) {
+    let topic = "kukuri:topic:transfer-contract";
+    let instance = runtime
+        .app_service
+        .create_metaverse_room(
+            topic,
+            CreateMetaverseRoomInput {
+                title: "transfer boundary".into(),
+                description: String::new(),
+                max_peers: Some(4),
+            },
+        )
+        .await
+        .expect("Dome");
+    let context = SpatialContextV1::Topic {
+        topic_id: TopicId::new(topic),
+    };
+    runtime
+        .start_owner_dome_hosting(crate::StartOwnerDomeHostingRequest {
+            spatial_context: context.clone(),
+            instance_id: instance.clone(),
+            endpoint_id: "owner-device".into(),
+            lease_duration_millis: 600_000,
+        })
+        .await
+        .expect("owner hosting");
+    (context, instance)
+}
+
+fn delegate_request(
+    node: &TransferNode,
+    base_url: &str,
+    context: &SpatialContextV1,
+    instance: &str,
+) -> crate::DelegateDomeHostingRequest {
+    crate::DelegateDomeHostingRequest {
+        spatial_context: context.clone(),
+        instance_id: instance.into(),
+        node_id: node.keys.public_key_hex(),
+        base_url: base_url.into(),
+        lease_duration_millis: 600_000,
+    }
+}
+
+fn layout_request(context: &SpatialContextV1, instance: &str) -> crate::CommitDomeLayoutRequest {
+    crate::CommitDomeLayoutRequest {
+        spatial_context: context.clone(),
+        instance_id: instance.into(),
+        operation_id: "layout-once".into(),
+    }
+}
+
+async fn saved_layout_operations(
+    runtime: &DesktopRuntime,
+    context: &SpatialContextV1,
+    instance: &str,
+) -> usize {
+    let current = runtime.iroh_stack.current.lock().await;
+    let docs = current.as_ref().expect("runtime stack").docs_sync.clone();
+    drop(current);
+    docs.query_replica(
+        &kukuri_docs_sync::topic_replica_id(context.topic_id().as_str()),
+        DocQuery::Prefix(format!("metaverse/dome-layout-commits/{instance}/")),
+    )
+    .await
+    .expect("saved layout operations")
+    .len()
+}
+
+#[tokio::test]
+async fn public_delegation_preserves_each_transfer_failure_boundary_and_retry() {
+    let _resource = lock_test_resource(TestResource::CommunityNodeServer).await;
+    for failure in 0..=3 {
+        let node = TransferNode::new();
+        let (runtime, base_url, _, server, _dir) = dome_runtime_with_routes(node.routes()).await;
+        seed_local_community_node_consents(&runtime, &base_url, 1);
+        let (context, instance) = create_owner(&runtime).await;
+        node.failure.store(failure, Ordering::SeqCst);
+        let result = runtime
+            .delegate_dome_hosting(delegate_request(&node, &base_url, &context, &instance))
+            .await;
+        assert_eq!(result.is_ok(), failure == 0, "failure {failure}");
+        let saved = runtime
+            .app_service
+            .get_dome_hosting(context.clone(), &instance)
+            .await
+            .expect("saved hosting");
+        assert_eq!(saved.state.lease_epoch, Some(2));
+        assert_eq!(
+            node.counts().await,
+            (1, usize::from(failure == 0 || failure == 3))
+        );
+        if failure == 1 || failure == 2 {
+            assert_eq!(saved.state.kind, DomeHostingStateKindV1::Transferring);
+            assert!(saved.signed_activation_json.is_none());
+        } else {
+            assert_eq!(
+                saved.state.kind,
+                DomeHostingStateKindV1::CommunityNodeHosted
+            );
+            assert_eq!(saved.state.session_id.as_deref(), Some("node-session-2"));
+            assert!(
+                saved.signed_activation_json.is_some(),
+                "HTTP failure must not undo saved activation"
+            );
+        }
+        if failure != 0 {
+            node.failure.store(0, Ordering::SeqCst);
+            let retried = runtime
+                .delegate_dome_hosting(delegate_request(&node, &base_url, &context, &instance))
+                .await
+                .expect("retry delegation");
+            assert_eq!(retried.state.lease_epoch, Some(3));
+            assert_eq!(retried.state.session_id.as_deref(), Some("node-session-3"));
+        }
+        runtime.shutdown().await;
+        server.abort();
+    }
+}
+
+#[tokio::test]
+async fn public_layout_restart_preserves_transfer_failure_and_operation_retry() {
+    let _resource = lock_test_resource(TestResource::CommunityNodeServer).await;
+    for failure in 0..=3 {
+        let node = TransferNode::new();
+        let (runtime, base_url, _, server, _dir) = dome_runtime_with_routes(node.routes()).await;
+        seed_local_community_node_consents(&runtime, &base_url, 1);
+        let (context, instance) = create_owner(&runtime).await;
+        runtime
+            .delegate_dome_hosting(delegate_request(&node, &base_url, &context, &instance))
+            .await
+            .expect("initial delegation");
+        node.changed_layout.store(true, Ordering::SeqCst);
+        node.failure.store(failure, Ordering::SeqCst);
+        let result = runtime
+            .commit_dome_layout(layout_request(&context, &instance))
+            .await;
+        assert_eq!(result.is_ok(), failure == 0, "failure {failure}");
+        let saved = runtime
+            .app_service
+            .get_dome_hosting(context.clone(), &instance)
+            .await
+            .expect("saved hosting");
+        assert_eq!(saved.state.lease_epoch, Some(3));
+        let manifest: kukuri_core::DomePresetManifestV1 =
+            serde_json::from_str(&saved.preset_manifest_json).expect("preset");
+        assert_eq!(manifest.revision, 2);
+        assert_eq!(manifest.dome.customization.persistent_props, vec![prop()]);
+        assert_eq!(
+            saved_layout_operations(&runtime, &context, &instance).await,
+            1
+        );
+        let before_retry = node.counts().await;
+        assert_eq!(
+            before_retry,
+            (2, 1 + usize::from(failure == 0 || failure == 3))
+        );
+        assert_eq!(
+            saved.signed_activation_json.is_some(),
+            failure == 0 || failure == 3
+        );
+        node.failure.store(0, Ordering::SeqCst);
+        let retried = runtime
+            .commit_dome_layout(layout_request(&context, &instance))
+            .await
+            .expect("retry same operation");
+        assert_eq!(retried.revision, 2);
+        assert_eq!(retried.hosting.state.lease_epoch, Some(3));
+        assert_eq!(
+            saved_layout_operations(&runtime, &context, &instance).await,
+            1
+        );
+        if failure == 1 || failure == 2 {
+            assert_eq!(node.counts().await, (3, 2));
+        } else {
+            assert_eq!(
+                node.counts().await,
+                before_retry,
+                "already activated operation sends no new transfer"
+            );
+        }
+        assert_eq!(node.candidates.load(Ordering::SeqCst), 2);
+        runtime.shutdown().await;
+        server.abort();
+    }
+}
+
+#[tokio::test]
+async fn cn_noop_and_owner_layout_changes_do_not_send_transfer_requests() {
+    let _resource = lock_test_resource(TestResource::CommunityNodeServer).await;
+    let node = TransferNode::new();
+    let (runtime, base_url, _, server, _dir) = dome_runtime_with_routes(node.routes()).await;
+    seed_local_community_node_consents(&runtime, &base_url, 1);
+    let (context, instance) = create_owner(&runtime).await;
+    let no_op = runtime
+        .commit_dome_layout(layout_request(&context, &instance))
+        .await
+        .expect("owner no-op");
+    assert_eq!(no_op.outcome, DomeLayoutCommitOutcome::NoOp);
+    assert_eq!(no_op.revision, 1);
+    assert_eq!(
+        saved_layout_operations(&runtime, &context, &instance).await,
+        0
+    );
+    runtime
+        .app_service
+        .submit_dome_session_input(SubmitDomeSessionInput {
+            spatial_context: context.clone(),
+            instance_id: instance.clone(),
+            sequence: 1,
+            input: DomeSessionInputKindV1::UpsertPersistentProp { prop: prop() },
+        })
+        .await
+        .expect("owner changes layout");
+    let committed = runtime
+        .commit_dome_layout(layout_request(&context, &instance))
+        .await
+        .expect("owner commit");
+    assert_eq!(committed.revision, 2);
+    assert_eq!(
+        committed.hosting.state.kind,
+        DomeHostingStateKindV1::OwnerHosted
+    );
+    assert_eq!(committed.hosting.state.lease_epoch, Some(2));
+    let retry = runtime
+        .commit_dome_layout(layout_request(&context, &instance))
+        .await
+        .expect("owner retry");
+    assert_eq!(retry.revision, committed.revision);
+    assert_eq!(retry.signed_commit_json, committed.signed_commit_json);
+    assert_eq!(
+        saved_layout_operations(&runtime, &context, &instance).await,
+        1
+    );
+    assert_eq!(node.counts().await, (0, 0));
+    runtime
+        .delegate_dome_hosting(delegate_request(&node, &base_url, &context, &instance))
+        .await
+        .expect("delegate");
+    let no_op = runtime
+        .commit_dome_layout(crate::CommitDomeLayoutRequest {
+            operation_id: "cn-noop".into(),
+            ..layout_request(&context, &instance)
+        })
+        .await
+        .expect("CN no-op");
+    assert_eq!(no_op.outcome, DomeLayoutCommitOutcome::NoOp);
+    assert_eq!(no_op.revision, 2);
+    assert_eq!(
+        saved_layout_operations(&runtime, &context, &instance).await,
+        1
+    );
+    assert_eq!(node.counts().await, (1, 1));
+    assert_eq!(node.candidates.load(Ordering::SeqCst), 1);
+    runtime.shutdown().await;
+    server.abort();
+}
+
+#[tokio::test]
+async fn public_transfer_entries_cannot_bypass_current_consent_or_configured_node() {
+    let _resource = lock_test_resource(TestResource::CommunityNodeServer).await;
+    for layout in [false, true] {
+        for guard in 0..4 {
+            if layout && guard == 0 {
+                continue;
+            } // CN layout starts from a previously consented lease.
+            let node = TransferNode::new();
+            let (runtime, base_url, managed, server, _dir) =
+                dome_runtime_with_routes(node.routes()).await;
+            if guard != 0 {
+                seed_local_community_node_consents(&runtime, &base_url, 1);
+            }
+            let (context, instance) = create_owner(&runtime).await;
+            if layout {
+                runtime
+                    .delegate_dome_hosting(delegate_request(&node, &base_url, &context, &instance))
+                    .await
+                    .expect("initial delegation");
+            }
+            match guard {
+                0 => {}
+                1 => {
+                    runtime
+                        .withdraw_community_node_consents(crate::CommunityNodeTargetRequest {
+                            base_url: base_url.clone(),
+                        })
+                        .await
+                        .expect("withdraw consent");
+                }
+                2 => {
+                    managed
+                        .simulate_pending_update
+                        .store(true, Ordering::SeqCst);
+                }
+                _ => {
+                    *runtime.community_node_config.lock().await = CommunityNodeConfig::default();
+                }
+            }
+            let requests = node.counts().await;
+            let auth = (
+                managed.challenge_hits.load(Ordering::SeqCst),
+                managed.verify_hits.load(Ordering::SeqCst),
+            );
+            let result = if layout {
+                runtime
+                    .commit_dome_layout(layout_request(&context, &instance))
+                    .await
+                    .map(|_| ())
+            } else {
+                runtime
+                    .delegate_dome_hosting(delegate_request(&node, &base_url, &context, &instance))
+                    .await
+                    .map(|_| ())
+            };
+            let error = result.expect_err("guard rejects public entry");
+            let error = error
+                .downcast_ref::<crate::DomeHostingRequestError>()
+                .expect("typed rejection");
+            assert_eq!(
+                error.code,
+                if guard == 3 {
+                    "DOME_HOSTING_TARGET_NOT_CONFIGURED"
+                } else {
+                    CONSENT_REQUIRED_CODE
+                }
+            );
+            assert_eq!(node.counts().await, requests);
+            assert_eq!(node.candidates.load(Ordering::SeqCst), 0);
+            assert_eq!(
+                (
+                    managed.challenge_hits.load(Ordering::SeqCst),
+                    managed.verify_hits.load(Ordering::SeqCst)
+                ),
+                auth
+            );
+            runtime.shutdown().await;
+            server.abort();
+        }
+    }
+}

--- a/crates/desktop-runtime/src/tests/community_node/dome_hosting/transfer_contract.rs
+++ b/crates/desktop-runtime/src/tests/community_node/dome_hosting/transfer_contract.rs
@@ -22,6 +22,7 @@ struct TransferNode {
     acceptances: Mutex<Vec<kukuri_core::SignedDomeHostingAcceptanceV1>>,
     activations: Mutex<Vec<DomeHostingActivationRequest>>,
     candidates: AtomicUsize,
+    policy_update_after_assignment: Mutex<Option<Arc<MockManagedCommunityNodeState>>>,
 }
 
 impl TransferNode {
@@ -34,6 +35,7 @@ impl TransferNode {
             acceptances: Mutex::new(Vec::new()),
             activations: Mutex::new(Vec::new()),
             candidates: AtomicUsize::new(0),
+            policy_update_after_assignment: Mutex::new(None),
         })
     }
     fn routes(self: &Arc<Self>) -> Router {
@@ -93,6 +95,11 @@ async fn assign(
         .lock()
         .await
         .push(signed_acceptance.clone());
+    if let Some(managed) = node.policy_update_after_assignment.lock().await.as_ref() {
+        managed
+            .simulate_pending_update
+            .store(true, Ordering::SeqCst);
+    }
     Ok(Json(DomeHostingAssignmentResponse {
         signed_acceptance,
         state: DomeHostingStateKindV1::Transferring,
@@ -294,6 +301,17 @@ async fn public_delegation_preserves_each_transfer_failure_boundary_and_retry() 
             .await
             .expect("saved hosting");
         assert_eq!(saved.state.lease_epoch, Some(2));
+        if failure == 0 {
+            let returned = result.expect("successful delegation view");
+            assert_eq!(returned.state.kind, saved.state.kind);
+            assert_eq!(returned.state.lease_epoch, saved.state.lease_epoch);
+            assert_eq!(returned.state.session_id, saved.state.session_id);
+            assert_eq!(returned.signed_lease_json, saved.signed_lease_json);
+            assert_eq!(
+                returned.signed_activation_json,
+                saved.signed_activation_json
+            );
+        }
         assert_eq!(
             node.counts().await,
             (1, usize::from(failure == 0 || failure == 3))
@@ -350,6 +368,20 @@ async fn public_layout_restart_preserves_transfer_failure_and_operation_retry() 
             .await
             .expect("saved hosting");
         assert_eq!(saved.state.lease_epoch, Some(3));
+        if failure == 0 {
+            let returned = result.expect("successful layout view");
+            assert_eq!(returned.outcome, DomeLayoutCommitOutcome::Committed);
+            assert_eq!(returned.revision, 2);
+            assert_eq!(returned.operation_id, "layout-once");
+            assert!(returned.signed_commit_json.is_some());
+            assert_eq!(returned.hosting.state.lease_epoch, saved.state.lease_epoch);
+            assert_eq!(returned.hosting.state.session_id, saved.state.session_id);
+            assert_eq!(returned.hosting.signed_lease_json, saved.signed_lease_json);
+            assert_eq!(
+                returned.hosting.signed_activation_json,
+                saved.signed_activation_json
+            );
+        }
         let manifest: kukuri_core::DomePresetManifestV1 =
             serde_json::from_str(&saved.preset_manifest_json).expect("preset");
         assert_eq!(manifest.revision, 2);
@@ -462,6 +494,56 @@ async fn cn_noop_and_owner_layout_changes_do_not_send_transfer_requests() {
     assert_eq!(node.candidates.load(Ordering::SeqCst), 1);
     runtime.shutdown().await;
     server.abort();
+}
+
+#[tokio::test]
+async fn activation_rechecks_current_consent_after_assignment_for_both_entries() {
+    let _resource = lock_test_resource(TestResource::CommunityNodeServer).await;
+    for layout in [false, true] {
+        let node = TransferNode::new();
+        let (runtime, base_url, managed, server, _dir) =
+            dome_runtime_with_routes(node.routes()).await;
+        seed_local_community_node_consents(&runtime, &base_url, 1);
+        let (context, instance) = create_owner(&runtime).await;
+        if layout {
+            runtime
+                .delegate_dome_hosting(delegate_request(&node, &base_url, &context, &instance))
+                .await
+                .expect("initial delegation");
+            node.changed_layout.store(true, Ordering::SeqCst);
+        }
+        *node.policy_update_after_assignment.lock().await = Some(managed.clone());
+        let before = node.counts().await;
+        let result = if layout {
+            runtime
+                .commit_dome_layout(layout_request(&context, &instance))
+                .await
+                .map(|_| ())
+        } else {
+            runtime
+                .delegate_dome_hosting(delegate_request(&node, &base_url, &context, &instance))
+                .await
+                .map(|_| ())
+        };
+        let error = result.expect_err("new policy stops activation HTTP");
+        assert_eq!(
+            error
+                .downcast_ref::<crate::DomeHostingRequestError>()
+                .expect("typed guard")
+                .code,
+            CONSENT_REQUIRED_CODE
+        );
+        assert_eq!(node.counts().await, (before.0 + 1, before.1));
+        let saved = runtime
+            .app_service
+            .get_dome_hosting(context, &instance)
+            .await
+            .expect("saved activation");
+        assert!(saved.signed_activation_json.is_some());
+        assert_eq!(saved.state.lease_epoch, Some(if layout { 3 } else { 2 }));
+        runtime.shutdown().await;
+        server.abort();
+    }
 }
 
 #[tokio::test]

--- a/crates/desktop-runtime/src/tests/support/lock_contract.rs
+++ b/crates/desktop-runtime/src/tests/support/lock_contract.rs
@@ -18,6 +18,11 @@ const LOCK_CLASSIFICATION: &[(&str, &str, usize)] = &[
     ("community_node/config.rs", "ProcessEnvironment", 5),
     ("community_node/connectivity.rs", "IrohNetwork", 6),
     ("community_node/dome_hosting.rs", "CommunityNodeServer", 6),
+    (
+        "community_node/dome_hosting/transfer_contract.rs",
+        "CommunityNodeServer",
+        5,
+    ),
     ("community_node/index_query.rs", "CommunityNodeServer", 14),
     ("community_node/metadata.rs", "CommunityNodeServer", 10),
     (
@@ -108,12 +113,13 @@ fn lock_acquisitions_match_declared_classification() {
     );
     let total: usize = expected.values().sum();
     assert_eq!(
-        total, 123,
+        total, 128,
         "classification total drifted from the Q7 T6 baseline(#711 で index_query 試験を 1 件、\
          #802 で tester_feedback_submission 試験を 3 件、#862 で config 永続化試験を 2 件、\
          #855 で device_backup 試験を 7 件、recovery 試験を 13 件へ拡充、\
          #857 で report consent gate 試験を 3 件、\
          Dome hosting consent gate 試験を 6 件、固定面回帰で session・metadata・report を各 1 件追加、
-         transition rerun で index_query 試験を 3 件、tester feedback・trust relation 試験を各 1 件追加)"
+         transition rerun で index_query 試験を 3 件、tester feedback・trust relation 試験を各 1 件追加、
+         #921 で Dome transfer contract の CommunityNodeServer 取得を 5 件追加)"
     );
 }

--- a/docs/progress/2026-09-08-921-dome-transfer-contract.md
+++ b/docs/progress/2026-09-08-921-dome-transfer-contract.md
@@ -20,6 +20,7 @@
 | INV-2、TR-1/2/3/4 | `public_layout_restart_preserves_transfer_failure_and_operation_retry`: 同4条件をlayout再起動で確認。revision2/operation1/epoch3の保存、同operation retryではrevision/operationを増やさない。未activation時は同leaseでtransfer再送、既にactivation保存済みなら再送しない |
 | INV-2、TR-4 | `cn_noop_and_owner_layout_changes_do_not_send_transfer_requests`: owner no-opはoperation0、owner新規変更はrevision/operation/lease更新を許可しCN送信0、retryで追加保存0。CN no-opはcandidate取得だけでassignment/activationを増やさない |
 | INV-3、TR-5 | `public_transfer_entries_cannot_bypass_current_consent_or_configured_node`: public delegationの未同意と、両入口の撤回/現行版変更/未登録拒否。新規assignment/activation/candidate0、challenge/verify不変。policy preflightの許可された取得は禁じない |
+| INV-1/2/3、TR-3/5 | `activation_rechecks_current_consent_after_assignment_for_both_entries`: assignment応答を返すmockがpolicyを更新し、両入口でactivation自身のpreflightがCONSENT_REQUIREDを返す。owner activationは保存済み、activation HTTPは増えない |
 | INV-3、TR-5 | 既存6 adapter testsは未同意、撤回、版変更、未登録、同意済み、401再認証を保持。authorityの署名/manifest整合は既存AppService2 testsとmock受信時のcore verifier・acceptance ID一致でも確認 |
 
 後段activation HTTP失敗でもownerの署名済みactivationは保存済み。同operationのlayout retryは前段candidateを取得するがtransferを再送しない、という現行挙動をそのまま記録する。このcontractへrollback/retry policy修正を混ぜない。
@@ -38,6 +39,7 @@ Tauri `commands/live_game.rs`とCLI `commands/live_metaverse.rs`の2command登�
 
 - before `cargo test -p kukuri-desktop-runtime tests::community_node::dome_hosting`: 6 PASS（0.54秒）。
 - 初回after: 既存6+新規4 tests PASS（5.93秒）。新規4 tests内で両入口の4failure条件と7guard条件等を実行。保存operation数のassert追加後の最終結果とCI/監査headはPR/Issueへ記録する。
+- 独立監査で返却viewの直接比較とassignment後のactivate再guardの証拠補強を指摘。成功時の返却lease/session/署名recordと保存状態の一致を追加し、policy更新を跨ぐ両入口のtestを追加。既存6+新規5の11 tests PASS（8.28秒）、最終headでdelta監査する。
 - 必須: 同targeted、`cargo test -p kukuri-app-api tests::dome_hosting`、`cargo xtask rust-test`。CIが全Rustの結果を担う場合は対象SHAとjobを記録し、local targetedを全suite成功と呼ばない。
 - UI/IPC/製品source変更なし。静的確認は`git diff --check`と製品diff0。
 

--- a/docs/progress/2026-09-08-921-dome-transfer-contract.md
+++ b/docs/progress/2026-09-08-921-dome-transfer-contract.md
@@ -42,6 +42,7 @@ Tauri `commands/live_game.rs`とCLI `commands/live_metaverse.rs`の2command登�
 - 独立監査で返却viewの直接比較とassignment後のactivate再guardの証拠補強を指摘。成功時の返却lease/session/署名recordと保存状態の一致を追加し、policy更新を跨ぐ両入口のtestを追加。既存6+新規5の11 tests PASS（8.28秒）、最終headでdelta監査する。
 - 必須: 同targeted、`cargo test -p kukuri-app-api tests::dome_hosting`、`cargo xtask rust-test`。CIが全Rustの結果を担う場合は対象SHAとjobを記録し、local targetedを全suite成功と呼ばない。
 - UI/IPC/製品source変更なし。静的確認は`git diff --check`と製品diff0。
+- CI `34146718415`で`tests::support::lock_contract::lock_acquisitions_match_declared_classification`がFAIL。新testのCommunityNodeServer lock取得5箇所を分類表に反映していなかったため、明示entryを追加し総数123→128へ同期した。scan/全件一致のassertは保持し、未分類追加の検出を弱めない。該当testと全CIを修正headで再実行する。
 
 ## Rollback
 

--- a/docs/progress/2026-09-08-921-dome-transfer-contract.md
+++ b/docs/progress/2026-09-08-921-dome-transfer-contract.md
@@ -1,0 +1,46 @@
+# Issue #921: runtimeのCN Dome transfer境界を固定
+
+- Scope revision `2026-09-08-872-C-RT-v1`、区分C。before `36e3732edfb68e0637a60e7badf4c778d0530e4d`（#928の文書同期後、製品は監査開始ac9946d6と同じ）。
+- 対象はtest fixtureと新規contract、記録のみ。後続#922の製品抽出前に実行する。全10IssueについてユーザーのCI/独立監査後merge承認あり。
+- `dome_runtime`の既存fixtureへ追加routeを渡せるtest-only入口を用意し、既存6 testsは従来と同じ空の追加routeで実行する。
+- 新規`tests/community_node/dome_hosting/transfer_contract.rs`はpublic runtime `delegate_dome_hosting` / `commit_dome_layout`を呼び、local HTTP受信、署名済みlease/acceptance/activation、保存済みhosting/manifest/layout operationを観測する。AppService直呼出は初期Dome/owner/inputの準備と保存状態の読取だけ。
+
+| 作業 | AC / INVAR | 対象・検証 | 依存 |
+| --- | --- | --- | --- |
+| T1 基準・全caller | AC-1/3、INVAR-1 | public runtime2入口、Tauri/CLI登録、3 HTTP adapterとAppService authorityを確認、既存6 tests before実行 | なし |
+| T2 途中失敗・retry保護 | AC-1/2、INVAR-1/2 | 下記failure matrix、HTTP回数・signed state・保存operation数 | T1 |
+| T3 guard・必要な検証 | AC-3、INVAR-1/2 | missing/withdrawn/current policy/configured node、existing AppService contract、rust-test CI | T2 |
+| T4 独立監査/CI/merge | 全AC/INVAR | 固定head、別担当監査、CI、merge tree照合。結果はPR/Issue | T3 |
+
+## Inventory / transition / test対応
+
+| 固定集合 | 実行証拠 |
+| --- | --- |
+| INV-1、TR-1/2/3 | `public_delegation_preserves_each_transfer_failure_boundary_and_retry`: success/assignment503/tampered acceptance/activation503。新epoch2の保存、activation送信回数、前段失敗でactivation未保存、後段失敗では保存済みactivation維持。新delegation retryはepoch3へ進む |
+| INV-2、TR-1/2/3/4 | `public_layout_restart_preserves_transfer_failure_and_operation_retry`: 同4条件をlayout再起動で確認。revision2/operation1/epoch3の保存、同operation retryではrevision/operationを増やさない。未activation時は同leaseでtransfer再送、既にactivation保存済みなら再送しない |
+| INV-2、TR-4 | `cn_noop_and_owner_layout_changes_do_not_send_transfer_requests`: owner no-opはoperation0、owner新規変更はrevision/operation/lease更新を許可しCN送信0、retryで追加保存0。CN no-opはcandidate取得だけでassignment/activationを増やさない |
+| INV-3、TR-5 | `public_transfer_entries_cannot_bypass_current_consent_or_configured_node`: public delegationの未同意と、両入口の撤回/現行版変更/未登録拒否。新規assignment/activation/candidate0、challenge/verify不変。policy preflightの許可された取得は禁じない |
+| INV-3、TR-5 | 既存6 adapter testsは未同意、撤回、版変更、未登録、同意済み、401再認証を保持。authorityの署名/manifest整合は既存AppService2 testsとmock受信時のcore verifier・acceptance ID一致でも確認 |
+
+後段activation HTTP失敗でもownerの署名済みactivationは保存済み。同operationのlayout retryは前段candidateを取得するがtransferを再送しない、という現行挙動をそのまま記録する。このcontractへrollback/retry policy修正を混ぜない。
+
+## 全callerと凍結境界
+
+CodeGraphでruntime2入口・共通CN adapter・core署名/候補検証・AppService layoutを確認。補完検索:
+
+```powershell
+rg -n 'delegate_dome_hosting|commit_dome_layout|assign_dome_hosting_to_community_node|activate_dome_hosting_on_community_node|build_dome_hosting_assignment_request' crates apps/desktop/src-tauri -g '*.rs'
+```
+
+Tauri `commands/live_game.rs`とCLI `commands/live_metaverse.rs`の2command登録→runtime→CN assignment/activationとAppService保存、CN layout candidateの経路を固定。request/response shape、error context、owner authority、同意guard、signed record、schema/public APIは無変更。製品inventory差分0、対象未分類0。
+
+## Validation
+
+- before `cargo test -p kukuri-desktop-runtime tests::community_node::dome_hosting`: 6 PASS（0.54秒）。
+- 初回after: 既存6+新規4 tests PASS（5.93秒）。新規4 tests内で両入口の4failure条件と7guard条件等を実行。保存operation数のassert追加後の最終結果とCI/監査headはPR/Issueへ記録する。
+- 必須: 同targeted、`cargo test -p kukuri-app-api tests::dome_hosting`、`cargo xtask rust-test`。CIが全Rustの結果を担う場合は対象SHAとjobを記録し、local targetedを全suite成功と呼ばない。
+- UI/IPC/製品source変更なし。静的確認は`git diff --check`と製品diff0。
+
+## Rollback
+
+このtest-only PRを単独revert可能。#922開始後は先にrefactorを戻す。新規contractと現行仕様の不一致が見つかった場合はfixへ分け、期待値を弱めて抽出を始めない。


### PR DESCRIPTION
Refs #921。CN Dome transferの2入口について、成功view、途中失敗、guard、same-operation/no-op、assignment後のpolicy更新を固定しました。禁止HTTPと永続状態を検証し、製品コードは変更していません。

- 種別 `contract`、区分C、Scope revision `2026-09-08-872-C-RT-v1`。
- [計画・AC/INVAR・対象境界・検証・rollback記録](docs/progress/2026-09-08-921-dome-transfer-contract.md)。詳細な独立監査とdeltaはPR commentsに保持。
- 既存6+新5の11 testsとlock分類の完全一致検査PASS。最初の分類登録漏れを修正し、独立delta監査PASS。
- 最終head `54c001d2f6fa944083cffc48da5912094d6f4128` の全13 checks SUCCESS。必要な独立監査とCIを満たしてmergeしました。
- merge `d5c7769a9c73c76ccfeabb8b0b0453d495b1e1b6` と監査対象のpath/surface一致を確認し、[Issue #921](https://github.com/KingYoSun/kukuri/issues/921)の現在判定をCompleteへ同期・Close済み。
