### PR TITLE
[codex][docs] #872の親完了監査と初回baselineを確定する

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -42,6 +42,7 @@
 - Issueの起票、scope固定、計画、実装、PR、独立監査、Close/Reopen: `docs/runbooks/issue-lifecycle.md`
 - 実装計画の要否、粒度と記録形式: root `PLANS.md`
 - path別validationとリファクタリング境界: root `REFACTORING.md`
+- 初回campaignの完了記録: `docs/progress/2026-09-08-872-refactoring-campaign-phase-4.md`。比較起点と初期signalは `xtask/refactoring-audit-baseline.json`、形状は `docs/schemas/refactoring-audit-baseline.schema.json`。継続checkの実装・有効化は #873 が所有する。
 - GitHub Issue / PRは追跡面。既存仕様と今回の変更要求の区別は次節に従う。
 
 ## 正本と変更要求

--- a/docs/progress/2026-09-08-872-refactoring-campaign-phase-4.md
+++ b/docs/progress/2026-09-08-872-refactoring-campaign-phase-4.md
@@ -1,0 +1,100 @@
+# Issue #872 Phase 4: 親完了監査と比較baseline
+
+## 目的・固定範囲
+
+- Scope revision: `2026-09-04-issue-872-refactoring-campaign-v1`、区分C。
+- Phase 4開始・製品実装完了commit: `e98d2025e01332a6dbd4b13f5f4712654a931c65`。Phase 0の`ac9946d6`と区別する。
+- #919〜#928の完了済み10子と20候補を親AC/INVAR/INV/TRへ対応させ、machine-readable baselineを確定する。製品コード・新しい候補の実装は対象外。
+- #873の判定command、schedule、Issue upsertは後続Issueが所有する。今回のbaselineはその入力であり、実行機構ではない。
+- 詳細な実施記録は[Phase 3](2026-09-08-872-refactoring-campaign-phase-3.md)、分類と開始inventoryは[Phase 0〜2](2026-09-08-872-refactoring-campaign-phase-2.md)を再利用する。過去記録の当時の未実施記述は書き換えない。
+
+## 作業と受入確認
+
+| ID | 親AC / INVAR / TR | 対象と受入確認 | 検証 | 依存 |
+| --- | --- | --- | --- | --- |
+| T1 基点と全記録の照合 | AC1〜4、全INVAR、TR1〜4 | 全10子のhead/merge/CI/監査と6groupを再対応。contract後のcomposition同期はdelta監査に対応 | git tree/path比較、Issue/PRの固定evidence | 完了済みPhase3 |
+| T2 構造・大型ファイル再測定 | AC4/5、INVAR3 | owner/site/依存の4成果、scope selectorのmember数/digest、現行16大型fileの実測とratchetを記録 | `cargo xtask oversized-files`、git/正規表現による再計測 | T1 |
+| T3 baselineとschema | AC5、TR5 | `xtask/refactoring-audit-baseline.json`とJSON Schema、採用signal/初期値/閾値/根拠・更新規則を固定 | Draft-07 schema、Git commit/集合/digest/metric整合、否定入力の拒否 | T2 |
+| T4 親の独立監査 | 全AC/INVAR、INV1〜6/TR1〜5 | 製品group監査とbaseline/完了記録の別担当確認。不適合/未分類/blocker0 | 不変surfaceの既存PASSは再利用し、組合せdeltaを照合 | T1〜3 |
+| T5 公開・完了同期 | AC5/TR5 | PR最終head監査/必須CI後にmerge、対象一致後に親Closeと#873への基点引継ぎ | PR/head/tree、Current statusと参照の同期 | T4 |
+
+## baselineの判断
+
+比較起点は既にmain祖先である製品実装完了commit `e98d2025`に固定する。baseline自身のcommit hashを自分の内容へ埋め込む循環を作らず、Phase4記録/設定だけの最終merge SHAはIssueの完了記録で別に保持する。source treeと実測の対象はこの固定commitであり、その後の未監査製品変更を消費しない。
+
+自動判定用の初期signalは、既存規範が開始triggerとして指定するratchet登録pathの新規追加と許容行数の増加に限定する。両方の差分初期値は0、閾値は`>0`。現在行数の美観目標や任意のcommit数を閾値にしない。hotspot/変更量は比較可能な観測データとして残すが、自動発火には採用しない。release/milestone/変更摩擦/sunset等はhuman-onlyとして引き継ぐ。
+
+既存`xtask/oversized-baseline.json`は変更しない。実測と許容上限の差（縮小note3件）は区別して記録する。これはratchetの緩和でも、実測を上限と同一視する変更でもない。
+
+## 検証の選定
+
+製品差分は0。親が明示要求するoversizedと全記録の整合、追加baseline/schemaの検証、独立親監査を実施する。子の同一source treeへ対応するRust/CN/UI/nativeのPASSを再利用し、ローカルで全suiteを再実行したとは記さない。`xtask/**`追加で起動する既存CIは変更・免除せず最終headで確認する。
+
+Phase 3で記録したnative長押し変位/fullmode中移動等の未測定、変更前から再現したfullscreen停止flagを保持する。今回のRegression/固定scopeのblockerと混同せず、修正済みとは記録しない。
+
+## 最終結果
+
+### 親AC/INVARと独立監査
+
+| 条件 | 結果と証拠 |
+| --- | --- |
+| AC1 / TR1 | #871 merge `f933a286`→開始`ac9946d6`→製品完了`e98d2025`の祖先関係と開始baselineを確認 |
+| AC2 / INVAR3 / TR2 | 全20候補は実施4・延期9・却下5・別種別2、固有ID20、未分類0。理由をcompletion baselineにも保存し、延期/却下を実装へ戻していない |
+| AC3 / INVAR2 / TR3 | #919→920、#921→922、#923→924、#925→926の契約先行・before PASS・独立監査・単独PR/rollbackを再確認。#927 fix/#928 docsは明示別種別 |
+| AC4 / INVAR1 / TR4 | 全10子Closed/PR merged、最終CI/独立監査、head→merge対象一致を確認。4構造成果を再測定。初回FAIL/INCONCLUSIVE/CI failureと解消後delta PASSも保持 |
+| AC5 / TR5 | [completion baseline](../../xtask/refactoring-audit-baseline.json)、[schema](../schemas/refactoring-audit-baseline.schema.json)、本記録をreview対象に固定。最終PR CI・merge SHA/対象一致は[親の完了記録](https://github.com/KingYoSun/kukuri/issues/872)に結び、成功後だけCompleteにする |
+
+root実装担当とは別の担当が固定Issue/source/記録から再構築した。INV1/2/5、INV3/4、INV6/baselineへ分け、製品6groupは適合6・不適合0・未分類0・具体blocker0。source依存の計測scopeが最初は曖昧だったため`measurement_scope`へstruct名を明記し、独立再計測6→2とschema否定検証で解消した。最終PR headの確認はPR commentsに保存する。
+
+全audit head→mergeの変更対象pathが一致。merge後の変化は#919の通知contractが#920で受けたcomposition同期1fileだけで、assertion/spies/payloadを変えず#920の監査対象に含まれる。他の対象pathはmerge→`e98d2025`も一致し、組合せdeltaに新しいstate/guard/IPC変更はない。
+
+### 責務・依存・scopeの再測定
+
+| 対象 | before | after | 現行ownerと維持した境界 |
+| --- | ---: | ---: | --- |
+| 通知取得owner file | 2 | 1 | `useNotificationLoaders.ts`、facade生成1。badge/inboxの異なるpolicy、effectsのevent/interval lifecycle、既読IPCを保持 |
+| CN transferのbundle/assign/activate各site | 各2 | 各1 | private `complete_community_node_dome_transfer`、caller2。prepare/no-op・同意再guard・owner保存→remote activate順を保持 |
+| sessionのattempt直接代入 | 9 | 0 | `useDomeTransitionAttempt.ts`へ9site、mutable attempt非公開。sequence/参加状態はsession、既存recovery/ack後handoff/cleanupを保持 |
+| source解決の到達service依存 | 6 | 2 | `ingest/source.rs::SourceResolver`のDocsSync/optional BlobService借用だけ。scan/metrics/2storeはpipeline、body/media各1入口は元位置 |
+
+beforeは`ac9946d6`、afterは`e98d2025`。JSONにpath/regexとwhole-file/struct-field scopeを保存。行数総和や公開入口数の削減を目的にしていない。API/DTO/route/CSS、signature/wire/identity/schema、authority、P2P三経路はrefactorで変更しておらず、#927だけを承認済みfixの挙動変更として分ける。
+
+| 親group | 開始member | 完了member | 追加・分類 |
+| --- | ---: | ---: | --- |
+| INV1 | 177 | 177 | tree無変更 |
+| INV2 | 309 | 311 | Dome listing/transferのtest追加 |
+| INV3 | 539 | 542 | 通知contract/通知owner/attempt owner追加 |
+| INV4 | 65 | 68 | attempt owner、Dome listing、transfer contractの横断集合 |
+| INV5 | 262 | 265 | source contract/support/resolver追加 |
+| INV6 | 402 | 424 | 実行・監査・比較記録と画像。harness/test-support/scenario/xtask/CI実装は無変更 |
+
+groupは重複を含む全tracked集合で、合計を重複なしfile数にしない。別のscanner filter候補は1,556 path。再生成は`git ls-tree -r --name-only <commit>`と保存selector/filterによる。pathをUnicode code point順でsortし、UTF-8/LF結合＋末尾LFのSHA-256を保存し独立再計算で一致した。
+
+### 大型ファイル・初期signal
+
+`cargo xtask oversized-files`はPASS、16件、violation0。全候補を独立走査して16件と一致した。
+
+| path | 開始実測 | 完了実測 | 既存許容上限 |
+| --- | ---: | ---: | ---: |
+| `useMetaverseRoomSession.ts` | 1272 | 1086 | 1272 |
+| `private_channels_game_api.rs` | 1100 | 1093 | 1100 |
+| `runtimeApi.ts` | 1035 | 1035 | 1042 |
+
+全16件をJSONに保存。runtimeApiの差7行は開始時からのnoteで、今回の改善へ算入しない。残る13件は実測/上限一致、上限緩和0。
+
+初期signalは`ratchet_new_paths`と`ratchet_increased_caps`、値各0、`operator=gt / threshold=0 / combination=any`。新規登録と既存上限の増加だけを監査検討へ渡し、削除/縮小は数えない。根拠は規範のratchet増加triggerで、現在行数の単一美観閾値ではない。
+
+参考履歴は`2026-05-29T00:00:00Z`以後566 commits。通知effects16、section loader13、room session15、runtime game API16、ingest12、runtimeApi25のpath変更commit。25変更のruntimeApiを延期した事実も踏まえ、commit数/経過日/変更量だけの自動閾値は採用しない。baselineからの差分初期値0は観測用として保存し、release/milestone/変更摩擦/sunset等をhuman-onlyで残す。
+
+### Validation・制約・引継ぎ
+
+- Draft-07 schemaを既存Ajv6.15で検証。現baseline PASS、missing commit/bad SHA/未完baseline/未知schema版・field/異なる閾値/負数/group不足/path traversal/未分類/子CI失敗の11否定入力を拒否。独立担当はAjv6.15とAjv8.18＋既存ajv-formatsでもschema/current/否定入力を検証。依存変更0。
+- Git commit/祖先、10 code OID、6group count/digest、1,556候補、16実測/上限、6metric、20候補、10子のhead/merge/CIを独立照合した。JSON Schemaだけでgit/counterの真実性まで証明したとはしない。
+- Rust/CNは#926 head `cedfad64`と完了基点の`crates` tree `9dd9733d9155fa022b77310399ecebfee73f792c`、Cargo/Tauri/harness/xtask実装が一致しFast34156245820を再利用できる。UIは#924 Fast34153376771、full UI152 files1209 tests/browser64/visual smoke14と対象treeを対応。slow199 PASSは#927、個別before/after/独立再実行はPhase3に対応する。
+- Phase4差分でローカル全Rust/CN/UI/実機suiteを再実行していない。製品変更0で不変の既存PASSを再利用する。起動する最終PR CIは成功後に親evidenceへ記録する。
+- nativeの未測定範囲と既存fullscreen停止状態は[実機record](../ui-reviews/2026-09-08-issue-924-transition-owner.md)を保持し、全native動作PASSや既存UI不具合の修正済みへ拡大しない。
+- 現行architecture/runbook/ADR/root規範に旧ownerの現役扱いは見つからなかった。docs/READMEへ完了記録の導線を追加する。#927のCurrentに残った「原因診断未着手」は追跡同期で除去する。
+
+初期実測は`e98d2025`の値であり、Phase4の記録/schema/baseline追加後の最新tree件数とは区別する。初回checkで記録追加分の差分が見えても採用ratchet signalは0のまま。main配置と親Complete後だけ確定入力として採用し、#873のcommand/workflow/upsert/scheduleをこの作業で実装・有効化しない。
+
+RollbackはPhase4のbaseline/schema/導線PRだけを戻す。製品の個別revert手順は保持する。baselineを戻す場合は#873の採用も解除し、未監査commitへ自動前進させない。

--- a/docs/progress/2026-09-08-872-refactoring-campaign-phase-4.md
+++ b/docs/progress/2026-09-08-872-refactoring-campaign-phase-4.md
@@ -92,6 +92,8 @@ groupは重複を含む全tracked集合で、合計を重複なしfile数にし�
 - Git commit/祖先、10 code OID、6group count/digest、1,556候補、16実測/上限、6metric、20候補、10子のhead/merge/CIを独立照合した。JSON Schemaだけでgit/counterの真実性まで証明したとはしない。
 - Rust/CNは#926 head `cedfad64`と完了基点の`crates` tree `9dd9733d9155fa022b77310399ecebfee73f792c`、Cargo/Tauri/harness/xtask実装が一致しFast34156245820を再利用できる。UIは#924 Fast34153376771、full UI152 files1209 tests/browser64/visual smoke14と対象treeを対応。slow199 PASSは#927、個別before/after/独立再実行はPhase3に対応する。
 - Phase4差分でローカル全Rust/CN/UI/実機suiteを再実行していない。製品変更0で不変の既存PASSを再利用する。起動する最終PR CIは成功後に親evidenceへ記録する。
+- 初回Fast34164485657のRust testsはCLIの`game_lifecycle_rejects_invalid_roster_without_mutation`で1失敗（651 PASS、652/910で停止）。Running/score7から、無効roster拒否後のreadが古いWaiting/score0/manifestへ戻った。[元job](https://github.com/KingYoSun/kukuri/actions/runs/34164485657/job/101872714365)と[別fix #942](https://github.com/KingYoSun/kukuri/issues/942)へ観測と未確定の実行順を保存した。local同test1回＋上限20回は全PASSで、CI failureを再現済みとはしていない。
+- ScoreGame create/update/validator、CLI、hydration、cache writerは開始SHAから同一。旧recordをblob await後に無条件upsertできる既存経路を確認したが、当該実行のwriter順は未確定。Phase4の製品差分0、#927のMetaverse分岐もこのrowは通らず、今回のRegressionを示す証拠はない。元20候補を拡張せず、既存問題の観測として引き継ぐ。製品/testを変更・弱体化してgreenにせず、最終headの必須CIが成功するまでは親完了を保留する。
 - nativeの未測定範囲と既存fullscreen停止状態は[実機record](../ui-reviews/2026-09-08-issue-924-transition-owner.md)を保持し、全native動作PASSや既存UI不具合の修正済みへ拡大しない。
 - 現行architecture/runbook/ADR/root規範に旧ownerの現役扱いは見つからなかった。docs/READMEへ完了記録の導線を追加する。#927のCurrentに残った「原因診断未着手」は追跡同期で除去する。
 

--- a/docs/schemas/refactoring-audit-baseline.schema.json
+++ b/docs/schemas/refactoring-audit-baseline.schema.json
@@ -1,0 +1,749 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Reviewed refactoring campaign completion baseline v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "$schema",
+    "schema_version",
+    "record_kind",
+    "completed_campaign_baseline",
+    "tracking_issue",
+    "scope_revision",
+    "audit_date",
+    "baseline_commit",
+    "audit_start_commit",
+    "commit_semantics",
+    "completion_record",
+    "update_policy",
+    "activation_policy",
+    "code_tree_oids",
+    "scope",
+    "oversized",
+    "signals",
+    "signal_combination",
+    "signal_semantics",
+    "diagnostics_at_baseline",
+    "human_only_triggers",
+    "structural_metrics",
+    "children",
+    "candidate_counts",
+    "candidates",
+    "known_limitations"
+  ],
+  "properties": {
+    "$schema": {
+      "const": "../docs/schemas/refactoring-audit-baseline.schema.json"
+    },
+    "schema_version": {
+      "const": 1
+    },
+    "record_kind": {
+      "const": "refactoring-campaign-completion"
+    },
+    "completed_campaign_baseline": {
+      "const": true
+    },
+    "tracking_issue": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "scope_revision": {
+      "type": "string",
+      "minLength": 1
+    },
+    "audit_date": {
+      "type": "string",
+      "format": "date"
+    },
+    "baseline_commit": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{40}$"
+    },
+    "audit_start_commit": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{40}$"
+    },
+    "commit_semantics": {
+      "type": "string",
+      "minLength": 1
+    },
+    "completion_record": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^(?!/)(?![A-Za-z]:)(?!.*(?:^|/)\\.\\.(?:/|$))[^\\\\\\u0000]+$"
+    },
+    "update_policy": {
+      "type": "string",
+      "minLength": 1
+    },
+    "activation_policy": {
+      "type": "string",
+      "minLength": 1
+    },
+    "code_tree_oids": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": {
+        "type": "string",
+        "pattern": "^[a-f0-9]{40}$"
+      },
+      "propertyNames": {
+        "type": "string",
+        "minLength": 1,
+        "pattern": "^(?!/)(?![A-Za-z]:)(?!.*(?:^|/)\\.\\.(?:/|$))[^\\\\\\u0000]+$"
+      }
+    },
+    "scope": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "source_policy",
+        "source_policy_blob",
+        "extensions",
+        "excluded_exact_paths",
+        "excluded_path_prefixes",
+        "tracked_candidate_count",
+        "tracked_candidate_paths_sha256",
+        "population_semantics",
+        "member_digest_semantics",
+        "groups"
+      ],
+      "properties": {
+        "source_policy": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source_policy_blob": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{40}$"
+        },
+        "extensions": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        },
+        "excluded_exact_paths": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^(?!/)(?![A-Za-z]:)(?!.*(?:^|/)\\.\\.(?:/|$))[^\\\\\\u0000]+$"
+          },
+          "minItems": 0,
+          "uniqueItems": true
+        },
+        "excluded_path_prefixes": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^(?!/)(?![A-Za-z]:)(?!.*(?:^|/)\\.\\.(?:/|$))[^\\\\\\u0000]+$"
+          },
+          "minItems": 0,
+          "uniqueItems": true
+        },
+        "tracked_candidate_count": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "tracked_candidate_paths_sha256": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{64}$"
+        },
+        "population_semantics": {
+          "type": "string",
+          "minLength": 1
+        },
+        "member_digest_semantics": {
+          "type": "string",
+          "minLength": 1
+        },
+        "groups": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/group"
+          },
+          "minItems": 6,
+          "uniqueItems": true,
+          "maxItems": 6
+        }
+      }
+    },
+    "oversized": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "line_limit",
+        "count",
+        "ratchet_path",
+        "ratchet_blob",
+        "line_count_semantics",
+        "files"
+      ],
+      "properties": {
+        "line_limit": {
+          "const": 1000
+        },
+        "count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "ratchet_path": {
+          "const": "xtask/oversized-baseline.json"
+        },
+        "ratchet_blob": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{40}$"
+        },
+        "line_count_semantics": {
+          "type": "string",
+          "minLength": 1
+        },
+        "files": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/oversized_file"
+          },
+          "minItems": 0,
+          "uniqueItems": true
+        }
+      }
+    },
+    "signals": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "ratchet_new_paths",
+        "ratchet_increased_caps"
+      ],
+      "properties": {
+        "ratchet_new_paths": {
+          "$ref": "#/definitions/signal"
+        },
+        "ratchet_increased_caps": {
+          "$ref": "#/definitions/signal"
+        }
+      }
+    },
+    "signal_combination": {
+      "const": "any"
+    },
+    "signal_semantics": {
+      "type": "string",
+      "minLength": 1
+    },
+    "diagnostics_at_baseline": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "commits_since_baseline",
+        "changed_candidate_paths",
+        "max_path_change_commits",
+        "days_since_audit",
+        "historical_context"
+      ],
+      "properties": {
+        "commits_since_baseline": {
+          "const": 0
+        },
+        "changed_candidate_paths": {
+          "const": 0
+        },
+        "max_path_change_commits": {
+          "const": 0
+        },
+        "days_since_audit": {
+          "const": 0
+        },
+        "historical_context": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "since",
+            "method",
+            "commits",
+            "path_change_commits"
+          ],
+          "properties": {
+            "since": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "method": {
+              "type": "string",
+              "minLength": 1
+            },
+            "commits": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "path_change_commits": {
+              "type": "object",
+              "minProperties": 1,
+              "additionalProperties": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "propertyNames": {
+                "type": "string",
+                "minLength": 1,
+                "pattern": "^(?!/)(?![A-Za-z]:)(?!.*(?:^|/)\\.\\.(?:/|$))[^\\\\\\u0000]+$"
+              }
+            }
+          }
+        }
+      }
+    },
+    "human_only_triggers": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "minItems": 1,
+      "uniqueItems": true
+    },
+    "structural_metrics": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/metric"
+      },
+      "minItems": 1,
+      "uniqueItems": true
+    },
+    "children": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/child"
+      },
+      "minItems": 1,
+      "uniqueItems": true
+    },
+    "candidate_counts": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "selected",
+        "deferred",
+        "rejected",
+        "other_type",
+        "unclassified"
+      ],
+      "properties": {
+        "selected": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "deferred": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "rejected": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "other_type": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "unclassified": {
+          "const": 0
+        }
+      }
+    },
+    "candidates": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/candidate"
+      },
+      "minItems": 1,
+      "uniqueItems": true
+    },
+    "known_limitations": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/limitation"
+      },
+      "minItems": 0,
+      "uniqueItems": true
+    }
+  },
+  "definitions": {
+    "group": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "selector_regex",
+        "before_count",
+        "member_count",
+        "member_paths_sha256",
+        "added_paths",
+        "removed_paths"
+      ],
+      "properties": {
+        "id": {
+          "enum": [
+            "INV-1",
+            "INV-2",
+            "INV-3",
+            "INV-4",
+            "INV-5",
+            "INV-6"
+          ]
+        },
+        "selector_regex": {
+          "type": "string",
+          "minLength": 1
+        },
+        "before_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "member_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "member_paths_sha256": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{64}$"
+        },
+        "added_paths": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^(?!/)(?![A-Za-z]:)(?!.*(?:^|/)\\.\\.(?:/|$))[^\\\\\\u0000]+$"
+          },
+          "minItems": 0,
+          "uniqueItems": true
+        },
+        "removed_paths": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^(?!/)(?![A-Za-z]:)(?!.*(?:^|/)\\.\\.(?:/|$))[^\\\\\\u0000]+$"
+          },
+          "minItems": 0,
+          "uniqueItems": true
+        }
+      }
+    },
+    "oversized_file": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "before_lines",
+        "observed_lines",
+        "ratchet_lines"
+      ],
+      "properties": {
+        "path": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^(?!/)(?![A-Za-z]:)(?!.*(?:^|/)\\.\\.(?:/|$))[^\\\\\\u0000]+$"
+        },
+        "before_lines": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "observed_lines": {
+          "type": "integer",
+          "minimum": 1000
+        },
+        "ratchet_lines": {
+          "type": "integer",
+          "minimum": 1000
+        }
+      }
+    },
+    "signal": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "initial_value",
+        "operator",
+        "threshold",
+        "unit",
+        "reason"
+      ],
+      "properties": {
+        "initial_value": {
+          "const": 0
+        },
+        "operator": {
+          "const": "gt"
+        },
+        "threshold": {
+          "const": 0
+        },
+        "unit": {
+          "const": "paths"
+        },
+        "reason": {
+          "type": "string",
+          "minLength": 20
+        }
+      }
+    },
+    "metric": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "before",
+        "after",
+        "before_paths",
+        "after_paths",
+        "measurement_regex",
+        "issues",
+        "meaning",
+        "measurement_scope"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "before": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "after": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "before_paths": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^(?!/)(?![A-Za-z]:)(?!.*(?:^|/)\\.\\.(?:/|$))[^\\\\\\u0000]+$"
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        },
+        "after_paths": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^(?!/)(?![A-Za-z]:)(?!.*(?:^|/)\\.\\.(?:/|$))[^\\\\\\u0000]+$"
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        },
+        "measurement_regex": {
+          "type": "string",
+          "minLength": 1
+        },
+        "issues": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        },
+        "meaning": {
+          "type": "string",
+          "minLength": 1
+        },
+        "measurement_scope": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "kind",
+                "before_symbol",
+                "after_symbol"
+              ],
+              "properties": {
+                "kind": {
+                  "const": "whole_file"
+                },
+                "before_symbol": {
+                  "type": "null"
+                },
+                "after_symbol": {
+                  "type": "null"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "kind",
+                "before_symbol",
+                "after_symbol"
+              ],
+              "properties": {
+                "kind": {
+                  "const": "struct_fields"
+                },
+                "before_symbol": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "after_symbol": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "child": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "issue",
+        "pr",
+        "audit_head",
+        "merge_commit",
+        "check_count",
+        "all_checks_success",
+        "fast_run_id",
+        "target_paths",
+        "audited_head_matches_merge",
+        "post_merge_changed_paths"
+      ],
+      "properties": {
+        "issue": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "pr": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "audit_head": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{40}$"
+        },
+        "merge_commit": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{40}$"
+        },
+        "check_count": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "all_checks_success": {
+          "const": true
+        },
+        "fast_run_id": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 1
+        },
+        "target_paths": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^(?!/)(?![A-Za-z]:)(?!.*(?:^|/)\\.\\.(?:/|$))[^\\\\\\u0000]+$"
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        },
+        "audited_head_matches_merge": {
+          "const": true
+        },
+        "post_merge_changed_paths": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^(?!/)(?![A-Za-z]:)(?!.*(?:^|/)\\.\\.(?:/|$))[^\\\\\\u0000]+$"
+          },
+          "minItems": 0,
+          "uniqueItems": true
+        }
+      }
+    },
+    "candidate": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "label",
+        "classification",
+        "reason",
+        "followup"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "label": {
+          "type": "string",
+          "minLength": 1
+        },
+        "classification": {
+          "enum": [
+            "実施",
+            "延期",
+            "却下",
+            "別種別"
+          ]
+        },
+        "reason": {
+          "type": "string",
+          "minLength": 1
+        },
+        "followup": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "limitation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "status",
+        "description",
+        "evidence"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "status": {
+          "enum": [
+            "not_measured",
+            "pre_existing",
+            "recorded"
+          ]
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1
+        },
+        "evidence": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^(?!/)(?![A-Za-z]:)(?!.*(?:^|/)\\.\\.(?:/|$))[^\\\\\\u0000]+$"
+        }
+      }
+    }
+  }
+}

