### PR TITLE
[codex][refactor:extract] Dome transition attemptの所有者を集約する

### DIFF
--- a/apps/desktop/src/components/extended/metaverse/useDomeTransitionAttempt.ts
+++ b/apps/desktop/src/components/extended/metaverse/useDomeTransitionAttempt.ts
@@ -1,0 +1,235 @@
+import { useCallback, useRef, useState, type Dispatch, type SetStateAction } from 'react';
+
+import type { DomeDirection, DomeSessionInputKindV1, DomeTransitionAdmissionTicketV1, GameRoomView } from '@/lib/api';
+import type { AvatarTransform } from '../MetaverseSceneModel';
+import type { MetaverseRoomActions } from './MetaverseRoomActions';
+import {
+  domeTransitionProgress,
+  transitionNeighborAtPosition,
+  transitionNeighborInZone,
+  transformAvatarBetweenDomes,
+  type DomeNeighborTransitionView,
+} from './DomeTransitionModel';
+import { recoverDomeTransitionCommit } from './DomeTransitionCommitRecovery';
+import { writeLastVisitedDome } from './DomeEntryModel';
+
+type TransitionAttempt = {
+  id: string;
+  sourceRoom: GameRoomView;
+  neighbor: DomeNeighborTransitionView;
+  phase: 'preparing' | 'provisional' | 'committing' | 'target_committed';
+  ticket: DomeTransitionAdmissionTicketV1 | null;
+  cancelled: boolean;
+};
+
+type UseDomeTransitionAttemptArgs = {
+  actions: MetaverseRoomActions;
+  admittedRoom: GameRoomView | null;
+  localAuthorPubkey: string;
+  localPeerId: string;
+  transitionNeighbors: DomeNeighborTransitionView[];
+  setTransitionNeighbors: Dispatch<SetStateAction<DomeNeighborTransitionView[]>>;
+  submitInputForRoom: (
+    room: GameRoomView,
+    input: DomeSessionInputKindV1,
+    suggestedSequence?: number
+  ) => ReturnType<MetaverseRoomActions['submitSessionInput']>;
+  onHandoff: (sourceRoom: GameRoomView, targetRoom: GameRoomView, transform: AvatarTransform) => void;
+  onError: (message: string | null) => void;
+};
+
+// Owns each asynchronous attempt; admission and the input sequence remain in the session.
+export function useDomeTransitionAttempt({
+  actions, admittedRoom, localAuthorPubkey, localPeerId, transitionNeighbors,
+  setTransitionNeighbors, submitInputForRoom, onHandoff, onError,
+}: UseDomeTransitionAttemptArgs) {
+  const [transitionPreparingDirections, setTransitionPreparingDirections] = useState<Set<DomeDirection>>(
+    () => new Set()
+  );
+  const transitionAttemptRef = useRef<TransitionAttempt | null>(null);
+
+  function setTransitionPreparing(direction: DomeDirection, preparing: boolean) {
+    setTransitionPreparingDirections((current) => {
+      const next = new Set(current);
+      if (preparing) next.add(direction);
+      else next.delete(direction);
+      return next;
+    });
+  }
+
+  const abortTransitionAttempt = useCallback(async (attempt: TransitionAttempt) => {
+    if (attempt.phase === 'committing' || attempt.phase === 'target_committed') return;
+    attempt.cancelled = true;
+    if (attempt.ticket) {
+      await actions.abortTransition(attempt.ticket).catch(() => undefined);
+    }
+    await submitInputForRoom(attempt.sourceRoom, {
+      type: 'abort_transition',
+      transition_id: attempt.id,
+    }).catch(() => undefined);
+    if (transitionAttemptRef.current === attempt) {
+      transitionAttemptRef.current = null;
+    }
+    setTransitionPreparingDirections((current) => {
+      const next = new Set(current);
+      next.delete(attempt.neighbor.direction);
+      return next;
+    });
+  }, [actions, submitInputForRoom]);
+
+  function beginTransitionAttempt(neighbor: DomeNeighborTransitionView) {
+    if (!admittedRoom?.metaverse || transitionAttemptRef.current) return;
+    const transitionId = `dome-transition-${globalThis.crypto?.randomUUID?.() ?? Date.now()}`;
+    const attempt: TransitionAttempt = {
+      id: transitionId,
+      sourceRoom: admittedRoom,
+      neighbor,
+      phase: 'preparing',
+      ticket: null,
+      cancelled: false,
+    };
+    transitionAttemptRef.current = attempt;
+    setTransitionPreparing(neighbor.direction, true);
+    void (async () => {
+      try {
+        await submitInputForRoom(attempt.sourceRoom, {
+          type: 'prepare_transition',
+          transition_id: attempt.id,
+          direction: neighbor.direction,
+        });
+        if (attempt.cancelled) return;
+        attempt.ticket = await actions.prepareTransition({
+          transition_id: attempt.id,
+          connection_id: neighbor.connectionId,
+          topology_digest: neighbor.topologyDigest,
+          spatial_context: attempt.sourceRoom.metaverse!.spatial_context,
+          source_instance_id: attempt.sourceRoom.metaverse!.instance_id,
+          source_instance_generation: attempt.sourceRoom.metaverse!.instance_generation,
+          target_instance_id: neighbor.room.metaverse!.instance_id,
+          target_instance_generation: neighbor.room.metaverse!.instance_generation,
+          participant_pubkey: localAuthorPubkey,
+          direction: neighbor.direction,
+          requested_at: Date.now(),
+        });
+        if (attempt.cancelled) {
+          await abortTransitionAttempt(attempt);
+          return;
+        }
+        attempt.phase = 'provisional';
+        setTransitionPreparing(neighbor.direction, false);
+      } catch (transitionError) {
+        await abortTransitionAttempt(attempt);
+        setTransitionNeighbors((current) => current.map((candidate) =>
+          candidate.connectionId === neighbor.connectionId
+            ? { ...candidate, boundaryState: 'error' }
+            : candidate
+        ));
+        onError(
+          transitionError instanceof Error
+            ? transitionError.message
+            : 'Dome transition preparation failed'
+        );
+      }
+    })();
+  }
+
+  function commitTransitionAttempt(attempt: TransitionAttempt, transform: AvatarTransform) {
+    if (attempt.phase !== 'provisional' || attempt.cancelled || !attempt.ticket) return;
+    attempt.phase = 'committing';
+    const targetPosition = transformAvatarBetweenDomes(transform.position, attempt.neighbor.relativeCoordinateCm);
+    const targetTransform: AvatarTransform = {
+      ...transform, roomId: attempt.neighbor.room.room_id, seq: 0,
+      position: targetPosition, sentAt: Date.now(),
+    };
+    void (async () => {
+      const recovery = await recoverDomeTransitionCommit({
+        ticket: attempt.ticket!,
+        commit: () => actions.commitTransition(attempt.ticket!, targetPosition, transform.rotation),
+        getHosting: () => actions.getHosting(attempt.ticket!.request.spatial_context, attempt.ticket!.request.target_instance_id),
+        isCurrent: () => transitionAttemptRef.current === attempt && !attempt.cancelled,
+      });
+      if (recovery.status === 'cancelled') return;
+      if (recovery.status === 'rollback') {
+        attempt.phase = 'provisional';
+        await abortTransitionAttempt(attempt);
+        setTransitionNeighbors((current) => current.map((candidate) =>
+          candidate.connectionId === attempt.neighbor.connectionId
+            ? { ...candidate, boundaryState: 'error' }
+            : candidate
+        ));
+        onError(recovery.error instanceof Error
+          ? recovery.error.message
+          : 'Dome transition commit failed');
+        return;
+      }
+      attempt.phase = 'target_committed';
+      transitionAttemptRef.current = null;
+      setTransitionPreparing(attempt.neighbor.direction, false);
+      onHandoff(attempt.sourceRoom, attempt.neighbor.room, targetTransform);
+      if (attempt.neighbor.room.metaverse) {
+        writeLastVisitedDome(
+          localAuthorPubkey,
+          attempt.neighbor.room.metaverse.spatial_context,
+          attempt.neighbor.room.metaverse.instance_id
+        );
+      }
+      onError(null);
+      let sourceCompleted = false;
+      for (const retryDelay of [0, 250, 1_000]) {
+        if (retryDelay > 0) {
+          await new Promise((resolve) => window.setTimeout(resolve, retryDelay));
+        }
+        try {
+          await submitInputForRoom(attempt.sourceRoom, {
+            type: 'complete_transition',
+            transition_id: attempt.id,
+          });
+          sourceCompleted = true;
+          break;
+        } catch {
+          // The destination remains authoritative; retry only source cleanup.
+        }
+      }
+      if (sourceCompleted) {
+        const leftAt = Date.now();
+        await actions.publishRoomEvent(attempt.sourceRoom.room_id, localPeerId, leftAt, {
+          type: 'presence_leave',
+          room_id: attempt.sourceRoom.room_id,
+          peer_id: localPeerId,
+          left_at: leftAt,
+        }).catch(() => undefined);
+      } else {
+        onError('Destination committed; source Dome cleanup will require resynchronization');
+      }
+    })();
+  }
+
+  const requestTransitionAbort = useCallback(() => {
+    const attempt = transitionAttemptRef.current;
+    if (attempt) void abortTransitionAttempt(attempt);
+  }, [abortTransitionAttempt]);
+
+  function handleTransitionTransform(transform: AvatarTransform, previous: AvatarTransform | null) {
+    const attempt = transitionAttemptRef.current;
+    const inZone = transitionNeighborInZone(transform.position, transitionNeighbors);
+    if (!attempt && inZone) {
+      beginTransitionAttempt(inZone);
+      return;
+    }
+    if (!attempt) return;
+    if (
+      attempt.phase !== 'committing' &&
+      domeTransitionProgress(transform.position, attempt.neighbor.direction) <= 0
+    ) {
+      void abortTransitionAttempt(attempt);
+      return;
+    }
+    const crossed = transitionNeighborAtPosition(previous?.position ?? null, transform.position, [
+      attempt.neighbor,
+    ]);
+    if (crossed && attempt.phase === 'provisional') {
+      commitTransitionAttempt(attempt, transform);
+    }
+  }
+  return { transitionPreparingDirections, requestTransitionAbort, handleTransitionTransform };
+}

