### PR TITLE
[codex][contract] Dome遷移の取消・ack喪失・cleanupを固定する

### DIFF
--- a/apps/desktop/src/components/extended/metaverse/useMetaverseRoomSession.test.tsx
+++ b/apps/desktop/src/components/extended/metaverse/useMetaverseRoomSession.test.tsx
@@ -14,6 +14,7 @@ import { METAVERSE_ROOM_RECOVERY_MS, type MetaverseRoomEvent } from '../Metavers
 import { useMetaverseRoomSession } from './useMetaverseRoomSession';
 import { createMetaverseRoomActions } from '@/shell/actions/metaverse';
 import { createDefaultMetaverseRoomState } from './DomeSceneModel';
+import { readLastVisitedDome } from './DomeEntryModel';
 
 const room: GameRoomView = {
   room_id: 'metaverse-room-1',
@@ -167,6 +168,164 @@ afterEach(() => {
   vi.useRealTimers();
   vi.unstubAllGlobals();
   vi.restoreAllMocks();
+});
+
+describe('Dome transition boundaries (#923)', () => {
+  async function setupTransition() {
+    vi.useFakeTimers();
+    const rooms = ['source', 'target'].map((id, index) => ({
+      ...room, room_id: id, host_pubkey: (index ? 'e' : 'f').repeat(64),
+      metaverse: createDefaultMetaverseRoomState(8, {
+        roomId: id, topicId: 'kukuri:topic:demo', ownerPubkey: (index ? 'e' : 'f').repeat(64),
+      }),
+    }));
+    const context = rooms[0].metaverse.spatial_context;
+    const api = createDesktopMockApi();
+    const topology = await api.listDomeConnectionTopology(context);
+    topology.connections = [{ record: {
+      agreement: { connection_id: 'boundary', proposal_id: 'proposal', spatial_context: context,
+        proposer: { instance_id: 'source', instance_generation: 1, owner_pubkey: rooms[0].host_pubkey, direction: 'north' },
+        receiver: { instance_id: 'target', instance_generation: 1, owner_pubkey: rooms[1].host_pubkey, direction: 'south' },
+        activation_generation: 1 },
+      receiver_slot_generation: 1, observed_active_connection_ids: [], status: 'active',
+      lifecycle_generation: 1, lifecycle_actor: null, lifecycle_reason: null, lifecycle_deadline_at: null,
+    } }];
+    topology.resolution.topology = { spatial_context: context,
+      components: [{ root_instance_id: 'source', instance_ids: ['source', 'target'], connection_ids: ['boundary'],
+        coordinates_cm: { source: [0, 0, 0], target: [0, 0, -5700] } }],
+      active_connection_ids: ['boundary'], topology_digest: 'boundary-digest' };
+    vi.spyOn(api, 'listDomeConnectionTopology').mockResolvedValue(topology);
+    const hosting = vi.spyOn(api, 'getDomeHosting').mockImplementation(async (_context, instanceId) => ({
+      instance_id: instanceId, state: { kind: 'community_node_hosted', lease_epoch: 1,
+        session_id: `session-${instanceId}`, lease_expires_at: Date.now() + 60_000,
+        host: { kind: 'community_node', node_id: 'node', api_base_url: 'https://node.example' } },
+      lease: null, signed_lease_json: null, signed_activation_json: null, signed_close_json: null,
+      instance_manifest_json: '{}', preset_manifest_json: '{}', participants: 1, sleeping: false,
+      resource_budget: {} as DomeHostingView['resource_budget'], resource_metrics: {} as DomeHostingView['resource_metrics'],
+    }));
+    const snapshot = (instance: string, sequence: number): DomePhysicsSnapshotV1 => ({
+      ...physicsSnapshot(sequence, 0), instance_id: instance, session_id: `session-${instance}`,
+    });
+    const submit = vi.spyOn(api, 'submitDomeSessionInput').mockImplementation(async (_c, id, sequence) => snapshot(id, sequence));
+    const prepare = vi.spyOn(api, 'prepareDomeTransition').mockImplementation(async request => ({
+      request, target_lease_epoch: 1, target_session_id: 'session-target', expires_at: Date.now() + 15_000,
+    }));
+    const commit = vi.spyOn(api, 'commitDomeTransition').mockResolvedValue(undefined);
+    const abort = vi.spyOn(api, 'abortDomeTransition').mockResolvedValue(undefined);
+    const publish = vi.spyOn(api, 'publishMetaverseRoomEvent');
+    const session = renderSession({ api, rooms, initialSelectedRoomId: 'source' });
+    const flush = async (ms = 0) => { await act(async () => { await vi.advanceTimersByTimeAsync(ms); }); };
+    await flush();
+    expect(session.result.current.admittedRoom?.room_id).toBe('source');
+    expect(session.result.current.transitionNeighbors[0]?.boundaryState).toBe('ready');
+    const move = (z: number) => act(() => session.result.current.handleLocalTransform({
+      roomId: 'source', peerId: 'local-peer', seq: 1, position: [0, 90, z],
+      rotation: [0, 0, 0], animation: 'walk', sentAt: Date.now(),
+    }));
+    const entered = async () => { move(-2200); await flush(); expect(prepare).toHaveBeenCalledTimes(1); };
+    const lastVisited = () => readLastVisitedDome('f'.repeat(64), context);
+    const sourceInputs = (type: string) => submit.mock.calls.filter(call => call[1] === 'source' && call[3].type === type);
+    return { session, submit, prepare, commit, abort, hosting, publish, snapshot, flush, move, entered, lastVisited, sourceInputs };
+  }
+
+  test('cancelling prepare aborts a late ticket without committing or handing off', async () => {
+    const f = await setupTransition();
+    let deliver!: () => void;
+    f.prepare.mockImplementationOnce(request => new Promise(resolve => { deliver = () => resolve({
+      request, target_lease_epoch: 1, target_session_id: 'session-target', expires_at: Date.now() + 15_000,
+    }); }));
+    await f.entered();
+    f.move(0);
+    await f.flush();
+    expect(f.sourceInputs('abort_transition')).toHaveLength(1);
+    expect(f.abort).not.toHaveBeenCalled();
+    await act(async () => deliver());
+    expect(f.abort).toHaveBeenCalledTimes(1);
+    expect(f.sourceInputs('abort_transition')).toHaveLength(2);
+    expect(f.commit).not.toHaveBeenCalled();
+    expect(f.sourceInputs('complete_transition')).toHaveLength(0);
+    expect(f.session.result.current.selectedRoomId).toBe('source');
+    expect(f.lastVisited()).toBe('source');
+    f.session.unmount();
+  });
+
+  test('lost ack and hosting lookup failure keep the same commit pending until confirmation', async () => {
+    const f = await setupTransition();
+    let confirm!: () => void;
+    f.commit.mockRejectedValueOnce(new Error('ack lost')).mockImplementationOnce(() => new Promise(resolve => { confirm = resolve; }));
+    await f.entered();
+    f.hosting.mockRejectedValueOnce(new Error('lookup unavailable'));
+    f.move(-2870);
+    await f.flush();
+    expect(f.commit).toHaveBeenCalledTimes(2);
+    expect(f.commit.mock.calls[1]).toEqual(f.commit.mock.calls[0]);
+    f.move(0);
+    await f.flush();
+    expect(f.abort).not.toHaveBeenCalled();
+    expect(f.sourceInputs('abort_transition')).toHaveLength(0);
+    expect(f.sourceInputs('complete_transition')).toHaveLength(0);
+    expect(f.session.result.current.selectedRoomId).toBe('source');
+    expect(f.lastVisited()).toBe('source');
+    await act(async () => confirm());
+    expect(f.session.result.current.selectedRoomId).toBe('target');
+    expect(f.lastVisited()).toBe('target');
+    expect(f.sourceInputs('complete_transition')).toHaveLength(1);
+    f.session.unmount();
+  });
+
+  test.each(['definitive rejection', 'replaced session'])('%s rolls back without a successful handoff', async failure => {
+    const f = await setupTransition();
+    await f.entered();
+    f.commit.mockRejectedValue(new Error(failure === 'definitive rejection' ? 'DOME_TRANSITION_INVALID_TICKET' : 'ack lost'));
+    if (failure === 'replaced session') {
+      const current = await f.hosting.mock.results.find((_result, index) => f.hosting.mock.calls[index][1] === 'target')!.value;
+      f.hosting.mockResolvedValueOnce({ ...current, state: { ...current.state, lease_epoch: 2, session_id: 'replacement' } });
+    }
+    f.move(-2870);
+    await f.flush();
+    expect(f.commit).toHaveBeenCalledTimes(1);
+    expect(f.abort).toHaveBeenCalledTimes(1);
+    expect(f.sourceInputs('abort_transition')).toHaveLength(1);
+    expect(f.sourceInputs('complete_transition')).toHaveLength(0);
+    expect(f.session.result.current.selectedRoomId).toBe('source');
+    expect(f.lastVisited()).toBe('source');
+    expect(f.session.onError).toHaveBeenCalledWith(expect.any(String));
+    f.session.unmount();
+  });
+
+  test.each([false, true])('source cleanup retries without rolling back target (all attempts fail: %s)', async allFail => {
+    const f = await setupTransition();
+    let attempts = 0;
+    f.submit.mockImplementation(async (_context, id, sequence, input) => {
+      if (id === 'source' && input.type === 'complete_transition') {
+        attempts += 1;
+        if (allFail || attempts === 1) throw new Error('source unavailable');
+      }
+      return f.snapshot(id, sequence);
+    });
+    await f.entered();
+    f.move(-2870);
+    await f.flush();
+    expect(attempts).toBe(1);
+    expect(f.session.result.current.selectedRoomId).toBe('target');
+    expect(f.lastVisited()).toBe('target');
+    await f.flush(249);
+    expect(attempts).toBe(1);
+    await f.flush(1);
+    expect(attempts).toBe(2);
+    await f.flush(1000);
+    expect(attempts).toBe(allFail ? 3 : 2);
+    expect(f.session.result.current.selectedRoomId).toBe('target');
+    expect(f.lastVisited()).toBe('target');
+    expect(f.abort).not.toHaveBeenCalled();
+    expect(f.sourceInputs('abort_transition')).toHaveLength(0);
+    const complete = f.sourceInputs('complete_transition');
+    expect(new Set(complete.map(call => call[3].type === 'complete_transition' ? call[3].transition_id : null)).size).toBe(1);
+    expect(new Set(complete.map(call => call[2])).size).toBe(complete.length);
+    expect(f.publish.mock.calls.filter(call => call[1] === 'source' && call[4].type === 'presence_leave')).toHaveLength(allFail ? 0 : 1);
+    if (allFail) expect(f.session.onError).toHaveBeenCalledWith('Destination committed; source Dome cleanup will require resynchronization');
+    f.session.unmount();
+  });
 });
 
 describe('useMetaverseRoomSession', () => {

--- a/apps/desktop/src/components/extended/metaverse/useMetaverseRoomSession.test.tsx
+++ b/apps/desktop/src/components/extended/metaverse/useMetaverseRoomSession.test.tsx
@@ -241,7 +241,10 @@ describe('Dome transition boundaries (#923)', () => {
     expect(f.abort).not.toHaveBeenCalled();
     await act(async () => deliver());
     expect(f.abort).toHaveBeenCalledTimes(1);
+    expect(f.abort).toHaveBeenCalledWith(await f.prepare.mock.results[0].value);
     expect(f.sourceInputs('abort_transition')).toHaveLength(2);
+    expect(f.sourceInputs('abort_transition').every(call => call[3].type === 'abort_transition'
+      && call[3].transition_id === f.prepare.mock.calls[0][0].transition_id)).toBe(true);
     expect(f.commit).not.toHaveBeenCalled();
     expect(f.sourceInputs('complete_transition')).toHaveLength(0);
     expect(f.session.result.current.selectedRoomId).toBe('source');
@@ -285,11 +288,58 @@ describe('Dome transition boundaries (#923)', () => {
     await f.flush();
     expect(f.commit).toHaveBeenCalledTimes(1);
     expect(f.abort).toHaveBeenCalledTimes(1);
+    expect(f.abort).toHaveBeenCalledWith(await f.prepare.mock.results[0].value);
     expect(f.sourceInputs('abort_transition')).toHaveLength(1);
+    expect(f.sourceInputs('abort_transition')[0][3]).toEqual({ type: 'abort_transition', transition_id: f.prepare.mock.calls[0][0].transition_id });
     expect(f.sourceInputs('complete_transition')).toHaveLength(0);
     expect(f.session.result.current.selectedRoomId).toBe('source');
     expect(f.lastVisited()).toBe('source');
     expect(f.session.onError).toHaveBeenCalledWith(expect.any(String));
+    f.session.unmount();
+  });
+
+  test.each([
+    ['join', false], ['leave', false], ['join', true], ['leave', true],
+  ] as const)('%s keeps its own effects and respects the attempt guard (committing: %s)', async (action, committing) => {
+    const f = await setupTransition();
+    await f.entered();
+    let confirm!: () => void;
+    if (committing) {
+      f.commit.mockImplementationOnce(() => new Promise(resolve => { confirm = resolve; }));
+      f.move(-2870);
+      await f.flush();
+      expect(f.commit).toHaveBeenCalledTimes(1);
+    }
+    if (action === 'join') {
+      await act(async () => { expect(await f.session.result.current.joinRoom('target')).toBe(true); });
+    } else {
+      act(() => f.session.result.current.leaveRoom());
+    }
+    await f.flush();
+    expect(f.abort).toHaveBeenCalledTimes(committing ? 0 : 1);
+    const aborted = f.sourceInputs('abort_transition');
+    expect(aborted).toHaveLength(committing ? 0 : 1);
+    if (!committing) {
+      expect(f.abort).toHaveBeenCalledWith(await f.prepare.mock.results[0].value);
+      expect(aborted[0][3]).toEqual({ type: 'abort_transition', transition_id: f.prepare.mock.calls[0][0].transition_id });
+      expect(f.commit).not.toHaveBeenCalled();
+    }
+    expect(f.sourceInputs('complete_transition')).toHaveLength(0);
+    expect(f.session.result.current.selectedRoomId).toBe(action === 'join' ? 'target' : null);
+    expect(f.session.result.current.admissionStatus).toBe(action === 'join' ? 'joined' : 'selection');
+    expect(f.lastVisited()).toBe(action === 'join' ? 'target' : 'source');
+    if (action === 'join') {
+      expect(f.submit.mock.calls.some(call => call[1] === 'target' && call[3].type === 'join')).toBe(true);
+    } else {
+      expect(f.sourceInputs('leave')).toHaveLength(1);
+      expect(f.publish.mock.calls.filter(call => call[1] === 'source' && call[4].type === 'presence_leave')).toHaveLength(1);
+      expect(f.session.result.current.admittedRoom).toBeNull();
+    }
+    if (committing) {
+      await act(async () => confirm());
+      expect(f.abort).not.toHaveBeenCalled();
+      expect(f.sourceInputs('abort_transition')).toHaveLength(0);
+    }
     f.session.unmount();
   });
 
@@ -320,6 +370,8 @@ describe('Dome transition boundaries (#923)', () => {
     expect(f.abort).not.toHaveBeenCalled();
     expect(f.sourceInputs('abort_transition')).toHaveLength(0);
     const complete = f.sourceInputs('complete_transition');
+    expect(complete.every(call => call[3].type === 'complete_transition'
+      && call[3].transition_id === f.prepare.mock.calls[0][0].transition_id)).toBe(true);
     expect(new Set(complete.map(call => call[3].type === 'complete_transition' ? call[3].transition_id : null)).size).toBe(1);
     expect(new Set(complete.map(call => call[2])).size).toBe(complete.length);
     expect(f.publish.mock.calls.filter(call => call[1] === 'source' && call[4].type === 'presence_leave')).toHaveLength(allFail ? 0 : 1);

--- a/docs/progress/2026-09-08-923-dome-transition-contract.md
+++ b/docs/progress/2026-09-08-923-dome-transition-contract.md
@@ -1,0 +1,39 @@
+# Issue #923: Dome遷移の取消・ack喪失・source cleanup contract
+
+- Scope revision `2026-09-08-872-C-MV-v1`、区分C、before `36e3732edfb68e0637a60e7badf4c778d0530e4d`。
+- 対象は既存session testへの追加と本記録のみ。製品hook/recovery helper、既存14 testsのassertion、IPC/authority、UI描画変更0。後続#924の前に現行挙動を固定する。
+- 正本は#923 AC1〜4/INVAR1・2/INV1〜4/TR1〜4、ADR0042/0044/0045。commit後の新しい取消やretry上限は追加しない。
+
+| 作業 | AC / invariant | 検証・証拠 | 依存 |
+| --- | --- | --- | --- |
+| T1 baselineとcaller | AC-4、INVAR-1/2 | session/recovery2 files14 tests before、prepare/commit/abort/last-visited/source input/presenceのcaller | なし |
+| T2 取消・commit結果不明 | AC-1/2、TR-1/2/3 | 下記4case、既存helper4 tests。public session hook→実actions→API mockまで通す | T1 |
+| T3 確定後cleanup | AC-3、TR-4 | 成功/全失敗2case、target選択とlast-visited、RPC入力/回数/sequence/presenceを観測 | T2 |
+| T4 検証・独立監査・merge | AC-4、全INVAR | targeted→desktop-ui-check→固定head独立監査/CI/merge tree確認 | T3 |
+
+## 固定集合とtestの対応
+
+| INV / TR | 新規testと観測 |
+| --- | --- |
+| INV-1/4、TR-1 | `cancelling prepare aborts a late ticket ...`: 準備中に中心線から戻る→source abort、ticket遅着後target abort/同id source abort。commit/completeなし、source選択・last-visited維持。既存join/leave自身の副作用を禁止する新仕様は置かない |
+| INV-2、TR-2 | `lost ack and hosting lookup failure ...`: 最初commit失敗+hosting取得失敗→同一ticket/transformで次commit待機。ack前に中心線から戻ってもabort/completeなし。ack後にtarget選択・last-visited・source complete |
+| INV-2、TR-3 | `... rolls back without a successful handoff`: invalid-ticket確定拒否とtarget session置換の2case。commit1、target/source abort、error、source選択・last-visited維持、completeなし |
+| INV-3、TR-4 | `source cleanup retries ...`: 1回目失敗→250ms後成功、または250/1000ms後も失敗。2/3回で停止しtarget/last-visited維持、abort0、同transition id・重複しないinput sequence。成功時のみsource presence_leave、全失敗時はerror表示 |
+
+元のsession10 testsとrecovery4 testsを維持。特に既存Return Homeは別joinのauthoritative admission後の選択・last-visitedを保護する。TR-1は取消対象attemptの副作用だけを禁止する。
+
+## 全caller・凍結境界
+
+session hookの本番呼出はMetaverseRoomPanel。prepare/abort/commitはsession callbacks→`createMetaverseRoomActions`→DesktopApi。commit recoveryの本番callerはsessionのcommit callbackだけ。
+`submitInputForRoom`はtransition以外のjoin/leave/keepalive/移動も共有し、sequence正本を増やさない。last-visitedはadmission成功とcommit成功だけ、source presence_leaveはcleanup成功だけ。
+CodeGraphのroot sourceとworktree（indexなし）の同一sourceを確認。補完は `rg -n 'recoverDomeTransitionCommit|prepareTransition|commitTransition|abortTransition|submitInputForRoom|writeLastVisitedDome' apps/desktop/src/components/extended/metaverse`。製品inventory増減0、対象未分類0。
+
+## 実行証拠
+
+- before: `npx pnpm@10.16.1 --dir apps/desktop test src/components/extended/metaverse/useMetaverseRoomSession.test.tsx src/components/extended/metaverse/DomeTransitionCommitRecovery.test.ts` →2 files/14 tests PASS。
+- 追加後同command: 2 files/20 tests PASS（4.83秒）。fake timer/deferred responseで非同期の観測点を固定する。製品private helperをmockせずAPIとstateを観測。
+- 初回のpresence_leave検査はAPI引数のtopic位置を取り違えて失敗したため、実際の5引数契約（topic/room/peer/sequence/event）に訂正。publish mockの戻り値も既存mock実装を使い、型契約を維持する。
+- 必須 `cargo xtask desktop-ui-check` は対象worktreeで実行。最終結果/CI/独立監査headはPR/Issueへ保存。Windowsのvisualはsmoke、Linuxのpixel比較はCIで確認する。
+- test-onlyのためOS/WebView動作を変更していない。#924の製品抽出時に必要な実機確認を本結果で代替しない。
+
+Rollbackはtest-only PRを単独revert。#924着手後は先にrefactorを戻し、contractだけを外さない。必要な検証・独立監査成功前にCompleteとはしない。

--- a/docs/progress/2026-09-08-923-dome-transition-contract.md
+++ b/docs/progress/2026-09-08-923-dome-transition-contract.md
@@ -15,12 +15,13 @@
 
 | INV / TR | 新規testと観測 |
 | --- | --- |
-| INV-1/4、TR-1 | `cancelling prepare aborts a late ticket ...`: 準備中に中心線から戻る→source abort、ticket遅着後target abort/同id source abort。commit/completeなし、source選択・last-visited維持。既存join/leave自身の副作用を禁止する新仕様は置かない |
+| INV-1、TR-1 | `cancelling prepare aborts a late ticket ...`: 準備中に中心線から戻る→source abort、ticket遅着後target abort/同id source abort。commit/completeなし、source選択・last-visited維持。既存join/leave自身の副作用を禁止する新仕様は置かない |
 | INV-2、TR-2 | `lost ack and hosting lookup failure ...`: 最初commit失敗+hosting取得失敗→同一ticket/transformで次commit待機。ack前に中心線から戻ってもabort/completeなし。ack後にtarget選択・last-visited・source complete |
 | INV-2、TR-3 | `... rolls back without a successful handoff`: invalid-ticket確定拒否とtarget session置換の2case。commit1、target/source abort、error、source選択・last-visited維持、completeなし |
 | INV-3、TR-4 | `source cleanup retries ...`: 1回目失敗→250ms後成功、または250/1000ms後も失敗。2/3回で停止しtarget/last-visited維持、abort0、同transition id・重複しないinput sequence。成功時のみsource presence_leave、全失敗時はerror表示 |
+| INV-4、TR-1/2 | `... keeps its own effects and respects the attempt guard ...`: join/leave × provisional/committingの4case。前者は同ticket/idでabort、後者はabort禁止。独立joinのadmission/target選択/last-visited、leaveのinput/presence/選択解除/非admittedを観測し、それらを禁止する新仕様を置かない |
 
-元のsession10 testsとrecovery4 testsを維持。特に既存Return Homeは別joinのauthoritative admission後の選択・last-visitedを保護する。TR-1は取消対象attemptの副作用だけを禁止する。
+元のsession10 testsとrecovery4 testsを維持。既存Return Homeはauthoritative admission後の選択を保護し、last-visitedは今回のjoin/leave caseで直接確認する。audio停止の既存実装は変更せず、実音声streamの確認をこのAPI/state contractで実施済みとはしない。TR-1は取消対象attemptの副作用だけを禁止する。
 
 ## 全caller・凍結境界
 
@@ -32,6 +33,8 @@ CodeGraphのroot sourceとworktree（indexなし）の同一sourceを確認。�
 
 - before: `npx pnpm@10.16.1 --dir apps/desktop test src/components/extended/metaverse/useMetaverseRoomSession.test.tsx src/components/extended/metaverse/DomeTransitionCommitRecovery.test.ts` →2 files/14 tests PASS。
 - 追加後同command: 2 files/20 tests PASS（4.83秒）。fake timer/deferred responseで非同期の観測点を固定する。製品private helperをmockせずAPIとstateを観測。
+- 初回独立監査`0ef7bee7`はINV-4のjoin/leave入口の観測不足とid対応の不足でFAIL。4caseを追加し、abort ticket/transition idとprepareの一致、cleanup idとprepareの一致を明示。最終targetedは2 files/24 tests PASS（4.00秒）。製品/既存assertionは不変。
+- local desktop-ui-checkは初回headの20 testsを含む151 files/1192 tests、Storybook、browser64、Windows visual smoke14でPASS。deltaの新4caseはtargetedと最終headのCI full suiteで検証し、初回結果を最終head全体の再実行とは扱わない。
 - 初回のpresence_leave検査はAPI引数のtopic位置を取り違えて失敗したため、実際の5引数契約（topic/room/peer/sequence/event）に訂正。publish mockの戻り値も既存mock実装を使い、型契約を維持する。
 - 必須 `cargo xtask desktop-ui-check` は対象worktreeで実行。最終結果/CI/独立監査headはPR/Issueへ保存。Windowsのvisualはsmoke、Linuxのpixel比較はCIで確認する。
 - test-onlyのためOS/WebView動作を変更していない。#924の製品抽出時に必要な実機確認を本結果で代替しない。


### PR DESCRIPTION
Refs #923。Dome移動のprepare取消、遅着ticket、ack不明、確定rollback、source cleanup失敗とjoin/leaveの取消入口をhookの観測で固定しました。製品hook・既存assertionは変更していません。

- 種別 `contract`、区分C、Scope revision `2026-09-08-872-C-MV-v1`。
- [計画・AC/INVAR・対象境界・検証・rollback記録](docs/progress/2026-09-08-923-dome-transition-contract.md)。詳細な独立監査とdeltaはPR commentsに保持。
- 既存14→最終24 targeted tests、typecheck、full UI gateと最終CI PASS。初回監査で不足したjoin/leave4caseとticket/id対応を補い、独立delta監査PASS。
- 最終head `6dfb95a1e6ace5a3190e28ddc6a97c5b9b57ddd5` の全11 checks SUCCESS。必要な独立監査とCIを満たしてmergeしました。
- merge `d9ea79be4fe03e3d97032b53bef2747760652908` と監査対象のpath/surface一致を確認し、[Issue #923](https://github.com/KingYoSun/kukuri/issues/923)の現在判定をCompleteへ同期・Close済み。
