### PR TITLE
[codex][refactor:extract] CN indexerのsource解決依存を絞る

### DIFF
--- a/crates/cn-indexer/src/ingest.rs
+++ b/crates/cn-indexer/src/ingest.rs
@@ -36,17 +36,13 @@ use kukuri_cn_core::{IndexEntryStore, IndexScopeKind, NewIndexEntry};
 use kukuri_cn_safety::ReasonCode;
 use kukuri_cn_safety::provider::{ProviderScanRequest, SubjectKind};
 use kukuri_cn_safety_runtime::{SafetyScanOutcome, SafetyScanService};
-use kukuri_core::{
-    AssetRef, KukuriEnvelope, KukuriMediaManifestV1, ObjectStatus, PayloadRef, ReplicaId,
-    blob_hash, verify_post_withdrawal,
-};
+use kukuri_core::{KukuriEnvelope, ObjectStatus, ReplicaId, verify_post_withdrawal};
 use kukuri_docs_sync::{DocFetchPolicy, DocQuery, DocRecord, DocsSync, stable_key};
 
 use crate::projection::{IndexProjection, IndexedEntry};
 
-/// app-api の投稿上限（10,000 Unicode scalar values）を UTF-8 bytes でも有界にする。
-const MAX_INDEXABLE_POST_BODY_CHARS: usize = 10_000;
-const MAX_INDEXABLE_POST_BODY_BYTES: u64 = (MAX_INDEXABLE_POST_BODY_CHARS as u64) * 4;
+mod source;
+use source::{PostObjectView, SourceResolver};
 
 /// 単一 scope（topic / channel）を ingest した結果のサマリ（監査 / テスト用）。
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -299,7 +295,11 @@ impl IngestPipeline {
         }
 
         // 本文 text を取り出す。blob 参照は scan 用の一時 fetch のみ（恒久保存しない）。
