### PR TITLE
[codex][refactor:extract] 通知取得とstate反映を単一loaderへ集約する

### DIFF
--- a/apps/desktop/src/shell/data/loaders/useDesktopShellSectionLoaders.test.tsx
+++ b/apps/desktop/src/shell/data/loaders/useDesktopShellSectionLoaders.test.tsx
@@ -4,6 +4,7 @@ import { describe, expect, test, vi } from 'vitest';
 
 import { createDesktopMockApi } from '@/mocks/desktopApiMock';
 import { useDesktopShellSectionLoaders } from '@/shell/data/loaders/useDesktopShellSectionLoaders';
+import { useNotificationLoaders } from '@/shell/data/loaders/useNotificationLoaders';
 import { privateTimelineScope } from '@/shell/presentation';
 import {
   createDesktopShellStore,
@@ -15,17 +16,23 @@ function setup() {
   const api = createDesktopMockApi();
   const store = createDesktopShellStore();
   const loadReactionCatalogData = vi.fn().mockResolvedValue(undefined);
+  const translate = (key: string) => key;
   const wrapper = ({ children }: { children: ReactNode }) => (
     <DesktopShellStoreContext.Provider value={store}>{children}</DesktopShellStoreContext.Provider>
   );
   const hook = renderHook(
-    () =>
-      useDesktopShellSectionLoaders({
+    () => {
+      const { loadNotificationsSection } = useNotificationLoaders({
+        api, translate, activePrimarySection: 'notifications',
+      });
+      return useDesktopShellSectionLoaders({
         api,
         loadReactionCatalogData,
+        loadNotificationsSection,
         storeApi: store,
-        translate: (key) => key,
-      }),
+        translate,
+      });
+    },
     { wrapper }
   );
   return { api, hook, store };

--- a/apps/desktop/src/shell/data/loaders/useDesktopShellSectionLoaders.ts
+++ b/apps/desktop/src/shell/data/loaders/useDesktopShellSectionLoaders.ts
@@ -1,10 +1,11 @@
 import { startTransition, useCallback } from 'react';
 
-import type { CommunityNodeNodeStatus, DesktopApi, NotificationView } from '@/lib/api';
+import type { CommunityNodeNodeStatus, DesktopApi } from '@/lib/api';
 import {
   eligibleCommunityIndexNodes,
   resolveCommunityIndexNodePreference,
 } from '@/lib/api/communityIndex';
+import type { LoadNotificationsSection } from '@/shell/data/loaders/useNotificationLoaders';
 import { VISIBLE_TIMELINE_LIMIT } from '@/shell/pagination';
 import {
   authorViewFromDirectMessageConversation,
@@ -30,6 +31,7 @@ import {
 type UseDesktopShellSectionLoadersArgs = {
   api: DesktopApi;
   loadReactionCatalogData: () => Promise<void>;
+  loadNotificationsSection: LoadNotificationsSection;
   storeApi: DesktopShellStoreApi;
   translate: (key: string, options?: Record<string, unknown>) => string;
 };
@@ -37,6 +39,7 @@ type UseDesktopShellSectionLoadersArgs = {
 export function useDesktopShellSectionLoaders({
   api,
   loadReactionCatalogData,
+  loadNotificationsSection,
   storeApi,
   translate,
 }: UseDesktopShellSectionLoadersArgs) {
@@ -70,12 +73,6 @@ export function useDesktopShellSectionLoaders({
   const setLiveSessionsByScopeKey = useDesktopShellFieldSetter('liveSessionsByScopeKey');
   const setLocalPeerTicket = useDesktopShellFieldSetter('localPeerTicket');
   const setLocalProfile = useDesktopShellFieldSetter('localProfile');
-  const setNotificationAutoReadError = useDesktopShellFieldSetter(
-    'notificationAutoReadError'
-  );
-  const setNotificationPanelState = useDesktopShellFieldSetter('notificationPanelState');
-  const setNotifications = useDesktopShellFieldSetter('notifications');
-  const setNotificationStatus = useDesktopShellFieldSetter('notificationStatus');
   const setProfileDraft = useDesktopShellFieldSetter('profileDraft');
   const setProfileError = useDesktopShellFieldSetter('profileError');
   const setProfilePanelState = useDesktopShellFieldSetter('profilePanelState');
@@ -310,58 +307,6 @@ export function useDesktopShellSectionLoaders({
     storeApi,
     translate,
   ]);
-
-  const loadNotificationsSection = useCallback(
-    async (options: { markAsRead?: boolean } = {}) => {
-      const markAsRead = options.markAsRead ?? true;
-      try {
-        const [status, notificationItems] = await Promise.all([
-          api.getNotificationStatus(),
-          api.listNotifications(),
-        ]);
-        let nextNotifications: NotificationView[] = notificationItems;
-        let nextStatus = status;
-        if (markAsRead && notificationItems.some((notification) => !notification.read_at)) {
-          try {
-            nextStatus = await api.markAllNotificationsRead();
-            const readAt = Date.now();
-            nextNotifications = notificationItems.map((notification) =>
-              notification.read_at ? notification : { ...notification, read_at: readAt }
-            );
-            setNotificationAutoReadError(null);
-          } catch (notificationReadError) {
-            setNotificationAutoReadError(
-              messageFromError(
-                notificationReadError,
-                translate('shell:notifications.errors.failedAutoRead')
-              )
-            );
-          }
-        }
-        startTransition(() => {
-          setNotificationStatus(nextStatus);
-          setNotifications(nextNotifications);
-          setNotificationPanelState({ status: 'ready', error: null });
-        });
-      } catch (error) {
-        setNotificationPanelState({
-          status: 'error',
-          error: messageFromError(
-            error,
-            translate('shell:notifications.errors.failedToLoad')
-          ),
-        });
-      }
-    },
-    [
-      api,
-      setNotificationAutoReadError,
-      setNotificationPanelState,
-      setNotifications,
-      setNotificationStatus,
-      translate,
-    ]
-  );
 
   const loadBookmarksSection = useCallback(async () => {
     try {

--- a/apps/desktop/src/shell/data/loaders/useDesktopShellSectionLoaders.ts
+++ b/apps/desktop/src/shell/data/loaders/useDesktopShellSectionLoaders.ts
@@ -515,7 +515,7 @@ export function useDesktopShellSectionLoaders({
   );
 
   // 個別 loader も公開する: section 遷移起点の effect(useDesktopShellDataEffects)が
-  // 同じ実装を呼ぶための SSoT。取得・state 反映ロジックはこのファイルにだけ置く。
+  // 同じ実装を呼ぶための入口。通知の取得・state反映は注入したloaderへ委譲する。
   return {
     loadShellSections,
     loadProfileSection,

--- a/apps/desktop/src/shell/data/loaders/useNotificationLoaders.ts
+++ b/apps/desktop/src/shell/data/loaders/useNotificationLoaders.ts
@@ -1,0 +1,98 @@
+import { startTransition, useCallback } from 'react';
+
+import type { DesktopApi, NotificationView } from '@/lib/api';
+import type { ShellChromeProjection } from '@/components/shell/types';
+import { messageFromError } from '@/shell/presentation';
+import { useDesktopShellFieldSetter } from '@/shell/store';
+
+export type LoadNotificationsSection = (options?: { markAsRead?: boolean }) => Promise<void>;
+
+type NotificationLoaderArgs = {
+  api: DesktopApi;
+  activePrimarySection: ShellChromeProjection['activePrimarySection'];
+  translate: (key: string, options?: Record<string, unknown>) => string;
+};
+
+// badgeとinboxの異なる取得・失敗・既読policyを同じ責務内で維持する。
+// 呼出時期、interval/eventの登録・解除はeffects側が所有する。
+export function useNotificationLoaders({ api, activePrimarySection, translate }: NotificationLoaderArgs) {
+  const setNotificationStatus = useDesktopShellFieldSetter('notificationStatus');
+  const setNotifications = useDesktopShellFieldSetter('notifications');
+  const setNotificationAutoReadError = useDesktopShellFieldSetter('notificationAutoReadError');
+  const setNotificationPanelState = useDesktopShellFieldSetter('notificationPanelState');
+
+  const refreshNotificationStatus = useCallback(async () => {
+    if (typeof document !== 'undefined' && document.visibilityState === 'hidden') {
+      return;
+    }
+    try {
+      const status = await api.getNotificationStatus();
+      setNotificationStatus(status);
+      if (
+        status.unread_count > 0 &&
+        activePrimarySection !== 'notifications'
+      ) {
+        const notificationItems = await api.listNotifications();
+        startTransition(() => {
+          setNotifications(notificationItems);
+        });
+      }
+    } catch {
+      // best effort badge refresh
+    }
+  }, [api, setNotificationStatus, setNotifications, activePrimarySection]);
+
+  const loadNotificationsSection = useCallback(
+    async (options: { markAsRead?: boolean } = {}) => {
+      const markAsRead = options.markAsRead ?? true;
+      try {
+        const [status, notificationItems] = await Promise.all([
+          api.getNotificationStatus(),
+          api.listNotifications(),
+        ]);
+        let nextNotifications: NotificationView[] = notificationItems;
+        let nextStatus = status;
+        if (markAsRead && notificationItems.some((notification) => !notification.read_at)) {
+          try {
+            nextStatus = await api.markAllNotificationsRead();
+            const readAt = Date.now();
+            nextNotifications = notificationItems.map((notification) =>
+              notification.read_at ? notification : { ...notification, read_at: readAt }
+            );
+            setNotificationAutoReadError(null);
+          } catch (notificationReadError) {
+            setNotificationAutoReadError(
+              messageFromError(
+                notificationReadError,
+                translate('shell:notifications.errors.failedAutoRead')
+              )
+            );
+          }
+        }
+        startTransition(() => {
+          setNotificationStatus(nextStatus);
+          setNotifications(nextNotifications);
+          setNotificationPanelState({ status: 'ready', error: null });
+        });
+      } catch (error) {
+        setNotificationPanelState({
+          status: 'error',
+          error: messageFromError(
+            error,
+            translate('shell:notifications.errors.failedToLoad')
+          ),
+        });
+      }
+    },
+    [
+      api,
+      setNotificationAutoReadError,
+      setNotificationPanelState,
+      setNotifications,
+      setNotificationStatus,
+      translate,
+    ]
+  );
+
+  return { refreshNotificationStatus, loadNotificationsSection };
+}

--- a/apps/desktop/src/shell/data/notificationLoaders.contract.test.tsx
+++ b/apps/desktop/src/shell/data/notificationLoaders.contract.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import type { DesktopApi, NotificationView, RuntimeEvent } from '@/lib/api';
 import { createDesktopMockApi } from '@/mocks/desktopApiMock';
 import { useDesktopShellSectionLoaders } from '@/shell/data/loaders/useDesktopShellSectionLoaders';
+import { useNotificationLoaders } from '@/shell/data/loaders/useNotificationLoaders';
 import { columnIdentityId, openTransientColumn } from '@/shell/slices/workspace';
 import { createShellHookHarness, resetWindowHash } from '@/shell/testSupport/renderShellHook';
 import { useDesktopShellData } from '@/shell/useDesktopShellData';
@@ -72,9 +73,14 @@ function mountInbox() {
     notificationAutoReadError: 'previous read failure',
   });
   const loadReactionCatalogData = vi.fn().mockResolvedValue(undefined);
-  const hook = renderHook(() => useDesktopShellSectionLoaders({
-    api, storeApi: harness.store, translate, loadReactionCatalogData,
-  }), { wrapper: harness.wrapper });
+  const hook = renderHook(() => {
+    const { loadNotificationsSection } = useNotificationLoaders({
+      api, translate, activePrimarySection: 'notifications',
+    });
+    return useDesktopShellSectionLoaders({
+      api, storeApi: harness.store, translate, loadReactionCatalogData, loadNotificationsSection,
+    });
+  }, { wrapper: harness.wrapper });
   return { api, ...harness, hook };
 }
 

--- a/apps/desktop/src/shell/data/useDesktopShellDataEffects.ts
+++ b/apps/desktop/src/shell/data/useDesktopShellDataEffects.ts
@@ -69,13 +69,14 @@ type UseDesktopShellDataEffectsArgs = {
   /// 表示中の Column id 列(DesktopShellColumnWorkspace の IntersectionObserver 由来)。
   visibleColumnIdsRef?: MutableRefObject<string[]>;
   loadTopics: (topics: string[], activeTopic: string, currentThread: string | null) => Promise<void>;
-  // section 取得ロジックの SSoT は data/loaders/useDesktopShellSectionLoaders.ts。
+  // section/通知の取得と結果反映は data/loaders/ の各loaderが所有する。
   // この hook は「いつ読むか」(section 遷移・interval)だけを持ち、
   // 「何をどう読むか」は loader を呼ぶ。
   loadProfileSection: () => Promise<void>;
   loadAuthorSection: (pubkey: string) => Promise<void>;
   loadMessagesSection: () => Promise<void>;
   loadNotificationsSection: (options?: { markAsRead?: boolean }) => Promise<void>;
+  refreshNotificationStatus: () => Promise<void>;
   loadCommunityIndexCapability: (
     refreshedStatuses?: readonly CommunityNodeNodeStatus[]
   ) => Promise<void>;
@@ -86,12 +87,10 @@ type UseDesktopShellDataEffectsArgs = {
     scopeChannelId?: string | null
   ) => Promise<void>;
   refreshConnectivityStatus: () => Promise<CommunityNodeNodeStatus[] | null>;
-  setNotificationStatus: Setter<'notificationStatus'>;
   setCommunityNodeStatuses: Setter<'communityNodeStatuses'>;
   setSyncStatus: Setter<'syncStatus'>;
   setLocalProfile: Setter<'localProfile'>;
   setProfileDraft: Setter<'profileDraft'>;
-  setNotifications: Setter<'notifications'>;
   setGameDrafts: Setter<'gameDrafts'>;
   setSelectedChannelIdByTopic: (
     value:
@@ -128,15 +127,14 @@ export function useDesktopShellDataEffects({
   loadAuthorSection,
   loadMessagesSection,
   loadNotificationsSection,
+  refreshNotificationStatus,
   loadCommunityIndexCapability,
   refreshVisibleShellData,
   refreshConnectivityStatus,
-  setNotificationStatus,
   setCommunityNodeStatuses,
   setSyncStatus,
   setLocalProfile,
   setProfileDraft,
-  setNotifications,
   setGameDrafts,
   setSelectedChannelIdByTopic,
   setComposeChannelByTopic,
@@ -274,27 +272,6 @@ export function useDesktopShellDataEffects({
     visibleColumnIdsRef,
     visibleRefreshInFlightRef,
   ]);
-
-  const refreshNotificationStatus = useCallback(async () => {
-    if (typeof document !== 'undefined' && document.visibilityState === 'hidden') {
-      return;
-    }
-    try {
-      const status = await api.getNotificationStatus();
-      setNotificationStatus(status);
-      if (
-        status.unread_count > 0 &&
-        shellChromeState.activePrimarySection !== 'notifications'
-      ) {
-        const notificationItems = await api.listNotifications();
-        startTransition(() => {
-          setNotifications(notificationItems);
-        });
-      }
-    } catch {
-      // best effort badge refresh
-    }
-  }, [api, setNotificationStatus, setNotifications, shellChromeState.activePrimarySection]);
 
   const applySyncStatusChange = useCallback(
     (

--- a/apps/desktop/src/shell/useDesktopShellData.ts
+++ b/apps/desktop/src/shell/useDesktopShellData.ts
@@ -24,6 +24,7 @@ import {
   openTransientColumn,
 } from '@/shell/slices/workspace';
 import { useDraftMediaHelpers } from '@/shell/data/useDraftMediaHelpers';
+import { useNotificationLoaders } from '@/shell/data/loaders/useNotificationLoaders';
 import { useDesktopShellSectionLoaders } from '@/shell/data/loaders/useDesktopShellSectionLoaders';
 import { useQueuedLoadTopics } from '@/shell/data/useQueuedLoadTopics';
 import {
@@ -168,8 +169,6 @@ export function useDesktopShellData({
   const setBookmarkedReactionAssets = useDesktopShellFieldSetter('bookmarkedReactionAssets');
   const setRecentReactions = useDesktopShellFieldSetter('recentReactions');
   const setProfileDraft = useDesktopShellFieldSetter('profileDraft');
-  const setNotifications = useDesktopShellFieldSetter('notifications');
-  const setNotificationStatus = useDesktopShellFieldSetter('notificationStatus');
   const setGameDrafts = useDesktopShellFieldSetter('gameDrafts');
   const setReactionPanelState = useDesktopShellFieldSetter('reactionPanelState');
   const setError = useDesktopShellFieldSetter('error');
@@ -604,16 +603,19 @@ export function useDesktopShellData({
     translate,
   ]);
 
+  const { refreshNotificationStatus, loadNotificationsSection } = useNotificationLoaders({
+    api, activePrimarySection: shellChromeState.activePrimarySection, translate,
+  });
   const {
     loadShellSections,
     loadProfileSection,
     loadAuthorSection,
     loadMessagesSection,
-    loadNotificationsSection,
     loadCommunityIndexCapability,
   } = useDesktopShellSectionLoaders({
     api,
     loadReactionCatalogData,
+    loadNotificationsSection,
     storeApi,
     translate,
   });
@@ -692,12 +694,11 @@ export function useDesktopShellData({
     loadCommunityIndexCapability,
     refreshVisibleShellData,
     refreshConnectivityStatus,
-    setNotificationStatus,
+    refreshNotificationStatus,
     setCommunityNodeStatuses,
     setSyncStatus,
     setLocalProfile,
     setProfileDraft,
-    setNotifications,
     setGameDrafts,
     setSelectedChannelIdByTopic,
     setComposeChannelByTopic,

--- a/docs/progress/2026-09-08-920-notification-loader.md
+++ b/docs/progress/2026-09-08-920-notification-loader.md
@@ -1,0 +1,46 @@
+# Issue #920: 通知取得・state反映の責務集約
+
+- Scope revision `2026-09-08-872-F-1R-v1`、区分C。before `0410261bb8091829db6b5cd8f1feb66791aaf327`。
+- 先行#919はPR#929でmerge済み。全CI・独立監査PASS、merge tree一致を確認して開始した。
+- 単一意図: badgeとinboxの異なる挙動を維持して、通知取得と結果setterの所有を一つのhookへ移す。
+
+| 作業 | AC / INVAR | 対象・証拠 | 依存 |
+| --- | --- | --- | --- |
+| T1 変更前contract | AC-3、全INVAR | #919の固定INV1〜7/TR1〜8と29 targeted testsをbeforeでPASS | #919 |
+| T2 取得owner抽出 | AC-1/2/4、INVAR-1〜5 | `useNotificationLoaders.ts`、data facade/effects/section loaderの最小配線。2 test fixtureのcompositionだけ同期 | T1 |
+| T3 変更後検証・構造証拠 | AC-3/4/5 | 同29 tests、typecheck、desktop-ui-check、caller/owner比較、既存assertion不変 | T2 |
+| T4 独立監査・CI・merge | AC-5、全INVAR | 固定headと別担当監査、必須CI、merge tree一致。結果はPR/Issue | T3 |
+
+## Before / afterと全caller
+
+| 指標 | before | after |
+| --- | ---: | ---: |
+| status/list取得と結果反映の製品module owner | effects + sectionの2 | notification loaderの1 |
+| effectsのstatus/list API直接呼出 | 2 | 0 |
+| sectionの通知inline実装 | 1 | 0 |
+| mark-allの製品呼出site | 1 | 1 |
+| 新loaderの製品生成site | 0 | facadeの1 |
+
+`useDesktopShellData`が一度生成し、同じinbox callbackをsection loaderとeffectsへ、badge callbackをeffectsへ渡す。section単体testも本番と同じloaderを注入する。fallbackや二つ目のownerは置かない。pageのmanual refreshとfacade戻り値は不変。
+元の2 callback本体を抽出し、badgeの`activePrimarySection`参照を引数に変えただけで、visibility/60秒周期/section変更時の即時refresh/markAsRead省略時true/Date.now/read_at投影/部分失敗とpanel errorの違いを維持する。
+effectはtimer/event/section triggerとcleanupを引き続き所有する。private/adult payloadを保持し、OS notification dispatch、routing/store設計、Rust/IPC/schema/UI/locale/CSSは変更しない。
+
+CodeGraphでsourceとcallerを確認し、次で全入口・sinkを補完した。
+
+```powershell
+rg -n 'getNotificationStatus|listNotifications|markAllNotificationsRead|refreshNotificationStatus|loadNotificationsSection|useNotificationLoaders' apps/desktop/src
+```
+
+本番のdirect status/list/markは新moduleのみ。登録点はdata facade→effects→runtime event/interval、active/background section、loadShellSections、page manual refresh。SQLite既読sinkは既存IPC/runtime/AppServiceのまま。INV/TRの増減0、対象未分類0。
+
+## Validation
+
+- before: #919新規contractと既存data/section/event bridgeの4 files/29 tests PASS、4.55秒。
+- after: 同29 tests PASS、4.35秒。既存assertion変更0。変更した2 test fixtureは新loaderの生成・callback注入だけ。
+- typecheck PASS。必須 `cargo xtask desktop-ui-check` は対象rootの実行directoryを確認して実行し、最終結果/CI/headはPR/Issueへ記録する。
+- 最初のUI gateは共有build cache内のxtaskが別worktreeのpathを埋め込んでおり、そちらでeslint未検出となったためFAIL。製品の失敗として扱わず、xtask packageのbuild artifactを再作成してrootの正しいpathで再実行する。失敗runを成功証拠に数えない。
+- Windowsのvisualはsmoke、Linux snapshot比較はCI。残る並行要求の完了順や取消モデルは変更しない。
+
+## Rollback
+
+この抽出PRだけをrevertし、#919のcontractを保持する。public API、schema、利用者データ変換は無い。


### PR DESCRIPTION
Refs #920。effectsとsection loaderに分かれていた通知取得・state反映を単一loaderへ集約しました。同じcallbackをfacadeから共有し、owner2→1、effects/sectionの直接通知取得0を達成しています。

- 種別 `refactor:extract`、区分C、Scope revision `2026-09-08-872-F-1R-v1`。
- [計画・AC/INVAR・対象境界・検証・rollback記録](docs/progress/2026-09-08-920-notification-loader.md)。詳細な独立監査とdeltaはPR commentsに保持。
- 先行#919の同29 testsをbefore/afterで維持、typecheck/desktop-ui-check、独立監査・comment delta PASS。
- 最終head `0884e85a5bffbecaa4d27f042f54859c3f8633fc` の全11 checks SUCCESS。必要な独立監査とCIを満たしてmergeしました。
- merge `4e833af8cbdb7263a75ad17f54ee64be6e263471` と監査対象のpath/surface一致を確認し、[Issue #920](https://github.com/KingYoSun/kukuri/issues/920)の現在判定をCompleteへ同期・Close済み。