--- a/xtask/refactoring-audit-baseline.json
+++ b/xtask/refactoring-audit-baseline.json
@@ -775,6 +775,12 @@
       "status": "recorded",
       "description": "縮小note3件は実測と許容上限を別々に保存。既存ratchetの値を変更せず、未使用容量を今回の構造成果と混同しない。",
       "evidence": "docs/progress/2026-09-08-872-refactoring-campaign-phase-4.md"
+    },
+    {
+      "id": "score-game-projection-ci-failure",
+      "status": "recorded",
+      "description": "Phase4 CIで無効roster拒否後のreadが古いprojectionへ戻る1失敗を観測。該当writer/validator/CLIはac9946から同一。実行順は未確定、local1+20回はPASS。製品差分によるRegressionの根拠はなく、元20候補の外の別fix #942へ追跡する。",
+      "evidence": "docs/progress/2026-09-08-872-refactoring-campaign-phase-4.md"
     }
   ],
   "activation_policy": "reviewed baselineがmainに存在し、tracking_issueのCurrent statusがCompleteになって初めて後続checkの確定入力として採用する。未mergeのbranch上の内容は候補である。"

--- a/xtask/refactoring-audit-baseline.json
+++ b/xtask/refactoring-audit-baseline.json
@@ -1,0 +1,781 @@
+{
+  "$schema": "../docs/schemas/refactoring-audit-baseline.schema.json",
+  "schema_version": 1,
+  "record_kind": "refactoring-campaign-completion",
+  "completed_campaign_baseline": true,
+  "tracking_issue": 872,
+  "scope_revision": "2026-09-04-issue-872-refactoring-campaign-v1",
+  "audit_date": "2026-09-08",
+  "baseline_commit": "e98d2025e01332a6dbd4b13f5f4712654a931c65",
+  "audit_start_commit": "ac9946d66aaf197204f669a10701fac8a13877e9",
+  "commit_semantics": "baseline_commitはmain祖先の製品実装完了・比較起点。baseline自身を含むdocs/config merge SHAはIssue #872のComplete evidenceで別記し、未監査の後続変更を消費しない。",
+  "completion_record": "docs/progress/2026-09-08-872-refactoring-campaign-phase-4.md",
+  "update_policy": "監査完了後の独立review付きPRだけで更新。#873のcheck自身による前進は禁止。",
+  "code_tree_oids": {
+    "crates": "9dd9733d9155fa022b77310399ecebfee73f792c",
+    "apps": "c28f81a1f7b89a225d0358bb810c4bea4a2abc21",
+    "harness": "7189d5600f14a7a02285e40234daf0d9b6dc95fc",
+    "xtask/src": "5ef814d6e4fb63ae927d0857fd84794e3fd028f2",
+    "xtask/Cargo.toml": "adf7ad5abac7582a2145d9d97a227e6dfa6fce3a",
+    "Cargo.toml": "7fd70d5d0ffab5a6592547e6d5f4780adb84ccee",
+    "Cargo.lock": "0053565d6a571db8547757dd10586c442fd6b93b",
+    "rust-toolchain.toml": "5dd88652da3b5f1496d2097252905e7346bc7984",
+    ".cargo": "0c4075fefb8e5cf974a5fdd2614125de1331ee58",
+    ".config": "d2d3f686f9889d8f570a8a19931b21387ecfe838"
+  },
+  "scope": {
+    "source_policy": "xtask/src/oversized.rs::should_scan_oversized_file",
+    "source_policy_blob": "f21996601e488a5ce26a5ff66d50ca7c637c256b",
+    "extensions": [
+      "css",
+      "html",
+      "js",
+      "json",
+      "jsx",
+      "md",
+      "ps1",
+      "rs",
+      "scss",
+      "sh",
+      "sql",
+      "toml",
+      "ts",
+      "tsx",
+      "txt",
+      "yaml",
+      "yml"
+    ],
+    "excluded_exact_paths": [
+      "Cargo.lock",
+      "apps/desktop/pnpm-lock.yaml",
+      "apps/desktop/src-tauri/Cargo.lock"
+    ],
+    "excluded_path_prefixes": [
+      "apps/desktop/src-tauri/gen/",
+      "apps/desktop/src-tauri/icons/"
+    ],
+    "tracked_candidate_count": 1556,
+    "tracked_candidate_paths_sha256": "b102979575231b39bad2885af6ed414c9e9b0b3dfecb3e472933f51580c5ddcc",
+    "population_semantics": "baseline_commitのgit ls-tree -r --name-onlyを既存oversized scannerのextension/exclusionへ適用した集合。実行時の未追跡filesはbaselineへ含めない。",
+    "groups": [
+      {
+        "id": "INV-1",
+        "selector_regex": "^crates/(core|store|transport|docs-sync|blob-service|iroh-node)/",
+        "before_count": 177,
+        "member_count": 177,
+        "member_paths_sha256": "ed77b4ca85efc7b9d16c757233318864a4c8bee6e3e4dd8c4e8887fbe4d1d19f",
+        "added_paths": [],
+        "removed_paths": []
+      },
+      {
+        "id": "INV-2",
+        "selector_regex": "^(crates/(app-api|desktop-runtime|kukuri-cli)/|apps/desktop/src-tauri/)",
+        "before_count": 309,
+        "member_count": 311,
+        "member_paths_sha256": "679e6f0f4ad0c3e95a3b11240a969e657790390f5f15d935c32ced4d6b32b953",
+        "added_paths": [
+          "crates/app-api/src/tests/dome_listing.rs",
+          "crates/desktop-runtime/src/tests/community_node/dome_hosting/transfer_contract.rs"
+        ],
+        "removed_paths": []
+      },
+      {
+        "id": "INV-3",
+        "selector_regex": "^apps/desktop/(?!src-tauri/)",
+        "before_count": 539,
+        "member_count": 542,
+        "member_paths_sha256": "91a96c5d5fe32e53d836ee8d2a6e63c815047f0d567a28ce5b0155c51b2c88f3",
+        "added_paths": [
+          "apps/desktop/src/components/extended/metaverse/useDomeTransitionAttempt.ts",
+          "apps/desktop/src/shell/data/loaders/useNotificationLoaders.ts",
+          "apps/desktop/src/shell/data/notificationLoaders.contract.test.tsx"
+        ],
+        "removed_paths": []
+      },
+      {
+        "id": "INV-4",
+        "selector_regex": "^crates/metaverse-host/|^(crates/(app-api|desktop-runtime)/|apps/desktop/src/).*([Mm]etaverse|[Dd]ome)",
+        "before_count": 65,
+        "member_count": 68,
+        "member_paths_sha256": "e230bb394e0aa07f3037469b4c1b9dce7dc73887456a836efd41df49040f5c03",
+        "added_paths": [
+          "apps/desktop/src/components/extended/metaverse/useDomeTransitionAttempt.ts",
+          "crates/app-api/src/tests/dome_listing.rs",
+          "crates/desktop-runtime/src/tests/community_node/dome_hosting/transfer_contract.rs"
+        ],
+        "removed_paths": []
+      },
+      {
+        "id": "INV-5",
+        "selector_regex": "^crates/cn-[^/]+/",
+        "before_count": 262,
+        "member_count": 265,
+        "member_paths_sha256": "66c0d9fcd9c9e6b4753ac4538b333d1819165a79ded6e87f6665c6aba3570de8",
+        "added_paths": [
+          "crates/cn-indexer/src/ingest/source.rs",
+          "crates/cn-indexer/tests/source_resolution_contracts.rs",
+          "crates/cn-indexer/tests/source_resolution_contracts/support.rs"
+        ],
+        "removed_paths": []
+      },
+      {
+        "id": "INV-6",
+        "selector_regex": "^(crates/(harness|test-support)/|harness/|xtask/|docs/|scripts/|\\.github/|\\.config/)|^(AGENTS\\.md|PLANS\\.md|REFACTORING\\.md|DESIGN\\.md|Cargo\\.(toml|lock)|rust-toolchain\\.toml)$",
+        "before_count": 402,
+        "member_count": 424,
+        "member_paths_sha256": "4cf84b621b8a7441f74e9d8c559706ff1542621759f384aa360a841c926d21e2",
+        "added_paths": [
+          "docs/progress/2026-09-08-872-audit-baseline.json",
+          "docs/progress/2026-09-08-872-audit-core-cn.md",
+          "docs/progress/2026-09-08-872-audit-frontend.md",
+          "docs/progress/2026-09-08-872-audit-harness.md",
+          "docs/progress/2026-09-08-872-audit-runtime-metaverse.md",
+          "docs/progress/2026-09-08-872-refactoring-campaign-phase-2.md",
+          "docs/progress/2026-09-08-872-refactoring-campaign-phase-3.md",
+          "docs/progress/2026-09-08-919-notification-contract.md",
+          "docs/progress/2026-09-08-920-notification-loader.md",
+          "docs/progress/2026-09-08-921-dome-transfer-contract.md",
+          "docs/progress/2026-09-08-922-dome-transfer-extract.md",
+          "docs/progress/2026-09-08-923-dome-transition-contract.md",
+          "docs/progress/2026-09-08-924-dome-transition-attempt.md",
+          "docs/progress/2026-09-08-925-indexer-source-contract.md",
+          "docs/progress/2026-09-08-926-indexer-source-resolver.md",
+          "docs/progress/2026-09-08-927-dome-preset-listing.md",
+          "docs/progress/2026-09-08-928-capability-freeze-docs.md",
+          "docs/ui-reviews/2026-09-08-issue-924-transition-owner.md",
+          "docs/ui-reviews/assets/issue-924/after-exit.jpg",
+          "docs/ui-reviews/assets/issue-924/after-input.jpg",
+          "docs/ui-reviews/assets/issue-924/before-exit.jpg",
+          "docs/ui-reviews/assets/issue-924/before-fullscreen-flags.jpg"
+        ],
+        "removed_paths": []
+      }
+    ],
+    "member_digest_semantics": "pathをUnicode code point順にsortし、UTF-8のLF結合と末尾LFをSHA-256する。groupは全tracked path、tracked_candidateはscanner filter集合。"
+  },
+  "oversized": {
+    "line_limit": 1000,
+    "count": 16,
+    "ratchet_path": "xtask/oversized-baseline.json",
+    "ratchet_blob": "cb37a553c18486c500abec2609ae26102344153d",
+    "line_count_semantics": "UTF-8 blobのLF区切り、末尾LFを追加空行に数えない。Rust str::linesと同じ対象。",
+    "files": [
+      {
+        "path": "apps/desktop/src/components/extended/metaverse/useMetaverseRoomSession.ts",
+        "before_lines": 1272,
+        "observed_lines": 1086,
+        "ratchet_lines": 1272
+      },
+      {
+        "path": "apps/desktop/src/lib/api/commands/runtimeApi.ts",
+        "before_lines": 1035,
+        "observed_lines": 1035,
+        "ratchet_lines": 1042
+      },
+      {
+        "path": "apps/desktop/src/shell/presentation.test.ts",
+        "before_lines": 1018,
+        "observed_lines": 1018,
+        "ratchet_lines": 1018
+      },
+      {
+        "path": "crates/app-api/src/dome_hosting.rs",
+        "before_lines": 1096,
+        "observed_lines": 1096,
+        "ratchet_lines": 1096
+      },
+      {
+        "path": "crates/app-api/src/private_channels.rs",
+        "before_lines": 1129,
+        "observed_lines": 1129,
+        "ratchet_lines": 1129
+      },
+      {
+        "path": "crates/app-api/src/service/private_channels_support.rs",
+        "before_lines": 1097,
+        "observed_lines": 1097,
+        "ratchet_lines": 1097
+      },
+      {
+        "path": "crates/cn-operator/src/config.rs",
+        "before_lines": 1287,
+        "observed_lines": 1287,
+        "ratchet_lines": 1287
+      },
+      {
+        "path": "crates/cn-operator/src/docs.rs",
+        "before_lines": 1191,
+        "observed_lines": 1191,
+        "ratchet_lines": 1191
+      },
+      {
+        "path": "crates/cn-operator/tests/generate.rs",
+        "before_lines": 1027,
+        "observed_lines": 1027,
+        "ratchet_lines": 1027
+      },
+      {
+        "path": "crates/desktop-runtime/src/identity.rs",
+        "before_lines": 1004,
+        "observed_lines": 1004,
+        "ratchet_lines": 1004
+      },
+      {
+        "path": "crates/desktop-runtime/src/runtime/private_channels_game_api.rs",
+        "before_lines": 1100,
+        "observed_lines": 1093,
+        "ratchet_lines": 1100
+      },
+      {
+        "path": "crates/harness/src/scenarios/community_node.rs",
+        "before_lines": 1228,
+        "observed_lines": 1228,
+        "ratchet_lines": 1228
+      },
+      {
+        "path": "crates/harness/src/scenarios/desktop_smoke.rs",
+        "before_lines": 1016,
+        "observed_lines": 1016,
+        "ratchet_lines": 1016
+      },
+      {
+        "path": "crates/metaverse-host/src/lib.rs",
+        "before_lines": 1191,
+        "observed_lines": 1191,
+        "ratchet_lines": 1191
+      },
+      {
+        "path": "crates/metaverse-host/src/tests.rs",
+        "before_lines": 1056,
+        "observed_lines": 1056,
+        "ratchet_lines": 1056
+      },
+      {
+        "path": "docs/THIRD_PARTY_NOTICES.md",
+        "before_lines": 1276,
+        "observed_lines": 1276,
+        "ratchet_lines": 1276
+      }
+    ]
+  },
+  "signals": {
+    "ratchet_new_paths": {
+      "initial_value": 0,
+      "operator": "gt",
+      "threshold": 0,
+      "unit": "paths",
+      "reason": "REFACTORING.mdがratchet baseline増加を監査開始triggerとする。保存したpath集合に対する新規登録を検出する。現在行数だけの美観判定ではない。"
+    },
+    "ratchet_increased_caps": {
+      "initial_value": 0,
+      "operator": "gt",
+      "threshold": 0,
+      "unit": "paths",
+      "reason": "既存の登録pathの許容上限を増やした件数。review済みratchet容量の増加を次の監査検討へ渡す。縮小・削除は発火しない。"
+    }
+  },
+  "signal_combination": "any",
+  "signal_semantics": "auditを推奨する入力のみ。CI failure、自動refactor、毎週の必須起票を意味しない。command/workflow/upsertは#873が実装する。",
+  "diagnostics_at_baseline": {
+    "commits_since_baseline": 0,
+    "changed_candidate_paths": 0,
+    "max_path_change_commits": 0,
+    "days_since_audit": 0,
+    "historical_context": {
+      "since": "2026-05-29T00:00:00Z",
+      "method": "git rev-list --count --since=<since> <commit> -- <path>; rename追跡なし、commit数のみで自動発火しない",
+      "commits": 566,
+      "path_change_commits": {
+        "apps/desktop/src/shell/data/useDesktopShellDataEffects.ts": 16,
+        "apps/desktop/src/shell/data/loaders/useDesktopShellSectionLoaders.ts": 13,
+        "apps/desktop/src/components/extended/metaverse/useMetaverseRoomSession.ts": 15,
+        "crates/desktop-runtime/src/runtime/private_channels_game_api.rs": 16,
+        "crates/cn-indexer/src/ingest.rs": 12,
+        "apps/desktop/src/lib/api/commands/runtimeApi.ts": 25
+      }
+    }
+  },
+  "human_only_triggers": [
+    "大規模feature/milestone完了",
+    "release安定化前",
+    "現構造が次の変更を阻害",
+    "同種のreview指摘/変更摩擦が反復",
+    "二重state/domain ruleまたは境界逸脱",
+    "互換経路/flagのsunset条件成立"
+  ],
+  "structural_metrics": [
+    {
+      "id": "notification_owner_files",
+      "before": 2,
+      "after": 1,
+      "before_paths": [
+        "apps/desktop/src/shell/data/useDesktopShellDataEffects.ts",
+        "apps/desktop/src/shell/data/loaders/useDesktopShellSectionLoaders.ts"
+      ],
+      "after_paths": [
+        "apps/desktop/src/shell/data/loaders/useNotificationLoaders.ts"
+      ],
+      "measurement_regex": "(?s)\\A(?=.*api\\.getNotificationStatus\\().*\\Z",
+      "issues": [
+        919,
+        920
+      ],
+      "meaning": "status/list取得を所有するmodule数。badge/inboxの2policyと2callは保持。",
+      "measurement_scope": {
+        "kind": "whole_file",
+        "before_symbol": null,
+        "after_symbol": null
+      }
+    },
+    {
+      "id": "build_dome_hosting_assignment_request_sites",
+      "before": 2,
+      "after": 1,
+      "before_paths": [
+        "crates/desktop-runtime/src/runtime/private_channels_game_api.rs"
+      ],
+      "after_paths": [
+        "crates/desktop-runtime/src/runtime/private_channels_game_api.rs"
+      ],
+      "measurement_regex": "\\.\\s*build_dome_hosting_assignment_request\\(",
+      "issues": [
+        921,
+        922
+      ],
+      "meaning": "両入口から1 private ownerへ集約した副作用callsite数。",
+      "measurement_scope": {
+        "kind": "whole_file",
+        "before_symbol": null,
+        "after_symbol": null
+      }
+    },
+    {
+      "id": "assign_dome_hosting_to_community_node_sites",
+      "before": 2,
+      "after": 1,
+      "before_paths": [
+        "crates/desktop-runtime/src/runtime/private_channels_game_api.rs"
+      ],
+      "after_paths": [
+        "crates/desktop-runtime/src/runtime/private_channels_game_api.rs"
+      ],
+      "measurement_regex": "\\.\\s*assign_dome_hosting_to_community_node\\(",
+      "issues": [
+        921,
+        922
+      ],
+      "meaning": "両入口から1 private ownerへ集約した副作用callsite数。",
+      "measurement_scope": {
+        "kind": "whole_file",
+        "before_symbol": null,
+        "after_symbol": null
+      }
+    },
+    {
+      "id": "activate_dome_hosting_on_community_node_sites",
+      "before": 2,
+      "after": 1,
+      "before_paths": [
+        "crates/desktop-runtime/src/runtime/private_channels_game_api.rs"
+      ],
+      "after_paths": [
+        "crates/desktop-runtime/src/runtime/private_channels_game_api.rs"
+      ],
+      "measurement_regex": "\\.\\s*activate_dome_hosting_on_community_node\\(",
+      "issues": [
+        921,
+        922
+      ],
+      "meaning": "両入口から1 private ownerへ集約した副作用callsite数。",
+      "measurement_scope": {
+        "kind": "whole_file",
+        "before_symbol": null,
+        "after_symbol": null
+      }
+    },
+    {
+      "id": "session_attempt_mutations",
+      "before": 9,
+      "after": 0,
+      "before_paths": [
+        "apps/desktop/src/components/extended/metaverse/useMetaverseRoomSession.ts"
+      ],
+      "after_paths": [
+        "apps/desktop/src/components/extended/metaverse/useMetaverseRoomSession.ts"
+      ],
+      "measurement_regex": "^\\s*(?:attempt\\.(?:phase|cancelled|ticket)|transitionAttemptRef\\.current)\\s*=(?!=)",
+      "issues": [
+        923,
+        924
+      ],
+      "meaning": "sessionからmutable attemptの直接所有を除去。",
+      "measurement_scope": {
+        "kind": "whole_file",
+        "before_symbol": null,
+        "after_symbol": null
+      }
+    },
+    {
+      "id": "source_service_dependencies",
+      "before": 6,
+      "after": 2,
+      "before_paths": [
+        "crates/cn-indexer/src/ingest.rs"
+      ],
+      "after_paths": [
+        "crates/cn-indexer/src/ingest/source.rs"
+      ],
+      "measurement_regex": "^\\s*(docs_sync|safety|entries|projection|blob_service|metrics):",
+      "issues": [
+        925,
+        926
+      ],
+      "meaning": "struct IngestPipelineの6service fieldからSourceResolverのDocsSync/optional BlobServiceの2borrowだけへ制限。",
+      "measurement_scope": {
+        "kind": "struct_fields",
+        "before_symbol": "IngestPipeline",
+        "after_symbol": "SourceResolver"
+      }
+    }
+  ],
+  "children": [
+    {
+      "issue": 919,
+      "pr": 929,
+      "audit_head": "f68baddce8fca68242fea1d8d8f9b97c7d2da966",
+      "merge_commit": "0410261bb8091829db6b5cd8f1feb66791aaf327",
+      "check_count": 11,
+      "all_checks_success": true,
+      "fast_run_id": 34143593820,
+      "target_paths": [
+        "apps/desktop/src/shell/data/notificationLoaders.contract.test.tsx",
+        "docs/progress/2026-09-08-919-notification-contract.md"
+      ],
+      "audited_head_matches_merge": true,
+      "post_merge_changed_paths": [
+        "apps/desktop/src/shell/data/notificationLoaders.contract.test.tsx"
+      ]
+    },
+    {
+      "issue": 920,
+      "pr": 933,
+      "audit_head": "0884e85a5bffbecaa4d27f042f54859c3f8633fc",
+      "merge_commit": "4e833af8cbdb7263a75ad17f54ee64be6e263471",
+      "check_count": 11,
+      "all_checks_success": true,
+      "fast_run_id": 34148811673,
+      "target_paths": [
+        "apps/desktop/src/shell/data/loaders/useDesktopShellSectionLoaders.test.tsx",
+        "apps/desktop/src/shell/data/loaders/useDesktopShellSectionLoaders.ts",
+        "apps/desktop/src/shell/data/loaders/useNotificationLoaders.ts",
+        "apps/desktop/src/shell/data/notificationLoaders.contract.test.tsx",
+        "apps/desktop/src/shell/data/useDesktopShellDataEffects.ts",
+        "apps/desktop/src/shell/useDesktopShellData.ts",
+        "docs/progress/2026-09-08-920-notification-loader.md"
+      ],
+      "audited_head_matches_merge": true,
+      "post_merge_changed_paths": []
+    },
+    {
+      "issue": 921,
+      "pr": 932,
+      "audit_head": "54c001d2f6fa944083cffc48da5912094d6f4128",
+      "merge_commit": "d5c7769a9c73c76ccfeabb8b0b0453d495b1e1b6",
+      "check_count": 13,
+      "all_checks_success": true,
+      "fast_run_id": 34149099066,
+      "target_paths": [
+        "crates/desktop-runtime/src/tests/community_node/dome_hosting.rs",
+        "crates/desktop-runtime/src/tests/community_node/dome_hosting/transfer_contract.rs",
+        "crates/desktop-runtime/src/tests/support/lock_contract.rs",
+        "docs/progress/2026-09-08-921-dome-transfer-contract.md"
+      ],
+      "audited_head_matches_merge": true,
+      "post_merge_changed_paths": []
+    },
+    {
+      "issue": 922,
+      "pr": 936,
+      "audit_head": "bec17adb73f6eb5de1e7f56bc01b3918dbf0dacf",
+      "merge_commit": "f90d28fb5c5b0f87fd30233250ba786c3938eba0",
+      "check_count": 13,
+      "all_checks_success": true,
+      "fast_run_id": 34152916868,
+      "target_paths": [
+        "crates/desktop-runtime/src/runtime/private_channels_game_api.rs",
+        "docs/progress/2026-09-08-922-dome-transfer-extract.md"
+      ],
+      "audited_head_matches_merge": true,
+      "post_merge_changed_paths": []
+    },
+    {
+      "issue": 923,
+      "pr": 934,
+      "audit_head": "6dfb95a1e6ace5a3190e28ddc6a97c5b9b57ddd5",
+      "merge_commit": "d9ea79be4fe03e3d97032b53bef2747760652908",
+      "check_count": 11,
+      "all_checks_success": true,
+      "fast_run_id": 34148920694,
+      "target_paths": [
+        "apps/desktop/src/components/extended/metaverse/useMetaverseRoomSession.test.tsx",
+        "docs/progress/2026-09-08-923-dome-transition-contract.md"
+      ],
+      "audited_head_matches_merge": true,
+      "post_merge_changed_paths": []
+    },
+    {
+      "issue": 924,
+      "pr": 937,
+      "audit_head": "e647f318fab49b5f3fed079055a4cc1823e572d6",
+      "merge_commit": "3971fba25a8d6034e16623aefc5a5b7b51d02bd6",
+      "check_count": 11,
+      "all_checks_success": true,
+      "fast_run_id": 34153376771,
+      "target_paths": [
+        "apps/desktop/src/components/extended/metaverse/useDomeTransitionAttempt.ts",
+        "apps/desktop/src/components/extended/metaverse/useMetaverseRoomSession.ts",
+        "docs/progress/2026-09-08-924-dome-transition-attempt.md"
+      ],
+      "audited_head_matches_merge": true,
+      "post_merge_changed_paths": []
+    },
+    {
+      "issue": 925,
+      "pr": 935,
+      "audit_head": "a2dbe8e2ebd701e5d3531456943f51846ab0e822",
+      "merge_commit": "7c9cba850d572c8d358d5f529798a89c3c84eb06",
+      "check_count": 17,
+      "all_checks_success": true,
+      "fast_run_id": 34153130599,
+      "target_paths": [
+        "crates/cn-indexer/tests/source_resolution_contracts.rs",
+        "crates/cn-indexer/tests/source_resolution_contracts/support.rs",
+        "docs/progress/2026-09-08-925-indexer-source-contract.md"
+      ],
+      "audited_head_matches_merge": true,
+      "post_merge_changed_paths": []
+    },
+    {
+      "issue": 926,
+      "pr": 939,
+      "audit_head": "cedfad649f1c13e48be523d356a39eb210595cc1",
+      "merge_commit": "5c61680c82607ae96ebcce78496e62e2f457ecb5",
+      "check_count": 17,
+      "all_checks_success": true,
+      "fast_run_id": 34156245820,
+      "target_paths": [
+        "crates/cn-indexer/src/ingest.rs",
+        "crates/cn-indexer/src/ingest/source.rs",
+        "docs/progress/2026-09-08-926-indexer-source-resolver.md"
+      ],
+      "audited_head_matches_merge": true,
+      "post_merge_changed_paths": []
+    },
+    {
+      "issue": 927,
+      "pr": 931,
+      "audit_head": "de3dec2a2d24699aa54be232d57fc645a7242b50",
+      "merge_commit": "2229fefaa479064bf8080bc55e2984acf025fc66",
+      "check_count": 13,
+      "all_checks_success": true,
+      "fast_run_id": 34146075496,
+      "target_paths": [
+        "crates/app-api/src/dome_hosting.rs",
+        "crates/app-api/src/game.rs",
+        "crates/app-api/src/service/live_game_support.rs",
+        "crates/app-api/src/service/mod.rs",
+        "crates/app-api/src/tests/dome_listing.rs",
+        "crates/app-api/src/tests/mod.rs",
+        "docs/progress/2026-09-08-927-dome-preset-listing.md"
+      ],
+      "audited_head_matches_merge": true,
+      "post_merge_changed_paths": []
+    },
+    {
+      "issue": 928,
+      "pr": 930,
+      "audit_head": "c1670fdb164dd442639b4bef61a02cc254e049d0",
+      "merge_commit": "36e3732edfb68e0637a60e7badf4c778d0530e4d",
+      "check_count": 1,
+      "all_checks_success": true,
+      "fast_run_id": null,
+      "target_paths": [
+        "REFACTORING.md",
+        "docs/adr/0027-deterministic-moderation-critical-safety.md",
+        "docs/progress/2026-09-08-928-capability-freeze-docs.md"
+      ],
+      "audited_head_matches_merge": true,
+      "post_merge_changed_paths": []
+    }
+  ],
+  "candidate_counts": {
+    "selected": 4,
+    "deferred": 9,
+    "rejected": 5,
+    "other_type": 2,
+    "unclassified": 0
+  },
+  "candidates": [
+    {
+      "id": "F-1",
+      "label": "F-1 通知取得/state反映",
+      "classification": "実施",
+      "reason": "2 owner、background inbox修正が4製品fileへ波及。modeを保ちowner2→1",
+      "followup": "[#919](https://github.com/KingYoSun/kukuri/issues/919) → [#920](https://github.com/KingYoSun/kukuri/issues/920)"
+    },
+    {
+      "id": "RT-1",
+      "label": "RT-1 CN Dome transfer",
+      "classification": "実施",
+      "reason": "assignment→owner activation→CN activateが2入口で重複。各3 helper callsite2→1",
+      "followup": "[#921](https://github.com/KingYoSun/kukuri/issues/921) → [#922](https://github.com/KingYoSun/kukuri/issues/922)"
+    },
+    {
+      "id": "MV-1",
+      "label": "MV-1 Dome transition attempt",
+      "classification": "実施",
+      "reason": "ack喪失fixの波及。元hookのprotocol state直接更新9→0、専用owner1",
+      "followup": "[#923](https://github.com/KingYoSun/kukuri/issues/923) → [#924](https://github.com/KingYoSun/kukuri/issues/924)"
+    },
+    {
+      "id": "C-CN-1",
+      "label": "C-CN-1 indexer source解決",
+      "classification": "実施",
+      "reason": "source検証とscan/metrics/2storeを同ownerが所有。source依存6→2",
+      "followup": "[#925](https://github.com/KingYoSun/kukuri/issues/925) → [#926](https://github.com/KingYoSun/kukuri/issues/926)"
+    },
+    {
+      "id": "F-2",
+      "label": "F-2 route/Column再抽出",
+      "classification": "延期",
+      "reason": "既存分離からさらに縮める正本/依存を未立証",
+      "followup": "新たな具体的変更圧力で再評価"
+    },
+    {
+      "id": "F-4",
+      "label": "F-4 runtimeApi全面分割",
+      "classification": "延期",
+      "reason": "25変更commitだけで取り違え/契約漏れとの因果を示せない",
+      "followup": "domain単位の必要性を確認後"
+    },
+    {
+      "id": "RT-2",
+      "label": "RT-2 startup全面集約",
+      "classification": "延期",
+      "reason": "ClientHost/同意/復元の抽出は実施済み",
+      "followup": "新しい共通判断の重複発生時"
+    },
+    {
+      "id": "MV-2",
+      "label": "MV-2 physics/budget分割",
+      "classification": "延期",
+      "reason": "同じauthority stateを分ける成果が未立証",
+      "followup": "state依存による変更阻害時"
+    },
+    {
+      "id": "C-DATA-1",
+      "label": "C-DATA-1 blob cache policy",
+      "classification": "延期",
+      "reason": "policy同居は観測、変更摩擦の独立証拠不足",
+      "followup": "次回cache policy変更時"
+    },
+    {
+      "id": "C-DATA-3",
+      "label": "C-DATA-3 row mapping",
+      "classification": "延期",
+      "reason": "parity/subtrait既設、NULL不具合が同居に起因する証拠なし",
+      "followup": "domain mappingの具体的摩擦時"
+    },
+    {
+      "id": "C-CN-2",
+      "label": "C-CN-2 admin guard",
+      "classification": "延期",
+      "reason": "HTTP否定経路保護不足、現行error/検証順に意味の差",
+      "followup": "admin変更時のcharacterizationから"
+    },
+    {
+      "id": "H-01",
+      "label": "H-01 CN connectivity runner",
+      "classification": "延期",
+      "reason": "同意変更圧力はあるが2 identity modeとcleanupを保つ成果未確定",
+      "followup": "次のCN scenario変更時"
+    },
+    {
+      "id": "H-02",
+      "label": "H-02 desktop smoke runner",
+      "classification": "延期",
+      "reason": "Dome step増加、現行DSL集約による具体的漏れ未観測",
+      "followup": "次のDome scenario変更時"
+    },
+    {
+      "id": "F-3",
+      "label": "F-3 旧test/mock/store/view分割",
+      "classification": "却下",
+      "reason": "既に実施済み。旧follow-upを再起票しない",
+      "followup": "現行境界維持"
+    },
+    {
+      "id": "RT-3",
+      "label": "RT-3 legacy identity撤去",
+      "classification": "却下",
+      "reason": "sunset条件と鍵保持契約に反する",
+      "followup": "任意cleanupにしない"
+    },
+    {
+      "id": "MV-3",
+      "label": "MV-3 client/host guard統合",
+      "classification": "却下",
+      "reason": "preflightとauthority再検証は別責務",
+      "followup": "両側guard維持"
+    },
+    {
+      "id": "C-DATA-2",
+      "label": "C-DATA-2 core/peer再整理",
+      "classification": "却下",
+      "reason": "既済の境界整理、secret/fetch policyの差を保持",
+      "followup": "再抽象化しない"
+    },
+    {
+      "id": "H-03",
+      "label": "H-03 waiter/test/slow再分割",
+      "classification": "却下",
+      "reason": "domain分割/poll共通化/slow laneは実施済み",
+      "followup": "現行検証網維持"
+    },
+    {
+      "id": "H-04",
+      "label": "H-04 Metaverse実iroh失敗",
+      "classification": "別種別",
+      "reason": "2 Nightlyと現行Windowsで同じmanifest未取得を再現",
+      "followup": "fix #927 / PR #931 完了。欠落だけをtyped outcomeへ分類し、不正参照・署名errorは伝播。"
+    },
+    {
+      "id": "C-CN-3",
+      "label": "C-CN-3 capability文書",
+      "classification": "別種別",
+      "reason": "既にAvailableへ昇格したcapabilityを規範がPlanned3件と記載",
+      "followup": "docs #928 / PR #930 完了。Availableと配備readinessを区別。製品状態変更なし。"
+    }
+  ],
+  "known_limitations": [
+    {
+      "id": "native-long-press",
+      "status": "not_measured",
+      "description": "方向キー到達と姿勢入力/通常input ownershipは確認。長押し変位、fullmode中移動、実audio/他peer/CPU-GPU定量は未測定。",
+      "evidence": "docs/ui-reviews/2026-09-08-issue-924-transition-owner.md"
+    },
+    {
+      "id": "native-fullscreen-suspension",
+      "status": "pre_existing",
+      "description": "fullmode開始でvisible=false/suspended=trueとなる状態はbefore元session cold restartでも再現。今回のRegressionではなく、修正済みとしない。",
+      "evidence": "docs/ui-reviews/2026-09-08-issue-924-transition-owner.md"
+    },
+    {
+      "id": "ratchet-stale-caps",
+      "status": "recorded",
+      "description": "縮小note3件は実測と許容上限を別々に保存。既存ratchetの値を変更せず、未使用容量を今回の構造成果と混同しない。",
+      "evidence": "docs/progress/2026-09-08-872-refactoring-campaign-phase-4.md"
+    }
+  ],
+  "activation_policy": "reviewed baselineがmainに存在し、tracking_issueのCurrent statusがCompleteになって初めて後続checkの確定入力として採用する。未mergeのbranch上の内容は候補である。"
+}