--- a/apps/desktop/src/components/extended/metaverse/useMetaverseRoomSession.ts
+++ b/apps/desktop/src/components/extended/metaverse/useMetaverseRoomSession.ts
@@ -8,7 +8,6 @@ import type {
   GameRoomView,
   DomePhysicsSnapshotV1,
   DomeSessionInputKindV1,
-  DomeTransitionAdmissionTicketV1,
   MetaverseAssetRef,
   MetaverseColliderV1,
   MetaverseInteractionKind,
@@ -20,13 +19,6 @@ import type {
 import type { MetaverseRoomActions } from './MetaverseRoomActions';
 import type { SessionPropView } from '../MetaverseScene';
 import { createDomeInteractionInput, persistentPropAsSharedObject } from './DomeSceneModel';
-import {
-  domeTransitionProgress,
-  transitionNeighborAtPosition,
-  transitionNeighborInZone,
-  transformAvatarBetweenDomes,
-  type DomeNeighborTransitionView,
-} from './DomeTransitionModel';
 import { useDomeTransitionNeighbors } from './useDomeTransitionNeighbors';
 import {
   DEFAULT_SHARED_OBJECT,
@@ -57,7 +49,7 @@ import {
   writeLastVisitedDome,
 } from './DomeEntryModel';
 import { loadAvatarCollider } from './AvatarColliderModel';
-import { recoverDomeTransitionCommit } from './DomeTransitionCommitRecovery';
+import { useDomeTransitionAttempt } from './useDomeTransitionAttempt';
 
 type UseMetaverseRoomSessionArgs = {
   actions: MetaverseRoomActions;
@@ -73,15 +65,6 @@ type UseMetaverseRoomSessionArgs = {
   activeChannelId?: string | null;
   configuredEntryInstanceId?: string | null;
   onError: (message: string | null) => void;
-};
-
-type TransitionAttempt = {
-  id: string;
-  sourceRoom: GameRoomView;
-  neighbor: DomeNeighborTransitionView;
-  phase: 'preparing' | 'provisional' | 'committing' | 'target_committed';
-  ticket: DomeTransitionAdmissionTicketV1 | null;
-  cancelled: boolean;
 };
 
 export type DomeRecoveryStatus = {
@@ -128,9 +111,6 @@ export function useMetaverseRoomSession({
   const [messageDraft, setMessageDraft] = useState('');
   const [sharedObject, setSharedObject] = useState<SharedRoomObjectV1>(DEFAULT_SHARED_OBJECT);
   const [sessionProps, setSessionProps] = useState<SessionPropView[]>([]);
-  const [transitionPreparingDirections, setTransitionPreparingDirections] = useState<Set<DomeDirection>>(
-    () => new Set()
-  );
   const [handoffTransform, setHandoffTransform] = useState<AvatarTransform | null>(null);
   const [lastSentSeq, setLastSentSeq] = useState(0);
   const [recoveringUntil, setRecoveringUntil] = useState(0);
@@ -147,7 +127,6 @@ export function useMetaverseRoomSession({
   const localPeerSeed = useId().replaceAll(':', '');
   const localPeerId = `${syncStatus.discovery.local_endpoint_id || syncStatus.local_author_pubkey || 'local'}:${localPeerSeed}`;
   const lastSentTransformRef = useRef<AvatarTransform | null>(null);
-  const transitionAttemptRef = useRef<TransitionAttempt | null>(null);
   const entryAttemptKeyRef = useRef<string | null>(null);
   const entryContextKeyRef = useRef<string | null>(null);
   const entryAutoDisabledRef = useRef(false);
@@ -268,18 +247,6 @@ export function useMetaverseRoomSession({
     syncStatus,
   ]);
   const knownPeerCount = Object.keys(remoteTransforms).length;
-  const transitionBoundaryStates = useMemo(() => {
-    const states: Partial<Record<DomeDirection, DomeBoundaryStateV1>> = {};
-    for (const neighbor of transitionNeighbors) {
-      states[neighbor.direction] = domeRecovery.state === 'offline'
-        ? 'offline'
-        : transitionPreparingDirections.has(neighbor.direction)
-        ? 'loading'
-        : neighbor.boundaryState;
-    }
-    return states;
-  }, [domeRecovery.state, transitionNeighbors, transitionPreparingDirections]);
-
   const nextSessionSequence = useCallback((instanceId: string, suggested = Date.now()) => {
     const next = Math.max(suggested, (sessionSequenceByInstanceRef.current.get(instanceId) ?? 0) + 1);
     sessionSequenceByInstanceRef.current.set(instanceId, next);
@@ -624,170 +591,38 @@ export function useMetaverseRoomSession({
     resetBackendEventCursor();
   }
 
-  function setTransitionPreparing(direction: DomeDirection, preparing: boolean) {
-    setTransitionPreparingDirections((current) => {
+  const applyTransitionHandoff = useCallback((
+    sourceRoom: GameRoomView, targetRoom: GameRoomView, targetTransform: AvatarTransform
+  ) => {
+    setHandoffTransform(targetTransform);
+    lastSentTransformRef.current = targetTransform;
+    setLastSentSeq(0);
+    setJoinedRoomIds((current) => {
       const next = new Set(current);
-      if (preparing) next.add(direction);
-      else next.delete(direction);
+      next.delete(sourceRoom.room_id);
+      next.add(targetRoom.room_id);
       return next;
     });
-  }
+    setSelectedRoomId(targetRoom.room_id);
+  }, []);
 
-  const abortTransitionAttempt = useCallback(async (attempt: TransitionAttempt) => {
-    if (attempt.phase === 'committing' || attempt.phase === 'target_committed') return;
-    attempt.cancelled = true;
-    if (attempt.ticket) {
-      await actions.abortTransition(attempt.ticket).catch(() => undefined);
+  const { transitionPreparingDirections, requestTransitionAbort, handleTransitionTransform } = useDomeTransitionAttempt({
+    actions, admittedRoom, localAuthorPubkey: syncStatus.local_author_pubkey, localPeerId,
+    transitionNeighbors, setTransitionNeighbors, submitInputForRoom,
+    onHandoff: applyTransitionHandoff, onError,
+  });
+
+  const transitionBoundaryStates = useMemo(() => {
+    const states: Partial<Record<DomeDirection, DomeBoundaryStateV1>> = {};
+    for (const neighbor of transitionNeighbors) {
+      states[neighbor.direction] = domeRecovery.state === 'offline'
+        ? 'offline'
+        : transitionPreparingDirections.has(neighbor.direction)
+        ? 'loading'
+        : neighbor.boundaryState;
     }
-    await submitInputForRoom(attempt.sourceRoom, {
-      type: 'abort_transition',
-      transition_id: attempt.id,
-    }).catch(() => undefined);
-    if (transitionAttemptRef.current === attempt) {
-      transitionAttemptRef.current = null;
-    }
-    setTransitionPreparingDirections((current) => {
-      const next = new Set(current);
-      next.delete(attempt.neighbor.direction);
-      return next;
-    });
-  }, [actions, submitInputForRoom]);
-
-  function beginTransitionAttempt(neighbor: DomeNeighborTransitionView) {
-    if (!admittedRoom?.metaverse || transitionAttemptRef.current) return;
-    const transitionId = `dome-transition-${globalThis.crypto?.randomUUID?.() ?? Date.now()}`;
-    const attempt: TransitionAttempt = {
-      id: transitionId,
-      sourceRoom: admittedRoom,
-      neighbor,
-      phase: 'preparing',
-      ticket: null,
-      cancelled: false,
-    };
-    transitionAttemptRef.current = attempt;
-    setTransitionPreparing(neighbor.direction, true);
-    void (async () => {
-      try {
-        await submitInputForRoom(attempt.sourceRoom, {
-          type: 'prepare_transition',
-          transition_id: attempt.id,
-          direction: neighbor.direction,
-        });
-        if (attempt.cancelled) return;
-        attempt.ticket = await actions.prepareTransition({
-          transition_id: attempt.id,
-          connection_id: neighbor.connectionId,
-          topology_digest: neighbor.topologyDigest,
-          spatial_context: attempt.sourceRoom.metaverse!.spatial_context,
-          source_instance_id: attempt.sourceRoom.metaverse!.instance_id,
-          source_instance_generation: attempt.sourceRoom.metaverse!.instance_generation,
-          target_instance_id: neighbor.room.metaverse!.instance_id,
-          target_instance_generation: neighbor.room.metaverse!.instance_generation,
-          participant_pubkey: syncStatus.local_author_pubkey,
-          direction: neighbor.direction,
-          requested_at: Date.now(),
-        });
-        if (attempt.cancelled) {
-          await abortTransitionAttempt(attempt);
-          return;
-        }
-        attempt.phase = 'provisional';
-        setTransitionPreparing(neighbor.direction, false);
-      } catch (transitionError) {
-        await abortTransitionAttempt(attempt);
-        setTransitionNeighbors((current) => current.map((candidate) =>
-          candidate.connectionId === neighbor.connectionId
-            ? { ...candidate, boundaryState: 'error' }
-            : candidate
-        ));
-        onError(
-          transitionError instanceof Error
-            ? transitionError.message
-            : 'Dome transition preparation failed'
-        );
-      }
-    })();
-  }
-
-  function commitTransitionAttempt(attempt: TransitionAttempt, transform: AvatarTransform) {
-    if (attempt.phase !== 'provisional' || attempt.cancelled || !attempt.ticket) return;
-    attempt.phase = 'committing';
-    const targetPosition = transformAvatarBetweenDomes(transform.position, attempt.neighbor.relativeCoordinateCm);
-    const targetTransform: AvatarTransform = {
-      ...transform, roomId: attempt.neighbor.room.room_id, seq: 0,
-      position: targetPosition, sentAt: Date.now(),
-    };
-    void (async () => {
-      const recovery = await recoverDomeTransitionCommit({
-        ticket: attempt.ticket!,
-        commit: () => actions.commitTransition(attempt.ticket!, targetPosition, transform.rotation),
-        getHosting: () => actions.getHosting(attempt.ticket!.request.spatial_context, attempt.ticket!.request.target_instance_id),
-        isCurrent: () => transitionAttemptRef.current === attempt && !attempt.cancelled,
-      });
-      if (recovery.status === 'cancelled') return;
-      if (recovery.status === 'rollback') {
-        attempt.phase = 'provisional';
-        await abortTransitionAttempt(attempt);
-        setTransitionNeighbors((current) => current.map((candidate) =>
-          candidate.connectionId === attempt.neighbor.connectionId
-            ? { ...candidate, boundaryState: 'error' }
-            : candidate
-        ));
-        onError(recovery.error instanceof Error
-          ? recovery.error.message
-          : 'Dome transition commit failed');
-        return;
-      }
-      attempt.phase = 'target_committed';
-      transitionAttemptRef.current = null;
-      setTransitionPreparing(attempt.neighbor.direction, false);
-      setHandoffTransform(targetTransform);
-      lastSentTransformRef.current = targetTransform;
-      setLastSentSeq(0);
-      setJoinedRoomIds((current) => {
-        const next = new Set(current);
-        next.delete(attempt.sourceRoom.room_id);
-        next.add(attempt.neighbor.room.room_id);
-        return next;
-      });
-      setSelectedRoomId(attempt.neighbor.room.room_id);
-      if (attempt.neighbor.room.metaverse) {
-        writeLastVisitedDome(
-          syncStatus.local_author_pubkey,
-          attempt.neighbor.room.metaverse.spatial_context,
-          attempt.neighbor.room.metaverse.instance_id
-        );
-      }
-      onError(null);
-      let sourceCompleted = false;
-      for (const retryDelay of [0, 250, 1_000]) {
-        if (retryDelay > 0) {
-          await new Promise((resolve) => window.setTimeout(resolve, retryDelay));
-        }
-        try {
-          await submitInputForRoom(attempt.sourceRoom, {
-            type: 'complete_transition',
-            transition_id: attempt.id,
-          });
-          sourceCompleted = true;
-          break;
-        } catch {
-          // The destination remains authoritative; retry only source cleanup.
-        }
-      }
-      if (sourceCompleted) {
-        const leftAt = Date.now();
-        await actions.publishRoomEvent(attempt.sourceRoom.room_id, localPeerId, leftAt, {
-          type: 'presence_leave',
-          room_id: attempt.sourceRoom.room_id,
-          peer_id: localPeerId,
-          left_at: leftAt,
-        }).catch(() => undefined);
-      } else {
-        onError('Destination committed; source Dome cleanup will require resynchronization');
-      }
-    })();
-  }
+    return states;
+  }, [domeRecovery.state, transitionNeighbors, transitionPreparingDirections]);
 
   const joinRoom = useCallback(async (
     roomId: string,
@@ -796,8 +631,7 @@ export function useMetaverseRoomSession({
   ): Promise<boolean> => {
     const room = rooms.find((candidate) => candidate.room_id === roomId);
     if (!room?.metaverse) return false;
-    const attempt = transitionAttemptRef.current;
-    if (attempt) void abortTransitionAttempt(attempt);
+    requestTransitionAbort();
     if (!preserveCurrent) {
       setHandoffTransform(null);
       setSelectedRoomId(roomId);
@@ -850,7 +684,7 @@ export function useMetaverseRoomSession({
       return false;
     }
   }, [
-    abortTransitionAttempt,
+    requestTransitionAbort,
     applyPhysicsSnapshot,
     localPeerId,
     onError,
@@ -1021,8 +855,7 @@ export function useMetaverseRoomSession({
       setSelectedRoomId(null);
       return;
     }
-    const attempt = transitionAttemptRef.current;
-    if (attempt) void abortTransitionAttempt(attempt);
+    requestTransitionAbort();
     const roomId = admittedRoom.room_id;
     const leftAt = Date.now();
     emit({ type: 'presence.leave', roomId, peerId: localPeerId, leftAt });
@@ -1060,26 +893,7 @@ export function useMetaverseRoomSession({
       rotation: transform.rotation,
       animation: transform.animation,
     }, transform.seq);
-    const attempt = transitionAttemptRef.current;
-    const inZone = transitionNeighborInZone(transform.position, transitionNeighbors);
-    if (!attempt && inZone) {
-      beginTransitionAttempt(inZone);
-      return;
-    }
-    if (!attempt) return;
-    if (
-      attempt.phase !== 'committing' &&
-      domeTransitionProgress(transform.position, attempt.neighbor.direction) <= 0
-    ) {
-      void abortTransitionAttempt(attempt);
-      return;
-    }
-    const crossed = transitionNeighborAtPosition(previous?.position ?? null, transform.position, [
-      attempt.neighbor,
-    ]);
-    if (crossed && attempt.phase === 'provisional') {
-      commitTransitionAttempt(attempt, transform);
-    }
+    handleTransitionTransform(transform, previous);
   }
 
   function handleSendMessage(event: FormEvent<HTMLFormElement>) {

--- a/docs/progress/2026-09-08-924-dome-transition-attempt.md
+++ b/docs/progress/2026-09-08-924-dome-transition-attempt.md
@@ -1,0 +1,36 @@
+# Issue #924: Dome transition attemptの所有者を抽出
+
+- Scope revision `2026-09-08-872-R-MV-v1`、区分C、before `4e833af8cbdb7263a75ad17f54ee64be6e263471`。
+- 先行#923はPR#934、merge `d9ea79be`。24 targeted・独立delta監査・最終CI・対象tree一致PASSを経て着手。
+- 対象利用者はMetaverse参加者。移動/取消/退出の観測結果を保ち、非同期attemptの所有者を一つにする。HTML/CSS・描画・audio/scene/admission・input sequence・IPCを変更しない。
+
+| 作業 | AC / INVAR / INV・TR | 証拠 | 依存 |
+| --- | --- | --- | --- |
+| T1 before baseline | AC3/4、全INVAR、INV1〜4/TR1〜4 | session/recovery/transition/entry/panelの5 files57 testsを製品変更前に実行 | #923 |
+| T2 attempt owner抽出 | AC1/2、全INVAR | 同directoryのuseDomeTransitionAttemptのみ。入力・取消要求と確定handoff通知でsessionに接続 | T1 |
+| T3 同contract・path validation | AC3/4、全INVAR | 同57 tests、typecheck、desktop-ui-check、Windows/WebView操作 | T2 |
+| T4 独立監査/CI/merge | AC4、全INVAR | fixed head監査、最終CI、merge対象一致。結果はPR/Issueへ | T3 |
+
+## 構造と凍結境界
+
+- `attempt.(phase|cancelled|ticket)`と`transitionAttemptRef.current`の直接代入はsession9→0、専用owner9。mutable attemptを戻り値に含めない。
+- prepare/commit/abort APIはsession各1→0、owner各1。source prepare/abort/completeとcleanup retryも同owner内。recoverDomeTransitionCommitの判断は変更しない。
+- sessionからはtransform（直前値を含む）とjoin/leaveの取消要求を渡す。選択・handoff・joined setは同期callbackが既存順で反映し、その後ownerがlast-visited/onError/cleanupを続ける。
+- 入力sequenceはsessionの既存MapとsubmitInputForRoomをそのまま共有。別の正本・追加state copy・公開API/依存追加なし。
+- abort callbackの依存はactions/submitInputForRoomのまま。取消要求callbackもそれに連動し、joinRoomのeffect安定性を保持。非同期途中の古いclosureを最新参照へ勝手に変更しない。
+- 全caller: session handleLocalTransform→handleTransitionTransform、joinRoom/leaveRoom→requestTransitionAbort、owner commit→既存recovery。source inputは既存submitInputForRoom経由。admission等の他caller無変更。
+- before/afterは代入regex、prepareTransition/commitTransition/abortTransition/recover/submitInputForRoom/writeLastVisitedDome全参照とdiffで照合する。固定inventory4・transition4の増減0、未分類0。
+
+## 維持する制御
+
+precommit取消、遅着ticket abort、commit適用不明でabort禁止、同ticket/transform再送、確定拒否/置換後だけrollback、ack後handoff、source cleanup0/250/1000msの最大3回、成功時だけsource presence leaveを保持。join/leave自身のadmission/selection/audio副作用もそのまま。
+
+既存Rust `desktop_smoke_metaverse_dome_transition` はsource prepare/target commit/source complete、entryはauthoritative entry/safe spawn、recoveryはtopologyの保護として対応する。hookの非同期競合とは区別し、Rust/scenario/DTO変更0のため追加scenario編集なし。
+
+## 検証とplatform
+
+- before: 5 files57 tests PASS（11.33秒）。after: 同57 PASS（10.14秒）。既存test/fixture/assertion差分0。typecheck PASS。
+- 必須desktop-ui-check、Windows/WebViewのpointer/keyboard移動・退出・fullscreen/input ownership・resource縮退、CI・独立監査は残gateとしてPR/Issueへ記録する。nativeの成功をbrowser/hook結果で代替しない。
+- 見た目・theme/locale/token/layoutは不変。UI実機はWindows、既存seed/隔離profile、同条件のbefore/afterで確認する。実音声/他peer接続の成否をmockや単一端末操作から推定しない。
+
+Rollbackは抽出PRだけrevertし#923 contractを保持。retry/authority/取消の新仕様が必要になれば別fixへ分離する。


### PR DESCRIPTION
Refs #924。Dome移動の非同期attemptとprepare/abort/commit/source cleanupを専用hookへ集約しました。sessionのattempt直接代入9→0、専用owner9。入力sequenceと参加状態はsessionが保持し、要求と確定handoff通知で接続します。

- 種別 `refactor:extract`、区分C、Scope revision `2026-09-08-872-R-MV-v1`。
- [計画・AC/INVAR・対象境界・検証・rollback記録](docs/progress/2026-09-08-924-dome-transition-attempt.md)。詳細な独立監査とdeltaはPR commentsに保持。
- 同57 targeted tests、152 files1209 testsを含むdesktop-ui-check、独立source監査・実機補完record確認PASS。既存test、public戻り値、描画、IPCは不変。
- 最終head `e647f318fab49b5f3fed079055a4cc1823e572d6` の全11 checks SUCCESS。必要な独立監査とCIを満たしてmergeしました。
- merge `3971fba25a8d6034e16623aefc5a5b7b51d02bd6` と監査対象のpath/surface一致を確認し、[Issue #924](https://github.com/KingYoSun/kukuri/issues/924)の現在判定をCompleteへ同期・Close済み。

実Windows/Tauri/WebViewでの通常入力・退出・画面外停止復帰は前後一致。[実機比較と制約](https://github.com/KingYoSun/kukuri/blob/0ccb5af8e622180e13fca84d2d689788016f33c8/docs/ui-reviews/2026-09-08-issue-924-transition-owner.md)に、長押し変位の未測定と変更前から再現する全画面停止フラグを明記しています。mock APIを実network/authorityの成功に読み替えていません。
