### PR TITLE
[codex][refactor:extract] CN Dome transfer完了処理を集約する

### DIFF
--- a/crates/desktop-runtime/src/runtime/private_channels_game_api.rs
+++ b/crates/desktop-runtime/src/runtime/private_channels_game_api.rs
@@ -345,47 +345,17 @@ impl DesktopRuntime {
                 lease_duration_millis: request.lease_duration_millis,
             })
             .await?;
-        let signed_lease: SignedDomeHostingLeaseV1 = serde_json::from_str(
-            prepared
-                .signed_lease_json
-                .as_deref()
-                .context("prepared Dome hosting view has no signed lease")?,
-        )?;
-        let assignment = self
-            .assign_dome_hosting_to_community_node(
-                &request.base_url,
-                &self
-                    .build_dome_hosting_assignment_request(
-                        signed_lease,
-                        &prepared.instance_manifest_json,
-                        &prepared.preset_manifest_json,
-                    )
-                    .await?,
-            )
-            .await?;
-        let activated = self
-            .app_service
-            .activate_community_node_dome_hosting(ActivateCommunityNodeDomeHostingInput {
-                spatial_context: request.spatial_context,
-                instance_id: request.instance_id.clone(),
-                signed_acceptance_json: serde_json::to_string(&assignment.signed_acceptance)?,
-            })
-            .await?;
-        let signed_activation: SignedDomeHostingActivationV1 = serde_json::from_str(
-            activated
-                .signed_activation_json
-                .as_deref()
-                .context("activated Dome hosting view has no signed activation")?,
-        )?;
-        self.activate_dome_hosting_on_community_node(
+        self.complete_community_node_dome_transfer(
             &request.base_url,
-            &DomeHostingActivationRequest {
-                instance_id: request.instance_id,
-                signed_activation,
-            },
+            request.spatial_context,
+            request.instance_id,
+            &prepared,
+            (
+                "prepared Dome hosting view has no signed lease",
+                "activated Dome hosting view has no signed activation",
+            ),
         )
-        .await?;
-        Ok(activated)
+        .await
     }
 
     pub async fn close_dome_hosting(
@@ -715,48 +685,18 @@ impl DesktopRuntime {
             return Ok(committed);
         }
         let api_base_url = api_base_url.clone();
-        let signed_lease: SignedDomeHostingLeaseV1 = serde_json::from_str(
-            committed
-                .hosting
-                .signed_lease_json
-                .as_deref()
-                .context("prepared layout commit has no signed lease")?,
-        )?;
-        let assignment = self
-            .assign_dome_hosting_to_community_node(
+        committed.hosting = self
+            .complete_community_node_dome_transfer(
                 &api_base_url,
-                &self
-                    .build_dome_hosting_assignment_request(
-                        signed_lease,
-                        &committed.hosting.instance_manifest_json,
-                        &committed.hosting.preset_manifest_json,
-                    )
-                    .await?,
+                request.spatial_context,
+                request.instance_id,
+                &committed.hosting,
+                (
+                    "prepared layout commit has no signed lease",
+                    "activated layout commit has no signed activation",
+                ),
             )
             .await?;
-        let activated = self
-            .app_service
-            .activate_community_node_dome_hosting(ActivateCommunityNodeDomeHostingInput {
-                spatial_context: request.spatial_context,
-                instance_id: request.instance_id.clone(),
-                signed_acceptance_json: serde_json::to_string(&assignment.signed_acceptance)?,
-            })
-            .await?;
-        let signed_activation: SignedDomeHostingActivationV1 = serde_json::from_str(
-            activated
-                .signed_activation_json
-                .as_deref()
-                .context("activated layout commit has no signed activation")?,
-        )?;
-        self.activate_dome_hosting_on_community_node(
-            &api_base_url,
-            &DomeHostingActivationRequest {
-                instance_id: request.instance_id,
-                signed_activation,
-            },
-        )
-        .await?;
-        committed.hosting = activated;
         Ok(committed)
     }
 
@@ -804,6 +744,59 @@ impl DesktopRuntime {
                 Ok(snapshot.snapshot)
             })
             .collect()
