### PR TITLE
[codex][contract] CN indexerのsource解決と禁止I/Oを固定する

### DIFF
--- a/crates/cn-indexer/tests/source_resolution_contracts.rs
+++ b/crates/cn-indexer/tests/source_resolution_contracts.rs
@@ -318,7 +318,7 @@ async fn duplicate_media_hashes_preserve_first_mime_including_a_thumbnail_withou
         .filter(|request| request.subject_kind == Some(SubjectKind::Blob))
         .map(|request| {
             (
-                request.subject_id.clone().unwrap(),
+                request.subject_id.clone().expect("media scan subject id"),
                 request.media_mime.clone(),
             )
         })

--- a/crates/cn-indexer/tests/source_resolution_contracts.rs
+++ b/crates/cn-indexer/tests/source_resolution_contracts.rs
@@ -1,0 +1,423 @@
+//! #925: observable I/O and durable results before source resolver extraction.
+#[path = "source_resolution_contracts/support.rs"]
+mod support;
+
+use anyhow::Result;
+use kukuri_cn_core::IndexScopeKind;
+use kukuri_cn_indexer::projection::IndexProjection;
+use kukuri_cn_safety::provider::SubjectKind;
+use kukuri_core::{
+    AssetRef, AssetRole, KukuriKeys, KukuriMediaManifestV1, MediaManifestItem, PayloadRef,
+    PostWithdrawalReason, TopicId, WithdrawalReasonVisibility, blob_hash,
+    build_media_manifest_envelope, build_post_envelope, build_post_withdrawal_envelope,
+};
+use kukuri_docs_sync::{DocOp, DocsSync};
+use support::*;
+
+#[tokio::test]
+async fn unverified_blob_metadata_has_zero_fetch_scan_and_index_upserts() -> Result<()> {
+    for invalid in [
+        "missing",
+        "malformed",
+        "signature",
+        "id",
+        "author",
+        "payload",
+        "oversized",
+    ] {
+        let f = Fixture::new(IndexScopeKind::PublicTopic).await?;
+        let mut post = if invalid == "oversized" {
+            f.post_with(
+                PayloadRef::BlobText {
+                    hash: blob_hash(b"body"),
+                    mime: "text/markdown".into(),
+                    bytes: 40_001,
+                },
+                Vec::new(),
+                Vec::new(),
+            )?
+        } else {
+            f.post(b"body")?
+        };
+        match invalid {
+            "signature" => post.envelope.content = "tampered".into(),
+            "id" => post.envelope = f.post(b"different signed object")?.envelope,
+            "author" => post.state["author"] = serde_json::json!("d".repeat(64)),
+            "payload" => {
+                post.state["payload_ref"] = serde_json::to_value(PayloadRef::BlobText {
+                    hash: blob_hash(b"body"),
+                    mime: "text/plain".into(),
+                    bytes: 4,
+                })?
+            }
+            _ => {}
+        }
+        f.persist(&post).await?;
+        let envelope_key = format!("objects/{}/envelope", post.id);
+        if invalid == "missing" {
+            f.docs
+                .apply_doc_op(
+                    &f.replica,
+                    DocOp::DeletePrefix {
+                        prefix: envelope_key,
+                    },
+                )
+                .await?;
+        } else if invalid == "malformed" {
+            f.docs
+                .apply_doc_op(
+                    &f.replica,
+                    DocOp::SetBytes {
+                        key: envelope_key,
+                        value: b"not-json".to_vec(),
+                    },
+                )
+                .await?;
+        }
+        let summary = f.ingest().await?;
+        assert_eq!(
+            (summary.scanned, summary.indexed, summary.skipped_non_allow),
+            (1, 0, 1),
+            "{invalid}"
+        );
+        let io = f.observed();
+        assert_no_durable_blob_io(&io);
+        assert!(io.ephemeral.is_empty(), "{invalid}: unverified body fetch");
+        assert!(io.scans.is_empty(), "{invalid}: provider request");
+        assert!(
+            io.entry_upserts.is_empty() && io.projection_upserts.is_empty(),
+            "{invalid}: index write"
+        );
+        assert_eq!(io.entry_removes, vec![post.id.clone()]);
+        assert_eq!(io.projection_removes, vec![post.id.clone()]);
+        assert!(!f.entries.inner.contains(f.kind, SCOPE, &post.id));
+        assert_eq!(f.projection.count_scope(f.kind, SCOPE).await?, 0);
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn rejected_blob_bytes_use_only_ephemeral_fetch_and_never_reach_a_provider() -> Result<()> {
+    for invalid in [
+        "missing",
+        "unavailable",
+        "size",
+        "hash",
+        "utf8",
+        "characters",
+    ] {
+        let f = Fixture::new(IndexScopeKind::PublicTopic).await?;
+        let bytes = match invalid {
+            "utf8" => vec![0xff],
+            "characters" => vec![b'x'; 10_001],
+            _ => b"body".to_vec(),
+        };
+        let post = f.post(&bytes)?;
+        f.persist(&post).await?;
+        if !matches!(invalid, "utf8" | "characters") {
+            assert_eq!(f.ingest().await?.indexed, 1);
+            assert!(f.entries.inner.contains(f.kind, SCOPE, &post.id));
+            f.clear_io();
+        }
+        let hash = blob_hash(&bytes);
+        let reply = match invalid {
+            "missing" => Reply::Missing,
+            "unavailable" => Reply::Failed,
+            "size" => Reply::Bytes(b"too long".to_vec()),
+            "hash" => Reply::Bytes(b"evil".to_vec()),
+            _ => Reply::Bytes(bytes),
+        };
+        f.blobs.respond(&hash, reply);
+        let summary = f.ingest().await?;
+        assert_eq!(
+            (summary.indexed, summary.skipped_non_allow),
+            (0, 1),
+            "{invalid}"
+        );
+        let io = f.observed();
+        assert_eq!(io.ephemeral, vec![hash.as_str().to_string()]);
+        assert_no_durable_blob_io(&io);
+        assert!(
+            io.scans.is_empty(),
+            "{invalid}: provider must not see rejected bytes"
+        );
+        assert!(io.entry_upserts.is_empty() && io.projection_upserts.is_empty());
+        assert_eq!(io.entry_removes, vec![post.id.clone()]);
+        assert_eq!(io.projection_removes, vec![post.id.clone()]);
+        assert!(!f.entries.inner.contains(f.kind, SCOPE, &post.id));
+        assert_eq!(f.projection.count_scope(f.kind, SCOPE).await?, 0);
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn unicode_body_at_the_character_limit_remains_scoped_and_ephemeral() -> Result<()> {
+    for kind in [IndexScopeKind::PublicTopic, IndexScopeKind::PrivateChannel] {
+        let f = Fixture::new(kind).await?;
+        let body = "界".repeat(10_000);
+        let post = f.post(body.as_bytes())?;
+        f.persist(&post).await?;
+        assert_eq!(f.ingest().await?.indexed, 1);
+        let io = f.observed();
+        assert_no_durable_blob_io(&io);
+        assert_eq!(
+            io.ephemeral,
+            vec![blob_hash(body.as_bytes()).as_str().to_string()]
+        );
+        assert_eq!(io.scans.len(), 1);
+        assert_eq!(io.scans[0].subject_id.as_deref(), Some(post.id.as_str()));
+        assert_eq!(io.scans[0].text.as_deref(), Some(body.as_str()));
+        assert_eq!(io.entry_upserts, vec![post.id.clone()]);
+        assert_eq!(io.projection_upserts, vec![post.id.clone()]);
+        let entries = f.projection.inner.entries_in_scope(kind, SCOPE).await;
+        assert_eq!(entries[0].text, body);
+        assert_eq!(entries[0].scope_kind, kind);
+        let other = if kind == IndexScopeKind::PublicTopic {
+            IndexScopeKind::PrivateChannel
+        } else {
+            IndexScopeKind::PublicTopic
+        };
+        assert_eq!(f.projection.count_scope(other, SCOPE).await?, 0);
+    }
+    Ok(())
+}
+
+fn media_item(
+    hash: kukuri_core::BlobHash,
+    mime: &str,
+    thumbnail: Option<kukuri_core::BlobHash>,
+) -> MediaManifestItem {
+    MediaManifestItem {
+        blob_hash: hash,
+        mime: mime.into(),
+        size: 4,
+        width: None,
+        height: None,
+        duration_ms: None,
+        codec: None,
+        thumbnail_blob_hash: thumbnail,
+    }
+}
+
+#[tokio::test]
+async fn invalid_media_manifest_never_sends_media_to_the_provider_or_upserts_indexes() -> Result<()>
+{
+    for invalid in ["missing", "signature", "kind", "author", "malformed"] {
+        let f = Fixture::new(IndexScopeKind::PublicTopic).await?;
+        let post = f.post_with(
+            PayloadRef::InlineText {
+                text: "caption".into(),
+            },
+            Vec::new(),
+            vec!["manifest".into()],
+        )?;
+        f.persist(&post).await?;
+        let manifest = KukuriMediaManifestV1 {
+            manifest_id: "manifest".into(),
+            owner_pubkey: post.keys.public_key(),
+            created_at: 1,
+            items: vec![media_item(blob_hash(b"media"), "image/png", None)],
+        };
+        let topic = TopicId::new(SCOPE);
+        let mut envelope = if invalid == "author" {
+            let other = KukuriKeys::generate();
+            build_media_manifest_envelope(
+                &other,
+                &topic,
+                &KukuriMediaManifestV1 {
+                    owner_pubkey: other.public_key(),
+                    ..manifest
+                },
+            )?
+        } else if invalid == "kind" {
+            build_post_envelope(&post.keys, &topic, "wrong kind", None)?
+        } else {
+            build_media_manifest_envelope(&post.keys, &topic, &manifest)?
+        };
+        if invalid == "signature" {
+            envelope.content = "tampered".into();
+        }
+        let key = "manifests/media/manifest/envelope";
+        if invalid == "malformed" {
+            f.docs
+                .apply_doc_op(
+                    &f.replica,
+                    DocOp::SetBytes {
+                        key: key.into(),
+                        value: b"not-json".to_vec(),
+                    },
+                )
+                .await?;
+        } else if invalid != "missing" {
+            f.set(key, serde_json::to_value(envelope)?).await?;
+        }
+        let summary = f.ingest().await?;
+        assert_eq!(
+            (summary.indexed, summary.skipped_non_allow),
+            (0, 1),
+            "{invalid}"
+        );
+        let io = f.observed();
+        assert_no_durable_blob_io(&io);
+        assert!(io.ephemeral.is_empty());
+        assert_eq!(
+            io.scans.len(),
+            1,
+            "only the already-allowed post text is scanned"
+        );
+        assert_eq!(io.scans[0].subject_kind, Some(SubjectKind::Post));
+        assert!(io.entry_upserts.is_empty() && io.projection_upserts.is_empty());
+        assert_eq!(io.entry_removes, vec![post.id.clone()]);
+        assert_eq!(io.projection_removes, vec![post.id]);
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn duplicate_media_hashes_preserve_first_mime_including_a_thumbnail_without_mime()
+-> Result<()> {
+    let f = Fixture::new(IndexScopeKind::PublicTopic).await?;
+    let a = blob_hash(b"attachment");
+    let b = blob_hash(b"manifest item");
+    let c = blob_hash(b"thumbnail");
+    let post = f.post_with(
+        PayloadRef::InlineText {
+            text: "caption".into(),
+        },
+        vec![AssetRef {
+            hash: a.clone(),
+            mime: " image/png ".into(),
+            bytes: 4,
+            role: AssetRole::Attachment,
+        }],
+        vec!["manifest".into()],
+    )?;
+    f.persist(&post).await?;
+    let manifest = KukuriMediaManifestV1 {
+        manifest_id: "manifest".into(),
+        owner_pubkey: post.keys.public_key(),
+        created_at: 1,
+        items: vec![
+            media_item(a.clone(), "image/jpeg", None),
+            media_item(b.clone(), "image/webp", Some(c.clone())),
+            media_item(c.clone(), "image/png", Some(a.clone())),
+        ],
+    };
+    let signed = build_media_manifest_envelope(&post.keys, &TopicId::new(SCOPE), &manifest)?;
+    f.set(
+        "manifests/media/manifest/envelope",
+        serde_json::to_value(signed)?,
+    )
+    .await?;
+    assert_eq!(f.ingest().await?.indexed, 1);
+    let io = f.observed();
+    assert_no_durable_blob_io(&io);
+    let media: Vec<_> = io
+        .scans
+        .iter()
+        .filter(|request| request.subject_kind == Some(SubjectKind::Blob))
+        .map(|request| {
+            (
+                request.subject_id.clone().unwrap(),
+                request.media_mime.clone(),
+            )
+        })
+        .collect();
+    assert_eq!(
+        media,
+        vec![
+            (a.as_str().into(), Some("image/png".into())),
+            (b.as_str().into(), Some("image/webp".into())),
+            (c.as_str().into(), None)
+        ]
+    );
+    assert_eq!(io.scans.len(), 4);
+    assert_eq!(io.entry_upserts, vec![post.id.clone()]);
+    assert_eq!(io.projection_upserts, vec![post.id]);
+    Ok(())
+}
+
+#[tokio::test]
+async fn mixed_scope_reingest_never_fetches_withdrawn_prevented_deleted_or_invalid_members()
+-> Result<()> {
+    let f = Fixture::new(IndexScopeKind::PublicTopic).await?;
+    let valid = f.post(b"valid body")?;
+    let withdrawn = f.post(b"withdrawn body")?;
+    let mut deleted = f.post(b"deleted body")?;
+    let mut tombstone = f.post(b"tombstone body")?;
+    let prevented = f.post(b"prevented body")?;
+    let mut invalid = f.post(b"invalid body")?;
+    for post in [
+        &valid, &withdrawn, &deleted, &tombstone, &prevented, &invalid,
+    ] {
+        f.persist(post).await?;
+    }
+    assert_eq!(f.ingest().await?.indexed, 6);
+    let withdrawal = build_post_withdrawal_envelope(
+        &withdrawn.keys,
+        &withdrawn.envelope,
+        1,
+        None,
+        WithdrawalReasonVisibility::Public,
+        Some(PostWithdrawalReason::AuthorRequest),
+    )?;
+    f.set(
+        &format!("withdrawals/{}/state", withdrawn.id),
+        serde_json::to_value(withdrawal)?,
+    )
+    .await?;
+    deleted.state["status"] = serde_json::json!("deleted");
+    f.persist(&deleted).await?;
+    tombstone.state["status"] = serde_json::json!("tombstoned");
+    f.persist(&tombstone).await?;
+    f.entries.inner.prevent_subject(prevented.id.clone());
+    invalid.envelope.content = "tampered".into();
+    f.persist(&invalid).await?;
+    f.set(
+        "objects/not-a-post/state",
+        serde_json::json!({"room_id": "other-domain"}),
+    )
+    .await?;
+    let mut removed = vec![
+        withdrawn.id,
+        deleted.id,
+        tombstone.id,
+        prevented.id,
+        invalid.id,
+    ];
+    removed.sort();
+    for _ in 0..2 {
+        f.clear_io();
+        let summary = f.ingest().await?;
+        assert_eq!(
+            (
+                summary.scanned,
+                summary.indexed,
+                summary.skipped_non_allow,
+                summary.deindexed
+            ),
+            (7, 1, 1, 4)
+        );
+        let mut io = f.observed();
+        assert_no_durable_blob_io(&io);
+        assert_eq!(
+            io.ephemeral,
+            vec![blob_hash(b"valid body").as_str().to_string()]
+        );
+        assert_eq!(io.scans.len(), 1);
+        assert_eq!(io.scans[0].subject_id.as_deref(), Some(valid.id.as_str()));
+        assert_eq!(io.entry_upserts, vec![valid.id.clone()]);
+        assert_eq!(io.projection_upserts, vec![valid.id.clone()]);
+        io.entry_removes.sort();
+        io.projection_removes.sort();
+        assert_eq!(io.entry_removes, removed);
+        assert_eq!(io.projection_removes, removed);
+        let entries = f.projection.inner.entries_in_scope(f.kind, SCOPE).await;
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].object_id, valid.id);
+        for id in &removed {
+            assert!(!f.entries.inner.contains(f.kind, SCOPE, id));
+        }
+    }
+    Ok(())
+}

--- a/crates/cn-indexer/tests/source_resolution_contracts/support.rs
+++ b/crates/cn-indexer/tests/source_resolution_contracts/support.rs
@@ -1,0 +1,360 @@
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use anyhow::Result;
+use async_trait::async_trait;
+use kukuri_blob_service::{BlobService, BlobStatus, StoredBlob};
+use kukuri_cn_core::{IndexEntryStore, IndexScopeKind, MemoryIndexEntryStore, NewIndexEntry};
+use kukuri_cn_indexer::ingest::{IngestPipeline, IngestSummary};
+use kukuri_cn_indexer::projection::{IndexProjection, IndexedEntry, MemoryIndexProjection};
+use kukuri_cn_safety::provider::{ProviderScanRequest, ProviderScanResult, ScanError};
+use kukuri_cn_safety::{
+    MockSafetyProvider, ModerationEventSigner, SafetyProvider, SafetyProviderCapability,
+};
+use kukuri_cn_safety_runtime::clock::SystemScanClock;
+use kukuri_cn_safety_runtime::id::UuidEventIdGenerator;
+use kukuri_cn_safety_runtime::{
+    MemorySafetyArtifactStore, SafetyOrchestrator, SafetyScanService,
+    Secp256k1ModerationEventSigner,
+};
+use kukuri_core::{
+    AssetRef, BlobHash, KukuriEnvelope, KukuriKeys, ObjectVisibility, PayloadRef, ReplicaId,
+    TopicId, blob_hash, build_post_envelope_with_payload,
+};
+use kukuri_docs_sync::{
+    DocOp, DocsSync, MemoryDocsSync, private_channel_replica_id, topic_replica_id,
+};
+
+pub(super) const SCOPE: &str = "source-contract";
+
+#[derive(Clone, Default)]
+pub(super) struct Observed {
+    pub ephemeral: Vec<String>,
+    pub durable: usize,
+    pub puts: usize,
+    pub pins: usize,
+    pub scans: Vec<ProviderScanRequest>,
+    pub entry_upserts: Vec<String>,
+    pub entry_removes: Vec<String>,
+    pub projection_upserts: Vec<String>,
+    pub projection_removes: Vec<String>,
+    pub scope_removes: usize,
+}
+
+type Trace = Arc<Mutex<Observed>>;
+
+#[derive(Clone)]
+pub(super) enum Reply {
+    Bytes(Vec<u8>),
+    Missing,
+    Failed,
+}
+
+pub(super) struct ObservedBlobs {
+    trace: Trace,
+    replies: Mutex<HashMap<String, Reply>>,
+}
+impl ObservedBlobs {
+    pub fn respond(&self, hash: &BlobHash, reply: Reply) {
+        self.replies
+            .lock()
+            .unwrap()
+            .insert(hash.as_str().into(), reply);
+    }
+    fn read(&self, hash: &BlobHash) -> Result<Option<Vec<u8>>> {
+        match self
+            .replies
+            .lock()
+            .unwrap()
+            .get(hash.as_str())
+            .cloned()
+            .unwrap_or(Reply::Missing)
+        {
+            Reply::Bytes(bytes) => Ok(Some(bytes)),
+            Reply::Missing => Ok(None),
+            Reply::Failed => anyhow::bail!("fixture fetch unavailable"),
+        }
+    }
+}
+#[async_trait]
+impl BlobService for ObservedBlobs {
+    async fn put_blob(&self, data: Vec<u8>, mime: &str) -> Result<StoredBlob> {
+        self.trace.lock().unwrap().puts += 1;
+        let hash = blob_hash(&data);
+        let bytes = data.len() as u64;
+        self.respond(&hash, Reply::Bytes(data));
+        Ok(StoredBlob {
+            hash,
+            mime: mime.into(),
+            bytes,
+        })
+    }
+    async fn fetch_blob(&self, hash: &BlobHash) -> Result<Option<Vec<u8>>> {
+        self.trace.lock().unwrap().durable += 1;
+        self.read(hash)
+    }
+    async fn fetch_blob_ephemeral(&self, hash: &BlobHash) -> Result<Option<Vec<u8>>> {
+        self.trace
+            .lock()
+            .unwrap()
+            .ephemeral
+            .push(hash.as_str().into());
+        self.read(hash)
+    }
+    async fn pin_blob(&self, _hash: &BlobHash) -> Result<()> {
+        self.trace.lock().unwrap().pins += 1;
+        Ok(())
+    }
+    async fn blob_status(&self, _hash: &BlobHash) -> Result<BlobStatus> {
+        Ok(BlobStatus::Available)
+    }
+    async fn import_peer_ticket(&self, _ticket: &str) -> Result<()> {
+        Ok(())
+    }
+}
+
+struct ObservedProvider {
+    trace: Trace,
+    inner: MockSafetyProvider,
+}
+#[async_trait]
+impl SafetyProvider for ObservedProvider {
+    fn name(&self) -> &str {
+        self.inner.name()
+    }
+    fn capabilities(&self) -> &[SafetyProviderCapability] {
+        self.inner.capabilities()
+    }
+    async fn scan(&self, request: &ProviderScanRequest) -> Result<ProviderScanResult, ScanError> {
+        self.trace.lock().unwrap().scans.push(request.clone());
+        self.inner.scan(request).await
+    }
+}
+
+pub(super) struct ObservedEntries {
+    pub inner: MemoryIndexEntryStore,
+    trace: Trace,
+}
+#[async_trait]
+impl IndexEntryStore for ObservedEntries {
+    async fn upsert_entry(&self, entry: &NewIndexEntry) -> Result<()> {
+        self.trace
+            .lock()
+            .unwrap()
+            .entry_upserts
+            .push(entry.object_id.clone());
+        self.inner.upsert_entry(entry).await
+    }
+    async fn remove_entry(&self, kind: IndexScopeKind, scope: &str, id: &str) -> Result<()> {
+        self.trace.lock().unwrap().entry_removes.push(id.into());
+        self.inner.remove_entry(kind, scope, id).await
+    }
+    async fn remove_scope(&self, kind: IndexScopeKind, scope: &str) -> Result<()> {
+        self.trace.lock().unwrap().scope_removes += 1;
+        self.inner.remove_scope(kind, scope).await
+    }
+    async fn filter_surfaceable(
+        &self,
+        kind: IndexScopeKind,
+        candidates: &[(String, String)],
+    ) -> Result<Vec<(String, String)>> {
+        self.inner.filter_surfaceable(kind, candidates).await
+    }
+    async fn list_scopes(&self) -> Result<Vec<(IndexScopeKind, String)>> {
+        self.inner.list_scopes().await
+    }
+    async fn is_transmission_prevented(&self, id: &str) -> Result<bool> {
+        self.inner.is_transmission_prevented(id).await
+    }
+}
+
+pub(super) struct ObservedProjection {
+    pub inner: MemoryIndexProjection,
+    trace: Trace,
+}
+#[async_trait]
+impl IndexProjection for ObservedProjection {
+    async fn upsert_entry(&self, entry: &IndexedEntry) -> Result<()> {
+        self.trace
+            .lock()
+            .unwrap()
+            .projection_upserts
+            .push(entry.object_id.clone());
+        self.inner.upsert_entry(entry).await
+    }
+    async fn contains_object(&self, kind: IndexScopeKind, scope: &str, id: &str) -> Result<bool> {
+        self.inner.contains_object(kind, scope, id).await
+    }
+    async fn count_scope(&self, kind: IndexScopeKind, scope: &str) -> Result<usize> {
+        self.inner.count_scope(kind, scope).await
+    }
+    async fn remove_scope(&self, kind: IndexScopeKind, scope: &str) -> Result<()> {
+        self.trace.lock().unwrap().scope_removes += 1;
+        self.inner.remove_scope(kind, scope).await
+    }
+    async fn remove_object(&self, kind: IndexScopeKind, scope: &str, id: &str) -> Result<()> {
+        self.trace
+            .lock()
+            .unwrap()
+            .projection_removes
+            .push(id.into());
+        self.inner.remove_object(kind, scope, id).await
+    }
+}
+
+pub(super) struct Fixture {
+    pub docs: Arc<MemoryDocsSync>,
+    pub blobs: Arc<ObservedBlobs>,
+    pub entries: Arc<ObservedEntries>,
+    pub projection: Arc<ObservedProjection>,
+    pub kind: IndexScopeKind,
+    pub replica: ReplicaId,
+    service: Arc<SafetyScanService>,
+    trace: Trace,
+}
+impl Fixture {
+    pub async fn new(kind: IndexScopeKind) -> Result<Self> {
+        let trace = Arc::new(Mutex::new(Observed::default()));
+        let signer = Secp256k1ModerationEventSigner::from_secret(&format!("{:064x}", 1))?;
+        let artifacts = Arc::new(MemorySafetyArtifactStore::new());
+        let provider = Arc::new(ObservedProvider {
+            trace: trace.clone(),
+            inner: MockSafetyProvider::known_csam("source-contract"),
+        });
+        let orchestrator = SafetyOrchestrator::builder(
+            signer.issuer_node_id(),
+            Arc::new(SystemScanClock),
+            Arc::new(UuidEventIdGenerator),
+        )
+        .provider(provider)
+        .build()?;
+        let service = Arc::new(
+            SafetyScanService::builder(Arc::new(orchestrator), artifacts.clone())
+                .signer(Arc::new(signer))
+                .build()?,
+        );
+        let docs = Arc::new(MemoryDocsSync::default());
+        let replica = match kind {
+            IndexScopeKind::PublicTopic => topic_replica_id(SCOPE),
+            IndexScopeKind::PrivateChannel => private_channel_replica_id(SCOPE),
+        };
+        if kind == IndexScopeKind::PrivateChannel {
+            docs.register_private_replica_secret(&replica, &"11".repeat(32))
+                .await?;
+        }
+        docs.open_replica(&replica).await?;
+        Ok(Self {
+            docs,
+            replica,
+            kind,
+            service,
+            blobs: Arc::new(ObservedBlobs {
+                trace: trace.clone(),
+                replies: Mutex::new(HashMap::new()),
+            }),
+            entries: Arc::new(ObservedEntries {
+                inner: MemoryIndexEntryStore::new(artifacts),
+                trace: trace.clone(),
+            }),
+            projection: Arc::new(ObservedProjection {
+                inner: MemoryIndexProjection::new(),
+                trace: trace.clone(),
+            }),
+            trace,
+        })
+    }
+    pub fn observed(&self) -> Observed {
+        self.trace.lock().unwrap().clone()
+    }
+    pub fn clear_io(&self) {
+        *self.trace.lock().unwrap() = Observed::default();
+    }
+    pub async fn ingest(&self) -> Result<IngestSummary> {
+        // Reconstruct the pipeline to model a later pass/restart with the same durable inputs.
+        IngestPipeline::new(
+            self.docs.clone(),
+            self.service.clone(),
+            self.entries.clone(),
+            self.projection.clone(),
+        )
+        .with_blob_service(self.blobs.clone())
+        .ingest_scope(self.kind, SCOPE, &self.replica)
+        .await
+    }
+    pub fn post(&self, bytes: &[u8]) -> Result<Post> {
+        let hash = blob_hash(bytes);
+        self.blobs.respond(&hash, Reply::Bytes(bytes.to_vec()));
+        self.post_with(
+            PayloadRef::BlobText {
+                hash,
+                mime: "text/markdown".into(),
+                bytes: bytes.len() as u64,
+            },
+            Vec::new(),
+            Vec::new(),
+        )
+    }
+    pub fn post_with(
+        &self,
+        payload: PayloadRef,
+        attachments: Vec<AssetRef>,
+        refs: Vec<String>,
+    ) -> Result<Post> {
+        let keys = KukuriKeys::generate();
+        let visibility = if self.kind == IndexScopeKind::PrivateChannel {
+            ObjectVisibility::Private
+        } else {
+            ObjectVisibility::Public
+        };
+        let envelope = build_post_envelope_with_payload(
+            &keys,
+            &TopicId::new(SCOPE),
+            payload,
+            attachments,
+            refs,
+            None,
+            visibility,
+        )?;
+        let state = serde_json::to_value(envelope.to_post_object()?.expect("post"))?;
+        Ok(Post {
+            id: envelope.id.as_str().into(),
+            keys,
+            envelope,
+            state,
+        })
+    }
+    pub async fn persist(&self, post: &Post) -> Result<()> {
+        self.set(&format!("objects/{}/state", post.id), post.state.clone())
+            .await?;
+        self.set(
+            &format!("objects/{}/envelope", post.id),
+            serde_json::to_value(&post.envelope)?,
+        )
+        .await
+    }
+    pub async fn set(&self, key: &str, value: serde_json::Value) -> Result<()> {
+        self.docs
+            .apply_doc_op(
+                &self.replica,
+                DocOp::SetJson {
+                    key: key.into(),
+                    value,
+                },
+            )
+            .await
+    }
+}
+pub(super) struct Post {
+    pub id: String,
+    pub keys: KukuriKeys,
+    pub envelope: KukuriEnvelope,
+    pub state: serde_json::Value,
+}
+
+pub(super) fn assert_no_durable_blob_io(io: &Observed) {
+    assert_eq!((io.durable, io.puts, io.pins), (0, 0, 0));
+    assert_eq!(
+        io.scope_removes, 0,
+        "an entry failure must not remove another scope"
+    );
+}

--- a/crates/cn-indexer/tests/source_resolution_contracts/support.rs
+++ b/crates/cn-indexer/tests/source_resolution_contracts/support.rs
@@ -58,14 +58,14 @@ impl ObservedBlobs {
     pub fn respond(&self, hash: &BlobHash, reply: Reply) {
         self.replies
             .lock()
-            .unwrap()
+            .expect("source contract fixture mutex poisoned")
             .insert(hash.as_str().into(), reply);
     }
     fn read(&self, hash: &BlobHash) -> Result<Option<Vec<u8>>> {
         match self
             .replies
             .lock()
-            .unwrap()
+            .expect("source contract fixture mutex poisoned")
             .get(hash.as_str())
             .cloned()
             .unwrap_or(Reply::Missing)
@@ -79,7 +79,10 @@ impl ObservedBlobs {
 #[async_trait]
 impl BlobService for ObservedBlobs {
     async fn put_blob(&self, data: Vec<u8>, mime: &str) -> Result<StoredBlob> {
-        self.trace.lock().unwrap().puts += 1;
+        self.trace
+            .lock()
+            .expect("source contract fixture mutex poisoned")
+            .puts += 1;
         let hash = blob_hash(&data);
         let bytes = data.len() as u64;
         self.respond(&hash, Reply::Bytes(data));
@@ -90,19 +93,25 @@ impl BlobService for ObservedBlobs {
         })
     }
     async fn fetch_blob(&self, hash: &BlobHash) -> Result<Option<Vec<u8>>> {
-        self.trace.lock().unwrap().durable += 1;
+        self.trace
+            .lock()
+            .expect("source contract fixture mutex poisoned")
+            .durable += 1;
         self.read(hash)
     }
     async fn fetch_blob_ephemeral(&self, hash: &BlobHash) -> Result<Option<Vec<u8>>> {
         self.trace
             .lock()
-            .unwrap()
+            .expect("source contract fixture mutex poisoned")
             .ephemeral
             .push(hash.as_str().into());
         self.read(hash)
     }
     async fn pin_blob(&self, _hash: &BlobHash) -> Result<()> {
-        self.trace.lock().unwrap().pins += 1;
+        self.trace
+            .lock()
+            .expect("source contract fixture mutex poisoned")
+            .pins += 1;
         Ok(())
     }
     async fn blob_status(&self, _hash: &BlobHash) -> Result<BlobStatus> {
@@ -126,7 +135,11 @@ impl SafetyProvider for ObservedProvider {
         self.inner.capabilities()
     }
     async fn scan(&self, request: &ProviderScanRequest) -> Result<ProviderScanResult, ScanError> {
-        self.trace.lock().unwrap().scans.push(request.clone());
+        self.trace
+            .lock()
+            .expect("source contract fixture mutex poisoned")
+            .scans
+            .push(request.clone());
         self.inner.scan(request).await
     }
 }
@@ -140,17 +153,24 @@ impl IndexEntryStore for ObservedEntries {
     async fn upsert_entry(&self, entry: &NewIndexEntry) -> Result<()> {
         self.trace
             .lock()
-            .unwrap()
+            .expect("source contract fixture mutex poisoned")
             .entry_upserts
             .push(entry.object_id.clone());
         self.inner.upsert_entry(entry).await
     }
     async fn remove_entry(&self, kind: IndexScopeKind, scope: &str, id: &str) -> Result<()> {
-        self.trace.lock().unwrap().entry_removes.push(id.into());
+        self.trace
+            .lock()
+            .expect("source contract fixture mutex poisoned")
+            .entry_removes
+            .push(id.into());
         self.inner.remove_entry(kind, scope, id).await
     }
     async fn remove_scope(&self, kind: IndexScopeKind, scope: &str) -> Result<()> {
-        self.trace.lock().unwrap().scope_removes += 1;
+        self.trace
+            .lock()
+            .expect("source contract fixture mutex poisoned")
+            .scope_removes += 1;
         self.inner.remove_scope(kind, scope).await
     }
     async fn filter_surfaceable(
@@ -177,7 +197,7 @@ impl IndexProjection for ObservedProjection {
     async fn upsert_entry(&self, entry: &IndexedEntry) -> Result<()> {
         self.trace
             .lock()
-            .unwrap()
+            .expect("source contract fixture mutex poisoned")
             .projection_upserts
             .push(entry.object_id.clone());
         self.inner.upsert_entry(entry).await
@@ -189,13 +209,16 @@ impl IndexProjection for ObservedProjection {
         self.inner.count_scope(kind, scope).await
     }
     async fn remove_scope(&self, kind: IndexScopeKind, scope: &str) -> Result<()> {
-        self.trace.lock().unwrap().scope_removes += 1;
+        self.trace
+            .lock()
+            .expect("source contract fixture mutex poisoned")
+            .scope_removes += 1;
         self.inner.remove_scope(kind, scope).await
     }
     async fn remove_object(&self, kind: IndexScopeKind, scope: &str, id: &str) -> Result<()> {
         self.trace
             .lock()
-            .unwrap()
+            .expect("source contract fixture mutex poisoned")
             .projection_removes
             .push(id.into());
         self.inner.remove_object(kind, scope, id).await
@@ -264,10 +287,16 @@ impl Fixture {
         })
     }
     pub fn observed(&self) -> Observed {
-        self.trace.lock().unwrap().clone()
+        self.trace
+            .lock()
+            .expect("source contract fixture mutex poisoned")
+            .clone()
     }
     pub fn clear_io(&self) {
-        *self.trace.lock().unwrap() = Observed::default();
+        *self
+            .trace
+            .lock()
+            .expect("source contract fixture mutex poisoned") = Observed::default();
     }
     pub async fn ingest(&self) -> Result<IngestSummary> {
         // Reconstruct the pipeline to model a later pass/restart with the same durable inputs.

--- a/docs/progress/2026-09-08-925-indexer-source-contract.md
+++ b/docs/progress/2026-09-08-925-indexer-source-contract.md
@@ -1,0 +1,42 @@
+# Issue #925: source解決前後のI/Oとindex結果を固定
+
+- Scope revision `2026-09-08-872-C-CN-v1`、区分C。before `2229fefaa479064bf8080bc55e2984acf025fc66`。
+- 新規integration testと同配下support、本記録のみ。製品IngestPipeline/既存test/公開API/wire/schemaを変更しない。後続#926の前に現在の挙動を固定する。
+- 既存のMemoryDocsSync、MemoryIndexEntryStore、MemoryIndexProjection、SafetyScanService、MockSafetyProviderを組み合わせ、境界traitを薄い計測wrapperで包む。既存sourceの複製や実装helperのmockはしない。
+
+| 作業 | AC / INVAR | 対象と受入確認 | 依存 |
+| --- | --- | --- | --- |
+| T1 変更前baseline / 全caller | AC-5、INVAR-1/2 | 既存blob/ingestion/transmission3 suite、publicPipelineとworker/participant、source/provider/2storeの逆引き | なし |
+| T2 body / manifest保護 | AC-1/2/3、INVAR-3 | 新規source_resolution_contractsと計測support。下表の拒否条件/禁止I/Oと許可deindex | T1 |
+| T3 mixed / reingest保護 | AC-4、INVAR-3 | 複数状態混在、同store/Docsでpipeline再生成、valid memberの継続と削除集合 | T2 |
+| T4 検証 / 独立監査 / CI | AC-5、全INVAR | targeted、cn-check/cn-test、固定head監査とmerge tree。結果はPR/Issueへ | T3 |
+
+## INV / TR / test対応
+
+| 対応 | 新規test・観測 |
+| --- | --- |
+| INV-R2/3/6、TR-R2 | `unverified_blob_metadata_has_zero_fetch_scan_and_index_upserts`: envelope missing/malformed/signature/ID/author/payload/declared oversizedの7条件。ephemeral/durable fetch・provider・2store upsert0、許可された各storeのremove1を別計測 |
+| INV-R3/6、TR-R3 | `rejected_blob_bytes_use_only_ephemeral_fetch_and_never_reach_a_provider`: missing/fetch error/size/hash/UTF8/character limitの6条件。ephemeral1だけ、durable/put/pin0、provider0、2store remove。正常index済み→取得不能もdeindexし古いentryを残さない |
+| INV-R1/3/6、TR-R1 | `unicode_body_at_the_character_limit_remains_scoped_and_ephemeral`: 10,000文字/30,000bytesの本文をpublic/許可済みprivate scopeでindex。本文・scope・provider入力・ephemeralだけの取得、別scopeへ出ないことを確認 |
+| INV-R4/5/6、TR-R5 | `invalid_media_manifest_never_sends_media_to_the_provider_or_upserts_indexes`: missing/invalid signature/wrong kind/wrong author/malformedの5条件。post text scan1は許可し、media scanとupsertを0、deindexを別計測 |
+| INV-R4/5、TR-R5 | `duplicate_media_hashes_preserve_first_mime_including_a_thumbnail_without_mime`: attachment→manifest重複、競合mime、thumbnail→後続item重複。同hash1scan、trimmed先勝ちmime、先勝ちNoneと対象順を保持 |
+| INV-R1/2/3/6、TR-R4/7 | `mixed_scope_reingest_never_fetches_withdrawn_prevented_deleted_or_invalid_members`: 最初6件index後、valid/署名withdrawal/deleted/tombstoned/legal prevented/invalid signature/nonpostを混在。pipeline再生成の2passとも7 scanned/1 indexed/1 skipped/4 deindexed、validのhash/providerだけ、2store削除5、他scope削除0 |
+| INV-R5/6、TR-R6 | 既存ingestion/query/worker/provider/CN e2eがnonallow・provider/artifact・2store failureを保護。新規source testへ同内容のassertを複製しない |
+
+`fetch_blob_ephemeral`は明示overrideし、trait defaultのdurable fetch委譲で誤検知しないよう分離計測する。MemoryIndexEntryStoreは同じmoderation artifact storeを参照し、既存allow制約を維持。upsertとremove、scope全体のremoveを混同しない。計測対象は外部trait I/Oと保存結果であり、private helper名を固定しない。
+
+## 全callerと凍結境界
+
+CodeGraphでrootのingestion/source/testを確認し、indexの無いworktreeでは同一sourceを直接読み補完した。
+`rg -n 'ingest_scope|ingest_all_supported|resolve_body_text|media_scan_targets|resolve_media_manifest|fetch_blob_ephemeral|upsert_entry|remove_entry|remove_object' crates/cn-indexer crates/cn-core crates/cn-e2e`でworker/participant/direct tests、source→scan→store、別query/legal deindex経路を分類。
+本Issueの製品INV-R1〜6に増減なし、未分類0。shared docs/blobs、private capability、wire/署名、same-pass envelope map、query policy、Postgres→projectionの順、error/summary/metricsの変更は0。
+
+## 実行記録
+
+- before: `cargo test -p kukuri-cn-indexer --test blob_text_ingestion_contracts --test ingestion_contracts --test transmission_prevention_contracts` →3+17+2=22 tests PASS。
+- 新規: `cargo test -p kukuri-cn-indexer --test source_resolution_contracts` →6 tests PASS（0.02秒）。
+- 最終は既存3suiteとの一括targetedと、必須`cargo xtask cn-check` / `cargo xtask cn-test`をCIで確認する。in-memory targetedの成功を実Postgres/Redis/ArcadeDB成功と混同しない。
+- worktree専用`CARGO_TARGET_DIR=.../target/issue-925`で実行し、別worktreeの埋込みpathを持つxtaskを再利用しない。
+- 最終結果・独立監査head・CI・merge tree一致はPR/Issueに保存する。
+
+Rollbackはtest-only PRを単独revert。#926実装後は先にrefactorを戻し、保護網だけを外さない。既存仕様との不一致が見つかったらfixへ分類し、assertionを弱めて抽出を開始しない。


### PR DESCRIPTION
Refs #925。CN indexerで未検証sourceがfetch/provider/upsertへ進まないことを固定しました。ephemeral/durable、put/pin、provider、両storeのupsertと許可deindexを分離計測し、mixed/reingestも観測します。

- 種別 `contract`、区分C、Scope revision `2026-09-08-872-C-CN-v1`。
- [計画・AC/INVAR・対象境界・検証・rollback記録](docs/progress/2026-09-08-925-indexer-source-contract.md)。詳細な独立監査とdeltaはPR commentsに保持。
- 新6+既存3suiteの28 testsと独立再実行PASS。CIのunwrap_usedをexpectへ修正し、Clippy・同6再実行・独立delta監査PASS。製品/既存assertion変更なし。
- 最終head `a2dbe8e2ebd701e5d3531456943f51846ab0e822` の全17 checks SUCCESS。必要な独立監査とCIを満たしてmergeしました。
- merge `7c9cba850d572c8d358d5f529798a89c3c84eb06` と監査対象のpath/surface一致を確認し、[Issue #925](https://github.com/KingYoSun/kukuri/issues/925)の現在判定をCompleteへ同期・Close済み。