-        let text = match self.resolve_body_text(replica_id, &object, envelopes).await {
+        let source = SourceResolver::new(self.docs_sync.as_ref(), self.blob_service.as_deref());
+        let text = match source
+            .resolve_body_text(replica_id, &object, envelopes)
+            .await
+        {
             Ok(text) => text,
             Err(error) => {
                 self.deindex_object(scope_kind, scope_id, object.object_id.as_str())
@@ -345,7 +345,7 @@ impl IngestPipeline {
         // provider / fetcher が未構成なら scan は Unavailable → fail-closed hold になり、media
         // 参照 post は従来どおり index されない（挙動後退なし）。全 allow のときのみ derived
         // 検索タグを収集する。
-        let media_targets = match self.media_scan_targets(replica_id, &object).await {
+        let media_targets = match source.media_scan_targets(replica_id, &object).await {
             Ok(targets) => targets,
             Err(error) => {
                 self.deindex_object(scope_kind, scope_id, object.object_id.as_str())
@@ -448,172 +448,6 @@ impl IngestPipeline {
             .await?;
         Ok(())
     }
-
-    /// scan 対象の media 参照を blob 単位（hash + mime）に展開する（#609）。
-    ///
-    /// attachments は `AssetRef` から直接、`media_manifest_refs` は replica 上の署名済み
-    /// manifest（`manifests/media/<id>/envelope`）を解決して items（+ thumbnail）に展開する。
-    /// 同一 blob hash は先勝ちで dedup する。manifest の欠落・検証失敗は Err
-    /// （呼び出し側が index しない = fail-closed）。
-    async fn media_scan_targets(
-        &self,
-        replica_id: &ReplicaId,
-        object: &PostObjectView,
-    ) -> Result<Vec<MediaScanTarget>> {
-        let mut targets: Vec<MediaScanTarget> = Vec::new();
-        for asset in &object.attachments {
-            push_media_target(
-                &mut targets,
-                asset.hash.as_str().to_string(),
-                non_empty_mime(asset.mime.as_str()),
-            );
-        }
-        for reference in &object.media_manifest_refs {
-            let manifest = self
-                .resolve_media_manifest(replica_id, object, reference)
-                .await?;
-            for item in &manifest.items {
-                push_media_target(
-                    &mut targets,
-                    item.blob_hash.as_str().to_string(),
-                    non_empty_mime(item.mime.as_str()),
-                );
-                if let Some(thumbnail) = &item.thumbnail_blob_hash {
-                    // thumbnail の mime は manifest に無い（fetcher の magic bytes 判定に委ねる）。
-                    push_media_target(&mut targets, thumbnail.as_str().to_string(), None);
-                }
-            }
-        }
-        Ok(targets)
-    }
-
-    /// replica から署名済み media manifest を解決する。
-    ///
-    /// 共有 replica の entry が本物であること（署名検証）に加えて、post author 本人が署名した
-    /// manifest であることを要求する（他者の manifest を参照して scan 対象を偽装する経路を
-    /// 塞ぐ）。いずれの失敗も Err = fail-closed。
-    async fn resolve_media_manifest(
-        &self,
-        replica_id: &ReplicaId,
-        object: &PostObjectView,
-        manifest_id: &str,
-    ) -> Result<KukuriMediaManifestV1> {
-        let key = stable_key("manifests/media", &format!("{manifest_id}/envelope"));
-        let records = self
-            .docs_sync
-            .query_replica_with_policy(
-                replica_id,
-                DocQuery::Exact(key),
-                DocFetchPolicy::LocalThenRemote,
-            )
-            .await
-            .with_context(|| format!("failed to query media manifest `{manifest_id}`"))?;
-        let Some(record) = records.into_iter().next() else {
-            bail!("media manifest `{manifest_id}` is not present in the replica");
-        };
-        let envelope: KukuriEnvelope = serde_json::from_slice(&record.value)
-            .with_context(|| format!("failed to decode media manifest envelope `{manifest_id}`"))?;
-        envelope.verify().with_context(|| {
-            format!("media manifest envelope `{manifest_id}` failed verification")
-        })?;
-        if envelope.kind != "media-manifest" {
-            bail!(
-                "entry for media manifest `{manifest_id}` has unexpected kind `{}`",
-                envelope.kind
-            );
-        }
-        if envelope.pubkey.as_str() != object.author.as_str() {
-            bail!("media manifest `{manifest_id}` is not signed by the post author (fail-closed)");
-        }
-        let manifest: KukuriMediaManifestV1 = serde_json::from_str(envelope.content.as_str())
-            .with_context(|| format!("failed to parse media manifest content `{manifest_id}`"))?;
-        Ok(manifest)
-    }
-
-    /// post 本文 text を取り出す。
-    ///
-    /// inline text はそのまま返す。blob text は同一 scope scan で取得済みの署名済み envelope と object
-    /// state の参照を突合し、`BlobService::fetch_blob_ephemeral` で本文 bytes を一時取得する。取得した
-    /// bytes は宣言サイズ・上限・BLAKE3 hash・UTF-8 を検証し、raw blob は恒久保存しない。
-    async fn resolve_body_text(
-        &self,
-        _replica_id: &ReplicaId,
-        object: &PostObjectView,
-        envelopes: &HashMap<String, DocRecord>,
-    ) -> Result<String> {
-        match &object.payload_ref {
-            PayloadRef::InlineText { text } => Ok(text.clone()),
-            PayloadRef::BlobText { hash, bytes, .. } => {
-                if *bytes > MAX_INDEXABLE_POST_BODY_BYTES {
-                    bail!(
-                        "blob text declared size exceeds the index body limit ({} > {} bytes)",
-                        bytes,
-                        MAX_INDEXABLE_POST_BODY_BYTES
-                    );
-                }
-                let record = envelopes
-                    .get(object.object_id.as_str())
-                    .context("blob text envelope is missing")?;
-                let envelope: KukuriEnvelope = serde_json::from_slice(&record.value)
-                    .context("failed to decode post envelope for blob text")?;
-                envelope
-                    .verify()
-                    .context("post envelope failed verification")?;
-                if envelope.id.as_str() != object.object_id {
-                    bail!("blob text envelope id does not match the object state");
-                }
-                if envelope.pubkey.as_str() != object.author {
-                    bail!("blob text envelope author does not match the object state");
-                }
-                let content = envelope
-                    .post_content()
-                    .context("failed to parse blob text post content")?
-                    .context("blob text envelope is not a post")?;
-                if content.payload_ref != object.payload_ref {
-                    bail!("blob text payload metadata does not match the signed envelope");
-                }
-
-                let blob_service = self
-                    .blob_service
-                    .as_ref()
-                    .context("blob service is not configured for blob text")?;
-                let fetched = blob_service
-                    .fetch_blob_ephemeral(hash)
-                    .await
-                    .context("failed to fetch blob text body")?
-                    .context("blob text body is not retrievable")?;
-                let actual_bytes = u64::try_from(fetched.len())
-                    .context("blob text body size does not fit in u64")?;
-                if actual_bytes != *bytes {
-                    bail!(
-                        "blob text body size does not match metadata ({} != {} bytes)",
-                        actual_bytes,
-                        bytes
-                    );
-                }
-                if actual_bytes > MAX_INDEXABLE_POST_BODY_BYTES {
-                    bail!(
-                        "blob text body exceeds the index body limit ({} > {} bytes)",
-                        actual_bytes,
-                        MAX_INDEXABLE_POST_BODY_BYTES
-                    );
-                }
-                if blob_hash(&fetched) != *hash {
-                    bail!("blob text body hash does not match metadata");
-                }
-                let text = String::from_utf8(fetched).context("blob text body is not UTF-8")?;
-                let char_count = text.chars().count();
-                if char_count > MAX_INDEXABLE_POST_BODY_CHARS {
-                    bail!(
-                        "blob text body exceeds the index character limit ({} > {} characters)",
-                        char_count,
-                        MAX_INDEXABLE_POST_BODY_CHARS
-                    );
-                }
-                Ok(text)
-            }
-        }
-    }
 }
 
 enum IngestOutcome {
@@ -621,49 +455,6 @@ enum IngestOutcome {
     SkippedNonAllow,
     Deindexed,
     Ignored,
-}
-
-/// docs replica に保存された post object state の最小 view。
-///
-/// `object_persistence_support` の `CanonicalPostHeader`（= `KukuriPostObjectV1`）と同じ JSON を
-/// 部分的に読む。cn-indexer は index に必要な最小フィールドのみを取り出す。
-#[derive(Debug, serde::Deserialize)]
-struct PostObjectView {
-    object_id: String,
-    author: String,
-    created_at: i64,
-    payload_ref: PayloadRef,
-    #[serde(default)]
-    attachments: Vec<AssetRef>,
-    #[serde(default)]
-    media_manifest_refs: Vec<String>,
-    #[serde(default)]
-    status: ObjectStatus,
-}
-
-/// scan 対象の media 参照 1 件（blob hash + 参照元 metadata 由来の mime）。
-#[derive(Clone, Debug, PartialEq, Eq)]
-struct MediaScanTarget {
-    hash: String,
-    mime: Option<String>,
-}
-
-/// 同一 blob hash を dedup しながら scan 対象へ追加する（mime は先勝ち）。
-fn push_media_target(targets: &mut Vec<MediaScanTarget>, hash: String, mime: Option<String>) {
-    if targets.iter().any(|target| target.hash == hash) {
-        return;
-    }
-    targets.push(MediaScanTarget { hash, mime });
-}
-
-/// 空 / 空白のみの mime は「無し」として扱う。
-fn non_empty_mime(mime: &str) -> Option<String> {
-    let trimmed = mime.trim();
-    if trimmed.is_empty() {
-        None
-    } else {
-        Some(trimmed.to_string())
-    }
 }
 
 /// 本文 text に derived 検索タグを相乗りさせた投影用 text を組み立てる。

--- a/crates/cn-indexer/src/ingest/source.rs
+++ b/crates/cn-indexer/src/ingest/source.rs
@@ -1,0 +1,240 @@
+//! Read-only source resolution. Scan policy, metrics and index mutation stay in the pipeline.
+
+use std::collections::HashMap;
+
+use anyhow::{Context, Result, bail};
+use kukuri_blob_service::BlobService;
+use kukuri_core::{
+    AssetRef, KukuriEnvelope, KukuriMediaManifestV1, ObjectStatus, PayloadRef, ReplicaId, blob_hash,
+};
+use kukuri_docs_sync::{DocFetchPolicy, DocQuery, DocRecord, DocsSync, stable_key};
+
+/// app-api の投稿上限（10,000 Unicode scalar values）を UTF-8 bytes でも有界にする。
+const MAX_INDEXABLE_POST_BODY_CHARS: usize = 10_000;
+const MAX_INDEXABLE_POST_BODY_BYTES: u64 = (MAX_INDEXABLE_POST_BODY_CHARS as u64) * 4;
+
+pub(super) struct SourceResolver<'a> {
+    docs_sync: &'a dyn DocsSync,
+    blob_service: Option<&'a dyn BlobService>,
+}
+
+impl<'a> SourceResolver<'a> {
+    pub(super) fn new(
+        docs_sync: &'a dyn DocsSync,
+        blob_service: Option<&'a dyn BlobService>,
+    ) -> Self {
+        Self {
+            docs_sync,
+            blob_service,
+        }
+    }
+
+    /// scan 対象の media 参照を blob 単位（hash + mime）に展開する（#609）。
+    ///
+    /// attachments は `AssetRef` から直接、`media_manifest_refs` は replica 上の署名済み
+    /// manifest（`manifests/media/<id>/envelope`）を解決して items（+ thumbnail）に展開する。
+    /// 同一 blob hash は先勝ちで dedup する。manifest の欠落・検証失敗は Err
+    /// （呼び出し側が index しない = fail-closed）。
+    pub(super) async fn media_scan_targets(
+        &self,
+        replica_id: &ReplicaId,
+        object: &PostObjectView,
+    ) -> Result<Vec<MediaScanTarget>> {
+        let mut targets: Vec<MediaScanTarget> = Vec::new();
+        for asset in &object.attachments {
+            push_media_target(
+                &mut targets,
+                asset.hash.as_str().to_string(),
+                non_empty_mime(asset.mime.as_str()),
+            );
+        }
+        for reference in &object.media_manifest_refs {
+            let manifest = self
+                .resolve_media_manifest(replica_id, object, reference)
+                .await?;
+            for item in &manifest.items {
+                push_media_target(
+                    &mut targets,
+                    item.blob_hash.as_str().to_string(),
+                    non_empty_mime(item.mime.as_str()),
+                );
+                if let Some(thumbnail) = &item.thumbnail_blob_hash {
+                    // thumbnail の mime は manifest に無い（fetcher の magic bytes 判定に委ねる）。
+                    push_media_target(&mut targets, thumbnail.as_str().to_string(), None);
+                }
+            }
+        }
+        Ok(targets)
+    }
+
+    /// replica から署名済み media manifest を解決する。
+    ///
+    /// 共有 replica の entry が本物であること（署名検証）に加えて、post author 本人が署名した
+    /// manifest であることを要求する（他者の manifest を参照して scan 対象を偽装する経路を
+    /// 塞ぐ）。いずれの失敗も Err = fail-closed。
+    async fn resolve_media_manifest(
+        &self,
+        replica_id: &ReplicaId,
+        object: &PostObjectView,
+        manifest_id: &str,
+    ) -> Result<KukuriMediaManifestV1> {
+        let key = stable_key("manifests/media", &format!("{manifest_id}/envelope"));
+        let records = self
+            .docs_sync
+            .query_replica_with_policy(
+                replica_id,
+                DocQuery::Exact(key),
+                DocFetchPolicy::LocalThenRemote,
+            )
+            .await
+            .with_context(|| format!("failed to query media manifest `{manifest_id}`"))?;
+        let Some(record) = records.into_iter().next() else {
+            bail!("media manifest `{manifest_id}` is not present in the replica");
+        };
+        let envelope: KukuriEnvelope = serde_json::from_slice(&record.value)
+            .with_context(|| format!("failed to decode media manifest envelope `{manifest_id}`"))?;
+        envelope.verify().with_context(|| {
+            format!("media manifest envelope `{manifest_id}` failed verification")
+        })?;
+        if envelope.kind != "media-manifest" {
+            bail!(
+                "entry for media manifest `{manifest_id}` has unexpected kind `{}`",
+                envelope.kind
+            );
+        }
+        if envelope.pubkey.as_str() != object.author.as_str() {
+            bail!("media manifest `{manifest_id}` is not signed by the post author (fail-closed)");
+        }
+        let manifest: KukuriMediaManifestV1 = serde_json::from_str(envelope.content.as_str())
+            .with_context(|| format!("failed to parse media manifest content `{manifest_id}`"))?;
+        Ok(manifest)
+    }
+
+    /// post 本文 text を取り出す。
+    ///
+    /// inline text はそのまま返す。blob text は同一 scope scan で取得済みの署名済み envelope と object
+    /// state の参照を突合し、`BlobService::fetch_blob_ephemeral` で本文 bytes を一時取得する。取得した
+    /// bytes は宣言サイズ・上限・BLAKE3 hash・UTF-8 を検証し、raw blob は恒久保存しない。
+    pub(super) async fn resolve_body_text(
+        &self,
+        _replica_id: &ReplicaId,
+        object: &PostObjectView,
+        envelopes: &HashMap<String, DocRecord>,
+    ) -> Result<String> {
+        match &object.payload_ref {
+            PayloadRef::InlineText { text } => Ok(text.clone()),
+            PayloadRef::BlobText { hash, bytes, .. } => {
+                if *bytes > MAX_INDEXABLE_POST_BODY_BYTES {
+                    bail!(
+                        "blob text declared size exceeds the index body limit ({} > {} bytes)",
+                        bytes,
+                        MAX_INDEXABLE_POST_BODY_BYTES
+                    );
+                }
+                let record = envelopes
+                    .get(object.object_id.as_str())
+                    .context("blob text envelope is missing")?;
+                let envelope: KukuriEnvelope = serde_json::from_slice(&record.value)
+                    .context("failed to decode post envelope for blob text")?;
+                envelope
+                    .verify()
+                    .context("post envelope failed verification")?;
+                if envelope.id.as_str() != object.object_id {
+                    bail!("blob text envelope id does not match the object state");
+                }
+                if envelope.pubkey.as_str() != object.author {
+                    bail!("blob text envelope author does not match the object state");
+                }
+                let content = envelope
+                    .post_content()
+                    .context("failed to parse blob text post content")?
+                    .context("blob text envelope is not a post")?;
+                if content.payload_ref != object.payload_ref {
+                    bail!("blob text payload metadata does not match the signed envelope");
+                }
+
+                let blob_service = self
+                    .blob_service
+                    .as_ref()
+                    .context("blob service is not configured for blob text")?;
+                let fetched = blob_service
+                    .fetch_blob_ephemeral(hash)
+                    .await
+                    .context("failed to fetch blob text body")?
+                    .context("blob text body is not retrievable")?;
+                let actual_bytes = u64::try_from(fetched.len())
+                    .context("blob text body size does not fit in u64")?;
+                if actual_bytes != *bytes {
+                    bail!(
+                        "blob text body size does not match metadata ({} != {} bytes)",
+                        actual_bytes,
+                        bytes
+                    );
+                }
+                if actual_bytes > MAX_INDEXABLE_POST_BODY_BYTES {
+                    bail!(
+                        "blob text body exceeds the index body limit ({} > {} bytes)",
+                        actual_bytes,
+                        MAX_INDEXABLE_POST_BODY_BYTES
+                    );
+                }
+                if blob_hash(&fetched) != *hash {
+                    bail!("blob text body hash does not match metadata");
+                }
+                let text = String::from_utf8(fetched).context("blob text body is not UTF-8")?;
+                let char_count = text.chars().count();
+                if char_count > MAX_INDEXABLE_POST_BODY_CHARS {
+                    bail!(
+                        "blob text body exceeds the index character limit ({} > {} characters)",
+                        char_count,
+                        MAX_INDEXABLE_POST_BODY_CHARS
+                    );
+                }
+                Ok(text)
+            }
+        }
+    }
+}
+
+/// docs replica に保存された post object state の最小 view。
+///
+/// `object_persistence_support` の `CanonicalPostHeader`（= `KukuriPostObjectV1`）と同じ JSON を
+/// 部分的に読む。cn-indexer は index に必要な最小フィールドのみを取り出す。
+#[derive(Debug, serde::Deserialize)]
+pub(super) struct PostObjectView {
+    pub(super) object_id: String,
+    pub(super) author: String,
+    pub(super) created_at: i64,
+    pub(super) payload_ref: PayloadRef,
+    #[serde(default)]
+    pub(super) attachments: Vec<AssetRef>,
+    #[serde(default)]
+    pub(super) media_manifest_refs: Vec<String>,
+    #[serde(default)]
+    pub(super) status: ObjectStatus,
+}
+
+/// scan 対象の media 参照 1 件（blob hash + 参照元 metadata 由来の mime）。
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) struct MediaScanTarget {
+    pub(super) hash: String,
+    pub(super) mime: Option<String>,
+}
+
+/// 同一 blob hash を dedup しながら scan 対象へ追加する（mime は先勝ち）。
+fn push_media_target(targets: &mut Vec<MediaScanTarget>, hash: String, mime: Option<String>) {
+    if targets.iter().any(|target| target.hash == hash) {
+        return;
+    }
+    targets.push(MediaScanTarget { hash, mime });
+}
+
+/// 空 / 空白のみの mime は「無し」として扱う。
+fn non_empty_mime(mime: &str) -> Option<String> {
+    let trimmed = mime.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}

--- a/docs/progress/2026-09-08-926-indexer-source-resolver.md
+++ b/docs/progress/2026-09-08-926-indexer-source-resolver.md
@@ -1,0 +1,50 @@
+# Issue #926: CN indexerのsource resolverを読み取り境界へ抽出
+
+- Scope revision `2026-09-08-872-R-CN-v1`、区分C。before `7c9cba850d572c8d358d5f529798a89c3c84eb06`。
+- 先行#925はPR#935、最終head `a2dbe8e2`。独立監査・delta監査・最終17 checks・merge対象subtree一致PASSを経て開始。
+- 一意図はsource解決の依存境界縮小。public IngestPipeline/IngestSummary、wire/schema、provider・readiness・query gateを変更しない。
+
+| 作業 | AC / INVAR / INV・TR | 証拠 | 依存 |
+| --- | --- | --- | --- |
+| T1 before contractとscope確認 | AC3/5、全INVAR、INV-R1〜6/TR-R1〜7 | #925 finalとmergeのcn-indexer subtree一致、下記39 tests | #925 |
+| T2 source moduleへ抽出 | AC1/2/4、全INVAR | DocsSync/BlobServiceだけを借用するprivate SourceResolver、元2callsiteの結線 | T1 |
+| T3 同contract/Clippy/差分確認 | AC3/4/5、全INVAR | 同39 tests、型/Clippy、全caller/依存逆引き | T2 |
+| T4 独立監査/CI/merge | AC5、全INVAR | 固定head、cn-check/cn-test、merge対象一致。最終結果はPR/Issueへ | T3 |
+
+## before / afterの責務と依存
+
+| owner | before | after |
+| --- | --- | --- |
+| 本文/manifest/target解決 | pipelineの6serviceに到達可能 | SourceResolverのDocsSyncとoptional BlobServiceの2借用のみ |
+| scope traversal、withdrawal/status/prevention | pipeline | pipelineのまま |
+| safety scan、metrics、publish/deindex | pipeline | pipelineのまま。sourceへ逆依存0 |
+| body/media解決callsite | pipeline内各1 | 同じ位置のSourceResolver各1、wrapperなし |
+| public Pipeline/Summary/API | 現行公開契約 | 差分0 |
+
+新規`ingest/source.rs`にbody/manifest解決3method、dedupe/mime2helper、上限定数、private PostObjectView/MediaScanTargetを移動した。`mod source`はprivateで、親だけが使う型/field/2解決methodは`pub(super)`、manifest解決はprivate。trait/crate/dependencyの追加なし。sourceは他のownerやpipelineを受け取らない。
+
+pipelineは既存のwithdrawal→status→transmission preventionを完了してからresolverを構成する。body解決後にpost scanし、allow後に同じresolverでmediaを解決する。構成自体にはI/O・clone・mutationがない。bodyとmediaを先読み・一括解決せず、失敗時のdeindex/summary/metrics/2store順を維持する。
+
+`BlobText`は同一scope passのenvelope mapから検証し、元と同じephemeral fetchだけを使用する。manifestは同replicaのExact query/LocalThenRemoteのまま。InlineTextの検証追加、canonical key/serde/signature/size/UTF8/error文言の変更なし。first-wins mime/thumbnail Noneとpost scan後のmedia判断をそのまま移す。`text_with_tags`はpublish側に残す。
+
+## 全callerと対応
+
+- worker startup/event/retry→participant→public ingest_scope→ingest_object_recordの入口は変更0。
+- resolve_body_text / media_scan_targetsのproduction callerはingest_object_record各1、resolve_media_manifestはsource内media_scan_targetsだけ。
+- source field/import/引数へSafetyScanService、IndexerRuntimeState、IndexEntryStore、IndexProjectionが0件。provider/metrics/upsert/removeはpipeline/既存participant/queryに保持。
+- `rg -n 'resolve_body_text|resolve_media_manifest|media_scan_targets|scan_and_record_with_metrics|deindex_object|fetch_blob_ephemeral|upsert_entry|remove_entry|remove_object' crates/cn-indexer crates/cn-core crates/cn-e2e -g '*.rs'` とdiffで順・逆方向を再列挙する。
+- 固定inventory6/transition7は増減0、未分類0。No permanent blob storage、private scope、two-store fail-closed、HTTP/authority/three-pathに変更なし。
+
+## 検証
+
+beforeの先行最終headとmergeのsubtree一致を確認。以下の同commandを変更前後に実行し、各6suiteの3/17/6/6/2/5、合計39 testsがPASSした（failed/ignored 0）。既存test/fixture/import/assertionの変更0。
+
+```powershell
+cargo test -p kukuri-cn-indexer --test source_resolution_contracts --test ingestion_contracts --test blob_text_ingestion_contracts --test transmission_prevention_contracts --test worker_contracts --test query_contracts
+```
+
+最初の抽出compileではpublish側に残る`bail!`のimport漏れを検出し、元のimportを保持して解消した。期待値やwarning規則を弱めていない。worktreeは先行と同じ絶対path/専用CARGO_TARGET_DIRを使い、別worktreeのxtask binaryを共有しない。
+
+必須`cargo xtask cn-check` / `cargo xtask cn-test`はCIの対象SHA/jobへ対応する。in-memory targetedの成功を実DB/stack成功と扱わない。独立監査とmerge対象一致まで完了判定を保留する。
+
+Rollbackは抽出PRだけrevertし#925 contractを保持。sourceとpublish policyを同時変更する必要が生じた場合は別fix/featureへ分離する。


### PR DESCRIPTION
Refs #926。CN indexerの本文・media manifest解決をprivate source moduleへ移し、到達service依存6→2へ絞りました。DocsSync/optional BlobServiceだけを借用し、guard・scan/metrics・publish/deindexはpipelineに残しています。

- 種別 `refactor:extract`、区分C、Scope revision `2026-09-08-872-R-CN-v1`。
- [計画・AC/INVAR・対象境界・検証・rollback記録](docs/progress/2026-09-08-926-indexer-source-resolver.md)。詳細な独立監査とdeltaはPR commentsに保持。
- 同6suite39 testsをbefore/afterと独立再実行で維持、全targets Clippy -D warnings PASS。3method/2helperの移動同一性、元2callsiteの実行位置、wire/API/依存不変を独立監査。
- 最終head `cedfad649f1c13e48be523d356a39eb210595cc1` の全17 checks SUCCESS。必要な独立監査とCIを満たしてmergeしました。
- merge `5c61680c82607ae96ebcce78496e62e2f457ecb5` と監査対象のpath/surface一致を確認し、[Issue #926](https://github.com/KingYoSun/kukuri/issues/926)の現在判定をCompleteへ同期・Close済み。