+    }
+
+    // Both entrypoints retain their own preparation/no-op rules. This method owns
+    // assignment -> owner activation persistence -> remote activation in that order.
+    async fn complete_community_node_dome_transfer(
+        &self,
+        base_url: &str,
+        spatial_context: kukuri_core::SpatialContextV1,
+        instance_id: String,
+        prepared: &DomeHostingView,
+        error_contexts: (&'static str, &'static str),
+    ) -> Result<DomeHostingView> {
+        let signed_lease: SignedDomeHostingLeaseV1 = serde_json::from_str(
+            prepared
+                .signed_lease_json
+                .as_deref()
+                .context(error_contexts.0)?,
+        )?;
+        let assignment = self
+            .assign_dome_hosting_to_community_node(
+                base_url,
+                &self
+                    .build_dome_hosting_assignment_request(
+                        signed_lease,
+                        &prepared.instance_manifest_json,
+                        &prepared.preset_manifest_json,
+                    )
+                    .await?,
+            )
+            .await?;
+        let activated = self
+            .app_service
+            .activate_community_node_dome_hosting(ActivateCommunityNodeDomeHostingInput {
+                spatial_context,
+                instance_id: instance_id.clone(),
+                signed_acceptance_json: serde_json::to_string(&assignment.signed_acceptance)?,
+            })
+            .await?;
+        let signed_activation: SignedDomeHostingActivationV1 = serde_json::from_str(
+            activated
+                .signed_activation_json
+                .as_deref()
+                .context(error_contexts.1)?,
+        )?;
+        self.activate_dome_hosting_on_community_node(
+            base_url,
+            &DomeHostingActivationRequest {
+                instance_id,
+                signed_activation,
+            },
+        )
+        .await?;
+        Ok(activated)
     }
 
     async fn build_dome_hosting_assignment_request(

--- a/docs/progress/2026-09-08-922-dome-transfer-extract.md
+++ b/docs/progress/2026-09-08-922-dome-transfer-extract.md
@@ -1,0 +1,38 @@
+# Issue #922: CN Dome transfer完了処理の所有者を集約
+
+- Scope revision `2026-09-08-872-R-RT-v1`、区分C。before `d5c7769a9c73c76ccfeabb8b0b0453d495b1e1b6`。
+- 先行#921はPR#932で全CI・独立監査・merge後照合PASSを経て完了。固定INV1〜3/TR1〜5のcontractを保持して着手。
+- 意図: runtimeの2入口が二重所有していたassignment→owner activation保存→CN activateを1 private methodへ抽出。
+
+| 作業 | AC / INVAR | 対象・証拠 | 依存 |
+| --- | --- | --- | --- |
+| T1 before contract | AC-2、INVAR-1/2 | runtime11 testsとAppService2 tests、#921 merge/head一致 | #921 |
+| T2 private method抽出 | AC-1/2、INVAR-1/2 | `private_channels_game_api.rs`だけ。prepare/no-op/view組立は各入口に残す | T1 |
+| T3 変更後検証・測定 | AC-3、全INVAR | 同runtime11 tests、AppService tests、caller2/実行site1の逆引き、rust-test CI | T2 |
+| T4 監査・CI・merge | AC-3、全INVAR | fixed head独立監査・必須CI・merge tree照合、結果はPR/Issue | T3 |
+
+## 構造上の成果
+
+`complete_community_node_dome_transfer`の本番callerはdelegate/commit layoutの2箇所のみ。
+このmethodだけが`build_dome_hosting_assignment_request`、`assign_dome_hosting_to_community_node`、`activate_dome_hosting_on_community_node`を順に利用し、間のAppService activationを所有する。各実行siteは2→1、public入口は2のまま。
+元のmodule内にprivate methodを置くため、他moduleへhelperの公開範囲を広げない。単なるファイル分割を成果にしない。
+
+## 維持した制御と境界
+
+- delegateは自分でprepareしてからhelperへ進み、その結果viewを返す。
+- layoutはcandidate取得、AppService commit、owner target/no-op/active operation retryの早期returnを維持。CN Transferring時だけhelperへ進み、committed.hostingを置換する。
+- 元の4つのmissing lease/activation error contextはstatic tupleで渡し、delegate/layoutの文言を維持する。新しいdomain policy、retry、transaction、rollbackは追加しない。
+- 既存CN adapterは各送信の直前に同意を再確認する。owner activation保存後の送信失敗で永続状態を巻き戻さない。
+- instance/context/base URL、署名済みJSONの取出し・serialize、asset bundle、public request/response/IPC/HTTP/wire/schema/authorityは不変。
+
+CodeGraphで元の各sequenceを確認し、抽出後は `rg -n 'complete_community_node_dome_transfer|assign_dome_hosting_to_community_node\(|activate_dome_hosting_on_community_node\(|build_dome_hosting_assignment_request\(' crates/desktop-runtime/src/runtime/private_channels_game_api.rs` で全siteを再列挙。Tauri/CLI callerに変更なし、INV/TR増減0、未分類0。
+
+## 検証
+
+- before runtime: `cargo test -p kukuri-desktop-runtime tests::community_node::dome_hosting` →11 PASS（4.65秒）。
+- before AppService: `cargo test -p kukuri-app-api tests::dome_hosting` →2 PASS（0.05秒）。
+- after runtime: 同11 tests PASS（3.76秒）。返却view、各失敗後の署名済み状態、同operation、追加HTTP禁止、assignment後のpolicy更新を同じassertionで検証。
+- test/fixture変更0、UI/Rust以外の境界変更0。必須rust-testはCIの対象SHA/jobとともに記録し、local targetedを全suite成功としない。
+- `git diff --check`とoversizedを確認。root専用CARGO_TARGET_DIRを使用する。
+
+Rollbackはこの抽出PRのみrevertし#921 contractを保持。data/schema migrationなし。公開契約変更が必要と判明した場合は抽出へ混ぜない。


### PR DESCRIPTION
Refs #922。delegate/layout commitに重複したassignment→owner activation保存→CN activateを同moduleのprivate methodへ集約しました。各実行site2→1、caller2を保ち、prepare/no-opは各入口に残しています。

- 種別 `refactor:extract`、区分C、Scope revision `2026-09-08-872-R-RT-v1`。
- [計画・AC/INVAR・対象境界・検証・rollback記録](docs/progress/2026-09-08-922-dome-transfer-extract.md)。詳細な独立監査とdeltaはPR commentsに保持。
- 同runtime11 tests・AppService2 testsをbefore/afterで維持、独立runtime再実行11 PASS。エラー文脈/返却view/同意再guard/副作用順、test/fixtureを維持。
- 最終head `bec17adb73f6eb5de1e7f56bc01b3918dbf0dacf` の全13 checks SUCCESS。必要な独立監査とCIを満たしてmergeしました。
- merge `f90d28fb5c5b0f87fd30233250ba786c3938eba0` と監査対象のpath/surface一致を確認し、[Issue #922](https://github.com/KingYoSun/kukuri/issues/922)の現在判定をCompleteへ同期・Close済み。