### PR DESCRIPTION
Refs #872。完了した10子と20候補を親の固定AC/INVARへ対応させ、#873が使用する初回comparison baselineを確定します。

- 区分C、Scope revision `2026-09-04-issue-872-refactoring-campaign-v1`。[親完了記録](docs/progress/2026-09-08-872-refactoring-campaign-phase-4.md)へ責務指標・全group・検証・残存制約・rollbackを集約。
- baselineはmain祖先の製品完了commit `e98d2025`を参照。自身のhashを埋め込まず、Phase4のdocs/config merge SHAはIssueの完了evidenceへ別記します。未監査の後続変更を消費しません。
- [baseline](xtask/refactoring-audit-baseline.json)と[Draft-07 schema](docs/schemas/refactoring-audit-baseline.schema.json)。初期signalは規範にあるratchet新規path/許容上限増加の各`>0`に限定し、値は0。履歴/変化量は参考値、他triggerはhuman-only。
- 製品/test/CI実装と既存ratchet値の差分0。#873のcommand・workflow・Issue upsert・scheduleは実装しません。
- oversized: 16件/violation0、schemaと実データPASS、否定11ケース拒否。6group/digest・1556 candidate paths・10 code OID・6metric・10子のhead/merge/CIを独立再現。依存変更なし。
- [親独立監査](https://github.com/KingYoSun/kukuri/pull/941#issuecomment-5575964277)と[記録delta監査](https://github.com/KingYoSun/kukuri/pull/941#issuecomment-5576190881)はPASS。適合6/未分類0/不適合0、具体blocker0。最終headのCI成功とmerge対象一致を確認し、#872をComplete/Closed、#873の初期baselineを確定済みへ同期しました。
- native未測定と変更前からのfullscreen停止状態を維持し、全native成功・既存問題修正済みとはしません。
- 初回Fast CIのScoreGame projection退行は[分類記録](https://github.com/KingYoSun/kukuri/pull/941#issuecomment-5576147074)と別fix #942へ保存。関連製品経路はcampaign開始から同一で、具体実行順は未確定。local単発+20回PASSをCI再現成功とは扱わず、製品/testの変更やassertion弱体化も行っていません。既知の未解消事項としてbaselineと完了記録に保持します。
- 最終head初回browser実行のColumn再activate観測（63 PASS / 1 FAIL、visual未実行）は別fix #943と親完了evidenceへ保持。artifactではLiveがActiveへ戻っており、scene/runtimeの同時不整合とは断定しません。関係12pathは開始SHAから同一、Windows限定5回はPASS、CIの原因sequenceは未確定です。[独立診断](https://github.com/KingYoSun/kukuri/pull/941#issuecomment-5576353473)後、同headの失敗jobだけを再検証し、browser64・visual14の成功を確認しました。原因修正済みとは扱いません。

最終結果: 監査head `8d03a7ac`、Fast34167073580（browserのみattempt2）・Linux Package34167073522・GitGuardianの全11 checks SUCCESS。Rust910＋harness22 PASS、既存skip4。merge `188c1df4ab81301a6eafb40645ffb24a4aaa931e`の4pathは監査headと完全一致し、#872の全AC/INVARと完了evidenceを同期してCloseしました。#873はAC1のみ完了、command/workflow/scheduleは未実装です。
