### PR TITLE
[codex][feature] リファクタリング監査の週次判定とIssue集約を追加

### DIFF
--- a/.github/workflows/kukuri-refactoring-audit-test.yml
+++ b/.github/workflows/kukuri-refactoring-audit-test.yml
@@ -1,0 +1,54 @@
+name: Kukuri Refactoring Audit Tests
+
+on:
+  pull_request:
+    paths:
+      - 'scripts/refactoring-audit/**'
+      - 'xtask/**'
+      - 'docs/schemas/refactoring-audit-baseline.schema.json'
+      - '.github/workflows/kukuri-refactoring-audit*.yml'
+      - '.cargo/config.toml'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  contracts:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.92.0
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: refactoring-audit-light
+      - run: python -m pip install -r scripts/refactoring-audit/requirements.txt
+      - run: cargo build --locked -p xtask --no-default-features
+      - name: Git fixture and real CLI contracts
+        env:
+          KUKURI_AUDIT_XTASK: ${{ github.workspace }}/target/debug/xtask
+        run: python -m unittest discover -s scripts/refactoring-audit -p 'test_*.py'
+      - run: node --test scripts/refactoring-audit/upsert.test.mjs
+      - run: cargo test --locked -p xtask --no-default-features
+      - run: cargo clippy --locked -p xtask --all-targets --no-default-features -- -D warnings
+      - name: Evaluate current repository baseline
+        run: cargo run --locked --quiet -p xtask --no-default-features -- refactoring-audit-check
+      - name: Workflow lint
+        uses: docker://rhysd/actionlint:1.7.7
+        with:
+          args: .github/workflows/kukuri-refactoring-audit.yml .github/workflows/kukuri-refactoring-audit-test.yml

--- a/.github/workflows/kukuri-refactoring-audit.yml
+++ b/.github/workflows/kukuri-refactoring-audit.yml
@@ -1,0 +1,90 @@
+name: Kukuri Refactoring Audit
+
+on:
+  schedule:
+    - cron: '0 0 * * 1'
+  workflow_dispatch:
+    inputs:
+      force_audit:
+        description: '人間判断のtriggerで監査を推奨する'
+        type: boolean
+        default: false
+      reason:
+        description: '手動理由（force_audit=trueでは必須）'
+        type: string
+        default: ''
+
+permissions:
+  contents: read
+
+# All scheduled/manual/rerun writers share this lock, across baselines.
+concurrency:
+  group: kukuri-refactoring-audit-upsert
+  cancel-in-progress: false
+
+jobs:
+  check:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      audit_required: ${{ steps.check.outputs.audit_required }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+          cache: pip
+          cache-dependency-path: scripts/refactoring-audit/requirements.txt
+      - name: Install schema validator
+        run: python -m pip install -r scripts/refactoring-audit/requirements.txt
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.92.0
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: refactoring-audit-light
+      - name: Read-only recommendation
+        id: check
+        env:
+          AUDIT_FORCE: ${{ inputs.force_audit }}
+          AUDIT_REASON: ${{ inputs.reason }}
+        run: python scripts/refactoring-audit/workflow_check.py
+      - uses: actions/upload-artifact@v4
+        if: steps.check.outputs.audit_required == 'true'
+        with:
+          name: refactoring-audit-result
+          path: ${{ runner.temp }}/refactoring-audit.json
+          if-no-files-found: error
+          retention-days: 7
+
+  upsert:
+    needs: check
+    if: github.ref == 'refs/heads/main' && needs.check.result == 'success' && needs.check.outputs.audit_required == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+          sparse-checkout: scripts/refactoring-audit
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - uses: actions/download-artifact@v4
+        with:
+          name: refactoring-audit-result
+          path: ${{ runner.temp }}/refactoring-audit
+      - name: Create or update one open audit issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          AUDIT_RESULT: ${{ runner.temp }}/refactoring-audit/refactoring-audit.json
+        run: node scripts/refactoring-audit/upsert.mjs "$AUDIT_RESULT"

--- a/docs/README.md
+++ b/docs/README.md
@@ -42,7 +42,7 @@
 - Issueの起票、scope固定、計画、実装、PR、独立監査、Close/Reopen: `docs/runbooks/issue-lifecycle.md`
 - 実装計画の要否、粒度と記録形式: root `PLANS.md`
 - path別validationとリファクタリング境界: root `REFACTORING.md`
-- 初回campaignの完了記録: `docs/progress/2026-09-08-872-refactoring-campaign-phase-4.md`。比較起点と初期signalは `xtask/refactoring-audit-baseline.json`、形状は `docs/schemas/refactoring-audit-baseline.schema.json`。継続checkの実装・有効化は #873 が所有する。
+- 初回campaignの完了記録: `docs/progress/2026-09-08-872-refactoring-campaign-phase-4.md`。比較起点と初期signalは `xtask/refactoring-audit-baseline.json`、形状は `docs/schemas/refactoring-audit-baseline.schema.json`。継続checkは `cargo xtask refactoring-audit-check`、週次／manualの発火判定と監査Issueの集約は `Kukuri Refactoring Audit`。実行・復旧・review付きbaseline更新は `docs/runbooks/dev.md` の「リファクタリング監査の発火要否」、#873の証跡は `docs/progress/2026-09-08-873-refactoring-audit-trigger.md`。
 - GitHub Issue / PRは追跡面。既存仕様と今回の変更要求の区別は次節に従う。
 
 ## 正本と変更要求

--- a/docs/progress/2026-09-08-873-refactoring-audit-trigger.md
+++ b/docs/progress/2026-09-08-873-refactoring-audit-trigger.md
@@ -1,0 +1,97 @@
+# #873 リファクタリング監査トリガーの継続チェック
+
+## 状態・固定範囲
+
+- 記録時点の状態: 実装済み、全体validationの一部が実行中。固定PR headの独立監査・CI・merge後確認の最終結果は [#873 Current status](https://github.com/KingYoSun/kukuri/issues/873) と対応PRのコメントへ結ぶ。この記録だけで未完了工程をPASSと判断しない。
+- Scope revision: `2026-09-04-issue-873-refactoring-audit-trigger-v1`。
+- リスク区分: C。正本は [#873 Current status](https://github.com/KingYoSun/kukuri/issues/873) のAC-1〜5／INVAR-1〜3／INV-1〜5／TR-1〜5。
+- 実装開始HEAD: `188c1df4ab81301a6eafb40645ffb24a4aaa931e`。
+- 比較起点: `e98d2025e01332a6dbd4b13f5f4712654a931c65`。#872のbaseline公開mergeと混同せず、baseline JSON／schema／ratchet設定は変更していない。
+- 依存: #871が規範、#872が初期baseline、本Issueが継続check／Issue集約を所有する。生成Issueは読み取り中心の有限監査から始め、個別実装を自動で開始しない。
+- 今回の承認: 計画と実装、commit／PR／mergeまで。区分Cの独立監査PASSと必須CI成功をmerge条件とする。
+
+## 実装判断
+
+1. 判定の正本は `scripts/refactoring-audit/check.py`。Python標準のGit subprocess／regex／日時処理と固定した `jsonschema` のDraft-07検証を使う。Rustの `refactoring_audit_check` はshellを介さず同じ処理へ引数を渡す。Python sourceは常に実行するcheckoutに固定し、baseline・製品情報は評価commitのGit objectから取得する。
+2. 既存xtaskのharness／tokioを既定有効featureへ移す。週次は `--no-default-features` で軽量xtaskだけをcompileする。標準commandとscenarioの既定挙動は維持する。依存追加はPython validatorのみで、Rust lockfileは不変。
+3. 自動signalは保存済み2項目、各 `> 0`、any。現在のratchetに対する新規path数／上限増加件数を保存上限から計測する。commit数・hotspot等を新しい閾値へ昇格させない。
+4. schemaに加え、commit／祖先、code tree、source policy blob、候補集合、groupのbefore/after集合とdigest、ratchet snapshot、実測行数、計測scope付き構造metric、候補分類を検証する。子IssueのCIや製品テストを週次で再実行しない。
+5. `workflow_check.py` がforce／reasonを引数へ渡し、成功したJSONのみをrunner temp、boolのjob output、summaryへ公開する。checkにtokenを渡さない。入力理由をshellやworkflow commandへ埋め込まない。
+6. Issue writeの正本は `upsert.mjs::upsert`。全ページのOpen marker検索、PR除外、重複検出、機械領域更新を一か所に置き、REST adapterは自動retryしない。workflow全体を共通concurrency groupで直列化する。人間のscope・判断本文と機械観測を分け、scopeを自動拡張しない。
+7. 週次workflowはmain限定、checkはcontents:read、upsert jobだけissues:write。既存nightly／required check設定は変更せず、変更時のtestは別の `Kukuri Refactoring Audit Tests` に置く。
+
+当初計画の新規Rust判定module案は、軽量実行とbaselineに保存されたPython互換regexの再現性から「Rust入口＋Python判定」に具体化した。fixture／CLI／schema testsはPython、API mockはNodeで実装し、Rustは既存xtaskの回帰とfeature分離を検証する。固定scopeや品質条件の削除はない。
+
+## 変更前の証拠
+
+### Feature Data Classification
+
+- Feature 名: 開発支援用のリファクタリング監査発火判定・Issue集約。
+- Durable / Transient: reviewed baselineとGitHub Issueはdurable。計測結果は再生成可能で、workflow間のartifactは7日保持。Actions summary/logはrepositoryのActions保持設定に従う。tokenはwrite stepの環境変数のみ。
+- Canonical Source: baseline/schemaと比較対象のGit commit。監査scope・人間判断はtracking Issue。判定はこれらを自動変更しない。
+- Replicated?: kukuriのreplication対象外。GitHubにはcommit ID、技術的なpath／signal、手動理由、監査の記録を送る。製品利用者の投稿・identity・秘密値は入力にしない。
+- Rebuildable From: baseline/current commit、評価日時、force/reasonからJSONとMarkdownを再生成する。
+- Public Replica / Private Replica / Local Only: 製品replicaなし。ローカルではGit read/stdout、workflowではGitHubのrepository権限内でsummary／Issueを扱う。
+- Gossip Hint 必要有無: 不要。
+- Blob 必要有無: 製品blob不要。Git object readとActionsの一時artifactのみ。
+- SQLite projection 必要有無: 不要。
+- 必須 contract: 計画で固定したGit fixture、schema／意味検証、no-write、実CLI exit、API mock、workflow adapterの契約。
+- 必須 scenario: 製品scenarioの追加なし。Git履歴→判定→summary→guarded upsertを専用契約testで確認する。
+
+CodeGraphで `xtask/src/main.rs`、`oversized.rs`、`scenario.rs`、`rust.rs`、`exec.rs::artifacts_dir` とcallerを確認した。開始HEADにはcommandと専用workflowがなく、baselineとschemaだけが存在した。
+
+先にGit fixture契約を置き、`python -m unittest discover -s scripts/refactoring-audit -p test_check.py` が `check.py` 未実装で失敗した。upsertも契約testを先に置き、`node --test scripts/refactoring-audit/upsert.test.mjs` がmodule不存在で失敗した。実装後、同じsequenceを正常／異常／禁止writeで検証した。
+
+## AC / INVAR と証跡
+
+| 条件 | 実装・検証 |
+| --- | --- |
+| AC-1 / AC-5 | #872のbaseline/schemaは維持。`validate_baseline` のschema・集合・metric検証、`test_baseline_corruption_semantics_and_unknown_schema`、`test_reviewed_baseline_update_is_accepted_without_automatic_advancement`、runbookのreviewed更新contract |
+| AC-2 | `check` / `render`、Git fixtureで未commit差分排除・再現性、各signal単独／複合、真偽、JSON／Markdown、実CLI exit。`test_threshold_boundaries_and_invalid_negative` は0閾値に存在しない未満ケースを正のfixture閾値で検証 |
+| AC-3 | `workflow_check.main`、週次／manual専用workflow、main限定、force理由必須。`test_arguments_preserve_manual_input_and_outputs_are_fixed`、`test_failure_never_publishes_success_output_or_artifact`、actionlint |
+| AC-4 | `upsert` のfalse早期return、marker全ページ検索、create/update/idempotency、複数match拒否、検索失敗とcreate応答喪失後rerunのAPI mock |
+| INVAR-1 | 判定はGit object readのみ。workflow adapterのwriteはrunner temp/output/summaryのみ。upsertは機械領域だけを更新。baseline／product codeのwrite callerなし |
+| INVAR-2 | trueもexit 0。既存nightlyとrequired設定は差分0。`cargo tree -p xtask --no-default-features --depth 1` にharness／tokio／製品crateなし。週次で製品build／testなし |
+| INVAR-3 | check/write job権限分離、mainの同一SHA checkout、tokenはwrite stepのみ、checkout credentials非保持。理由・pathを引数／JSONとして渡す。REST adapterのJSON送信・no-retry test |
+
+## 固定surface inventoryとsink逆引き
+
+| ID | 入口・trigger／shared helper | 読み書き・sink／guard | transitionと証跡 |
+| --- | --- | --- | --- |
+| INV-1 | `main.rs` command → `refactoring_audit_check` → `check.py::main/check/validate_baseline`。local／workflowは同じ入口 | git読込／stdout。異常では結果を出さずnonzero。HEAD/index/worktree/baseline不変 | TR-1〜3。Git fixture・real CLI・dirty/untracked・schema/metric/非祖先/取得失敗 |
+| INV-2 | schedule／dispatch → `workflow_check.main` → 上記command | main限定、成功した結果だけtemp artifact/summary/bool output。通常contents:read | TR-1〜4。adapter正負test、actionlint、専用CIの実repo評価 |
+| INV-3 | check job成功かつtrue → upsert job → `upsert.mjs::main/upsert` → `githubApi.create/update` | marker検索後だけPOST/PATCH。共通concurrency、複数match／管理領域破損はwrite 0。人間領域は保持 | TR-2/4/5。create/update/pagination/idempotency/duplicate/search失敗/応答喪失/403 |
+| INV-4 | `audit_required=false` → summary。`upsert(false)`も早期return | Issue API呼出0、baseline/commit変更0 | TR-1。Python false adapterとNode no-write test |
+| INV-5 | 完了監査後のreview付きbaseline更新PR → 次回check | check自身にbaselineの書込みなし。schema＋意味検証、更新手順と監査証拠のreview | TR-5。reviewed update fixtureとread-only前後比較 |
+
+追加された製品入口は0。新規入口はINV-1 command、INV-2のschedule/dispatch、INV-3共有upsert。既存 `artifacts_dir` のcallerは `scenario.rs::e2e_smoke` のみで、scenarioと同じharness featureへ限定した。
+
+Issue mutation sinkの逆引きは `githubApi` のPOST/PATCH → `upsert` のcreate/update分岐 → CLI main → 専用workflowのupsert step。testからの呼出はmockのみ。全実writeがschema/true/marker guardを通る。false／判定errorはworkflow jobもskipし、API検索失敗／複数markerはcreate分岐へ進めない。retryは新しいworkflow runとして検索から再開し、同一run内の無条件再送はない。
+
+## Validation
+
+実施済み:
+
+- Python fixture／実xtask CLI／workflow adapter／実JSON→Node接続: 計18 tests PASS（Windows、追加・変更箇所はtargeted再実行）。初回のWindows fixtureで改行を含むファイル名が作成不能だったため、Windowsは空白／日本語／shell類似文字、Linuxは追加で改行を含むpathを検証するよう修正した。
+- Node API mock／REST adapter: 10 tests PASS。
+- `cargo test -p xtask --no-default-features`: 44 PASS、既存AppImage署名metadata test 1 ignored（今回追加のskipなし）。
+- `cargo clippy -p xtask --all-targets --no-default-features -- -D warnings`: PASS。
+- actionlint 1.7.7: 専用2workflow PASS。
+- 現行baselineの実Git評価: 2signalとも0、false、exit 0。比較起点と公開mergeを区別したJSON/Markdownを確認。
+
+- `cargo xtask check` PASS（non-CN Rust clippy、operator-neutrality、Tauri compile、frontend lint/typecheck）。
+- `cargo xtask test` のnon-CN／非harness部分: 886 PASS、既存skip 4。harness／doctest／frontendは記録時点で未完了。
+- `git diff --check`、新規文書の相対リンク、Python依存整合はPASS。
+
+記録時点の未完了／再実行対象:
+
+- 上記全体testの残り、PR CI、PR head独立監査、merge後確認。
+- `cargo xtask oversized-files` は全体testと並行したbuildで、実行中 `target/debug/xtask.exe` の置換がWindowsのファイルロックに拒否された（OS error 5）。ratchet判定には未到達。全体test完走後に同commandを再実行する。製品の検証失敗や成功へ読み替えない。
+
+## 独立監査・完了条件
+
+固定PR headとAC/INVAR evidenceを別担当へ渡し、全INV/TR、Issue sinkの全caller、false/error/retry/duplicate、権限、baseline非更新を独立確認する。FAIL/INCONCLUSIVEは解消し、差分変更後はdeltaもPASSにする。PRは `Refs #873` とし、必須CI成功と独立監査PASS後にmerge、対象tree一致を確認してからIssueをComplete/Closeする。
+
+## 残存事項
+
+既存baselineの採用signalや規範は変更していない。新規閾値、LLM判定、Issue乱造、製品refactor、既存required CIの緩和は対象外。現時点の未完了項目は上記validationと独立監査／merge工程であり、成功済みとして扱わない。

--- a/docs/runbooks/dev.md
+++ b/docs/runbooks/dev.md
@@ -68,6 +68,51 @@ cargo xtask desktop-visual-test
 
 日常の製品変更は `cargo xtask check` + `cargo xtask test` を起点とし、変更pathと影響に応じた必須項目は [検証マトリクス](../../REFACTORING.md#path別検証マトリクス) で選ぶ。文書の誤字など区分Aは同節の対象確認を使う。UIの証跡は [ADR 0014](../adr/0014-uiux-dev-flow.md)、視覚baselineの更新方法は次節を参照する。
 
+## リファクタリング監査の発火要否（#873）
+
+`cargo xtask refactoring-audit-check` は、監査済みbaseline以後にratchetの新規path登録または許容上限増加があるかを読み取り専用で判定する。判定結果のtrue／falseはともにexit 0で、破損baseline・commit不足・非祖先・git取得失敗はnonzero。既存 `oversized-files` のCIゲートとは別のコマンドである。
+
+Python 3.13とschema validatorを準備する（Linuxでは必要に応じて `python` を `python3` に置き換え、venvを使用する）。判定自身は依存をinstallせず、GitHub APIも呼ばない。
+
+```bash
+python -m pip install -r scripts/refactoring-audit/requirements.txt
+cargo xtask refactoring-audit-check
+cargo xtask refactoring-audit-check --format json --now 2026-09-09T00:00:00Z
+cargo xtask refactoring-audit-check --force-audit --reason "release安定化前の責務確認"
+```
+
+Python実行ファイルは `KUKURI_AUDIT_PYTHON` で指定できる。未指定時はWindowsで `python`、他OSで `python3`。`--repo` はfixture等のGit repository、`--current` は評価するcommit（既定HEAD）、`--now` はtimezone付き評価日時（既定UTC現在時刻）。同じ入力ではJSONとMarkdownは同一になる。入力は引数で渡し、shellのコードとして展開しない。
+
+baselineは評価commit内の `xtask/refactoring-audit-baseline.json` から読み、その `baseline_commit` と評価commitの確定blobを比較する。未commit／未追跡の変更は含めない。schemaとcommit祖先関係、保存した集合／digest、ratchet上限、計測scope付きmetricを検証する。baselineを検証するために `audit_start_commit` までの履歴も必要となる。shallow cloneで履歴不足ならfetchして再実行し、比較起点を動かして回避しない。
+
+発火は `ratchet_new_paths > 0 OR ratchet_increased_caps > 0` のみ。縮小・削除は発火せず、実測行数と許容上限を区別する。commit数・変更path数・hotspot・経過日は観測専用で自動閾値を持たない。変更path数は比較起点以後の履歴で一度でも変更された手書きpathの集合、hotspotはpathごとの変更commit数（mergeはfirst parentとの差分、rename追跡なし、binaryはpath変更として数える）。手書きpathの対象はbaselineのextension／除外設定に従う。
+
+週次実行は `Kukuri Refactoring Audit`、毎週月曜00:00 UTC（日本時間09:00）。手動実行はmainを選び、必要なら `force_audit=true` と空白だけではない `reason` を指定する。forceでもbaseline異常を迂回しない。release／milestone／変更摩擦／互換経路のsunsetなど、人間判断の項目はsummaryと監査Issueに残す。
+
+workflowは以下の軽量経路を使い、harnessと製品crateをbuildしない。標準xtaskではharness featureが既定有効で、既存scenario等の挙動は維持する。
+
+```bash
+cargo run --locked --quiet -p xtask --no-default-features -- refactoring-audit-check
+```
+
+false時はsummaryだけで終わり、GitHub Issueへのwriteは0件。true時だけ専用jobがOpen Issueの固定marker `kukuri-refactoring-audit:v1` を全ページ探索し、一件を作成または最新の機械管理領域だけ更新する。人間が書いたscope／AC／判断本文は更新対象にしない。全schedule／manual／rerunは共通concurrency groupで直列化するため、Issue write scriptを別経路で同時実行しない。
+
+検索／API失敗は新規作成で回避しない。応答喪失時はActionsログとOpen Issueを確認してworkflowを再実行し、既存markerへ収束させる。同じmarkerのOpen Issueが複数、または管理領域が欠落／重複した場合はwriteせず失敗する。担当者が履歴・scopeを確認して正しい一件と管理領域を確定してから再実行する。既存IssueのClose／削除／scope拡張をworkflowに任せない。
+
+baseline更新は監査完了後の独立review付きPRだけで行う。比較起点・監査日・採用signal・根拠・集合／metric・完了証拠を再計測して更新し、schema／意味検証の成功とtracking IssueのCompleteを確認する。baseline公開merge SHAと製品比較起点は分けて記録し、定期checkの成功だけでbaselineを前進させない。初期入力は [#872完了記録](../progress/2026-09-08-872-refactoring-campaign-phase-4.md)、実装と証跡は [#873作業記録](../progress/2026-09-08-873-refactoring-audit-trigger.md)。
+
+変更時のtargeted validation（週次runでは実行しない）:
+
+```bash
+python -m unittest discover -s scripts/refactoring-audit -p 'test_*.py'
+node --test scripts/refactoring-audit/upsert.test.mjs
+cargo test --locked -p xtask --no-default-features
+cargo clippy --locked -p xtask --all-targets --no-default-features -- -D warnings
+actionlint .github/workflows/kukuri-refactoring-audit.yml .github/workflows/kukuri-refactoring-audit-test.yml
+```
+
+`KUKURI_AUDIT_XTASK` にbuild済みxtask実行ファイルの絶対pathを指定すると、PythonのCLI fixture testは実xtask経由で終了コードと出力を検証する。`Kukuri Refactoring Audit Tests` はこの経路と実repository baselineも検証する。基準値・workflowだけの変更でもこの専用test workflowが動く。
+
 ## 視覚回帰 (visual regression)
 
 WP-H8（CSS 改名・整理）の安全網として、主要 14 サーフェスを Playwright `toHaveScreenshot` で撮って baseline と比較する（`apps/desktop/tests/playwright/visual.spec.ts`）。

--- a/scripts/refactoring-audit/.gitignore
+++ b/scripts/refactoring-audit/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+.venv/

--- a/scripts/refactoring-audit/check.py
+++ b/scripts/refactoring-audit/check.py
@@ -1,0 +1,264 @@
+"""Read-only audit recommendation. All product inputs come from Git objects."""
+import argparse
+from collections import Counter
+from datetime import date, datetime, timezone
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+
+from jsonschema import Draft7Validator, FormatChecker
+
+ROOT = Path(__file__).resolve().parents[2]
+BASELINE = "xtask/refactoring-audit-baseline.json"
+SCHEMA = ROOT / "docs/schemas/refactoring-audit-baseline.schema.json"
+
+
+class AuditError(Exception):
+    """An invalid input or failed read, never a successful recommendation."""
+
+
+def require(condition, message):
+    if not condition:
+        raise AuditError(message)
+
+
+def git(root, *args):
+    result = subprocess.run(
+        ["git", "--no-pager", *args], cwd=root, capture_output=True,
+        env={**os.environ, "GIT_NO_REPLACE_OBJECTS": "1", "GIT_OPTIONAL_LOCKS": "0"},
+    )
+    require(result.returncode == 0, f"git_read_failed: {args[0]}: {result.stderr.decode('utf-8', errors='replace').strip()}")
+    return result.stdout.decode("utf-8")
+
+
+def blob(root, commit, path):
+    return git(root, "show", f"{commit}:{path}")
+
+
+def oid(root, commit, path):
+    return git(root, "rev-parse", "--verify", f"{commit}:{path}").strip()
+
+
+def paths_at(root, commit):
+    return git(root, "ls-tree", "-r", "--name-only", "-z", commit).rstrip("\0").split("\0")
+
+
+def digest(paths):
+    return hashlib.sha256(("\n".join(sorted(paths)) + "\n").encode("utf-8")).hexdigest()
+
+
+def json_value(text):
+    def unique_object(pairs):
+        result = {}
+        for key, value in pairs:
+            require(key not in result, f"duplicate_json_key: {key}")
+            result[key] = value
+        return result
+    return json.loads(text, object_pairs_hook=unique_object)
+
+
+def unique(items, key, label):
+    values = [item[key] for item in items]
+    require(len(values) == len(set(values)), f"duplicate_{label}")
+
+
+def candidate(path, scope):
+    return (path.rsplit(".", 1)[-1].lower() in scope["extensions"]
+            and path not in scope["excluded_exact_paths"]
+            and not any(path.startswith(prefix) for prefix in scope["excluded_path_prefixes"]))
+
+
+def ratchet(text):
+    value = json_value(text)
+    require(isinstance(value, dict) and set(value) == {"files"} and isinstance(value["files"], list), "invalid_ratchet")
+    result = {}
+    for entry in value["files"]:
+        require(isinstance(entry, dict) and set(entry) == {"path", "lines"}, "invalid_ratchet_entry")
+        path, lines = entry["path"], entry["lines"]
+        require(isinstance(path, str) and path and not path.startswith("/") and "\\" not in path
+                and ".." not in path.split("/") and not re.match(r"^[A-Za-z]:", path)
+                and "\0" not in path, "invalid_ratchet_path")
+        require(type(lines) is int and lines >= 1000, "invalid_ratchet_cap")
+        require(path not in result, "duplicate_ratchet_path")
+        result[path] = lines
+    return result
+
+
+def line_count(text):
+    # str::lines: LF delimiter, optional CR, no extra line for a final LF.
+    return len(text.split("\n")) - (1 if text.endswith("\n") else 0) if text else 0
+
+
+def metric_value(root, commit, metric, side):
+    total = 0
+    for path in metric[f"{side}_paths"]:
+        text = blob(root, commit, path)
+        scope = metric["measurement_scope"]
+        if scope["kind"] == "struct_fields":
+            symbol = scope[f"{side}_symbol"]
+            # Current baseline describes named Rust structs, not arbitrary code execution.
+            match = re.search(r"\bstruct\s+" + re.escape(symbol) + r"\b[^\{]*\{([^}]*)\}", text, re.S)
+            require(match is not None, f"metric_struct_missing: {metric['id']}:{symbol}")
+            text = match[1]
+        total += len(re.findall(metric["measurement_regex"], text, re.M))
+    return total
+
+
+def validate_baseline(root, current, baseline):
+    schema = json_value(SCHEMA.read_text(encoding="utf-8"))
+    validator = Draft7Validator(schema, format_checker=FormatChecker())
+    errors = list(validator.iter_errors(baseline))
+    require(not errors, "baseline_schema_invalid: " + "; ".join(error.message for error in errors[:3]))
+    base, start = baseline["baseline_commit"], baseline["audit_start_commit"]
+    git(root, "cat-file", "-e", f"{base}^{{commit}}")
+    git(root, "cat-file", "-e", f"{start}^{{commit}}")
+    git(root, "merge-base", "--is-ancestor", start, base)
+    git(root, "merge-base", "--is-ancestor", base, current)
+    for path, expected in baseline["code_tree_oids"].items():
+        require(oid(root, base, path) == expected, f"baseline_tree_mismatch: {path}")
+
+    scope = baseline["scope"]
+    require(scope["source_policy"] == "xtask/src/oversized.rs::should_scan_oversized_file", "unsupported_source_policy")
+    require(oid(root, base, "xtask/src/oversized.rs") == scope["source_policy_blob"], "source_policy_blob_mismatch")
+    before, after = paths_at(root, start), paths_at(root, base)
+    candidates = [path for path in after if candidate(path, scope)]
+    require(len(candidates) == scope["tracked_candidate_count"]
+            and digest(candidates) == scope["tracked_candidate_paths_sha256"], "candidate_population_mismatch")
+    unique(scope["groups"], "id", "group")
+    for group in scope["groups"]:
+        selector = re.compile(group["selector_regex"])
+        old = {path for path in before if selector.search(path)}
+        new = {path for path in after if selector.search(path)}
+        require(len(old) == group["before_count"] and len(new) == group["member_count"]
+                and digest(new) == group["member_paths_sha256"]
+                and new - old == set(group["added_paths"])
+                and old - new == set(group["removed_paths"]), f"group_population_mismatch: {group['id']}")
+
+    oversized = baseline["oversized"]
+    require(oid(root, base, oversized["ratchet_path"]) == oversized["ratchet_blob"], "ratchet_blob_mismatch")
+    caps = ratchet(blob(root, base, oversized["ratchet_path"]))
+    unique(oversized["files"], "path", "oversized_path")
+    require(oversized["count"] == len(oversized["files"]), "oversized_count_mismatch")
+    require(caps == {item["path"]: item["ratchet_lines"] for item in oversized["files"]}, "ratchet_snapshot_mismatch")
+    for item in oversized["files"]:
+        require(item["path"] in candidates, "oversized_path_outside_scope")
+        require(line_count(blob(root, base, item["path"])) == item["observed_lines"], "observed_lines_mismatch")
+        require(line_count(blob(root, start, item["path"])) == item["before_lines"], "before_lines_mismatch")
+        require(item["observed_lines"] <= item["ratchet_lines"], "baseline_ratchet_violation")
+    unique(baseline["structural_metrics"], "id", "metric")
+    for metric in baseline["structural_metrics"]:
+        for side, commit in [("before", start), ("after", base)]:
+            require(metric_value(root, commit, metric, side) == metric[side], f"metric_mismatch: {metric['id']}:{side}")
+    unique(baseline["candidates"], "id", "candidate")
+    counts = Counter(item["classification"] for item in baseline["candidates"])
+    for field, label in [("selected", "実施"), ("deferred", "延期"), ("rejected", "却下"), ("other_type", "別種別")]:
+        require(counts[label] == baseline["candidate_counts"][field], "candidate_classification_mismatch")
+    unique(baseline["children"], "issue", "child")
+    return caps
+
+
+def evaluate(value, threshold):
+    require(type(value) is int and value >= 0, "invalid_signal_value")
+    return value > threshold
+
+
+def diagnostics(root, base, current, scope, now, audit_date):
+    history_range = f"{base}..{current}"
+    commits = int(git(root, "rev-list", "--count", history_range).strip())
+    # One numstat row per path/commit, merges compared to first parent; renames
+    # are deletion+addition. Binary rows count as path touches, not lines.
+    history = git(root, "log", "--format=", "--numstat", "-z", "--no-renames",
+                  "--diff-merges=first-parent", "--no-ext-diff", "--no-textconv", history_range, "--")
+    counts = Counter()
+    for row in history.split("\0"):
+        if not row:
+            continue
+        parts = row.split("\t", 2)
+        require(len(parts) == 3, "invalid_git_numstat")
+        path = parts[2]
+        if candidate(path, scope):
+            counts[path] += 1
+    return dict(commits_since_baseline=commits, changed_candidate_paths=len(counts),
+                max_path_change_commits=max(counts.values(), default=0),
+                days_since_audit=(now.date() - date.fromisoformat(audit_date)).days,
+                hotspots=[dict(path=path, commits=count) for path, count in sorted(counts.items(), key=lambda item: (-item[1], item[0]))[:10]])
+
+
+def markdown_text(text):
+    # Keep input visible without allowing it to create HTML markers or tables.
+    return str(text).replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace("|", "&#124;").replace("\r", "").replace("\n", "<br>")
+
+
+def render(result):
+    lines = ["## 監査トリガー判定", "",
+             f"- 比較起点: `{result['baseline_commit']}`", f"- 評価commit: `{result['current_commit']}`",
+             f"- 判定日時: {result['evaluated_at']}", f"- audit_required: `{str(result['audit_required']).lower()}`",
+             f"- 直前の監査／campaign: #{result['tracking_issue']}、規範: #871", "",
+             "| signal | 値 | 閾値 | 発火 | 根拠 |", "| --- | ---: | --- | --- | --- |"]
+    for signal in result["signals"]:
+        lines.append(f"| {signal['id']} | {signal['value']} | > {signal['threshold']} | {str(signal['triggered']).lower()} | {markdown_text(signal['reason'])} |")
+    lines += ["", "### 手動入力", "", markdown_text(result["manual_reason"]) or "指定なし",
+              "", "### 人間による確認項目", ""]
+    lines += [f"- {markdown_text(item)}" for item in result["human_only_triggers"]]
+    lines += ["", "### 対象候補path", ""]
+    lines += [f"- {markdown_text(path)}" for path in result["candidate_paths"]] or ["- 自動候補なし。手動理由から有限scopeを固定する。"]
+    diag = result["diagnostics"]
+    lines += ["", "### 観測情報（自動閾値なし）", "",
+              f"commit数: {diag['commits_since_baseline']}、変更path数: {diag['changed_candidate_paths']}、最大変更commit数: {diag['max_path_change_commits']}、監査後日数: {diag['days_since_audit']}", ""]
+    lines += [f"- {markdown_text(item['path'])}: {item['commits']} commits" for item in diag["hotspots"]]
+    return "\n".join(lines) + "\n"
+
+
+def check(root, current="HEAD", now=None, force=False, reason=""):
+    require(not force or bool(reason.strip()), "force_reason_required")
+    current = git(root, "rev-parse", "--verify", "--end-of-options", f"{current}^{{commit}}").strip()
+    require(re.fullmatch(r"[0-9a-f]{40}", current) is not None, "invalid_current_commit")
+    baseline = json_value(blob(root, current, BASELINE))
+    old = validate_baseline(root, current, baseline)
+    new = ratchet(blob(root, current, baseline["oversized"]["ratchet_path"]))
+    timestamp = datetime.fromisoformat(now.replace("Z", "+00:00")) if now else datetime.now(timezone.utc)
+    require(timestamp.tzinfo is not None, "evaluation_timezone_required")
+    timestamp = timestamp.astimezone(timezone.utc).replace(microsecond=0)
+    require(timestamp.date() >= date.fromisoformat(baseline["audit_date"]), "evaluation_before_audit")
+    new_paths = sorted(new.keys() - old.keys())
+    increased = sorted(path for path in old.keys() & new.keys() if new[path] > old[path])
+    signals = []
+    for name, paths in [("ratchet_new_paths", new_paths), ("ratchet_increased_caps", increased)]:
+        config = baseline["signals"][name]
+        signals.append(dict(id=name, value=len(paths), threshold=config["threshold"],
+                            triggered=evaluate(len(paths), config["threshold"]), reason=config["reason"], paths=paths))
+    result = dict(schema_version=1, baseline_commit=baseline["baseline_commit"], current_commit=current,
+                  tracking_issue=baseline["tracking_issue"], evaluated_at=timestamp.isoformat().replace("+00:00", "Z"),
+                  audit_required=force or any(signal["triggered"] for signal in signals),
+                  force_audit=force, manual_reason=reason, signals=signals,
+                  candidate_paths=sorted(set(new_paths + increased)), human_only_triggers=baseline["human_only_triggers"],
+                  diagnostics=diagnostics(root, baseline["baseline_commit"], current, baseline["scope"], timestamp, baseline["audit_date"]))
+    result["markdown"] = render(result)
+    return result
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", type=Path, default=ROOT)
+    parser.add_argument("--current", default="HEAD")
+    parser.add_argument("--now", help="ISO-8601 timezone-aware evaluation time; default UTC now")
+    parser.add_argument("--force-audit", action="store_true")
+    parser.add_argument("--reason", default="")
+    parser.add_argument("--format", choices=["json", "markdown"], default="markdown")
+    args = parser.parse_args()
+    try:
+        result = check(args.repo, current=args.current, now=args.now, force=args.force_audit, reason=args.reason)
+        output = json.dumps(result, ensure_ascii=False, indent=2) + "\n" if args.format == "json" else result["markdown"]
+        sys.stdout.buffer.write(output.encode("utf-8"))
+        return 0
+    except (AuditError, ValueError, KeyError, TypeError, OSError, re.error) as error:
+        sys.stderr.buffer.write(f"refactoring_audit_error: {error}\n".encode("utf-8"))
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/refactoring-audit/requirements.txt
+++ b/scripts/refactoring-audit/requirements.txt
@@ -1,0 +1,5 @@
+jsonschema==4.25.1
+attrs==26.1.0
+jsonschema-specifications==2025.9.1
+referencing==0.37.0
+rpds-py==2026.6.3

--- a/scripts/refactoring-audit/test_check.py
+++ b/scripts/refactoring-audit/test_check.py
@@ -1,0 +1,225 @@
+"""Observable contracts for the read-only audit command (fixture Git history)."""
+import copy
+import importlib.util
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import sys
+import unittest
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent.parent
+SPEC = importlib.util.spec_from_file_location("audit_check", HERE / "check.py")
+audit = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(audit)
+
+
+class AuditContract(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name)
+        self.git("init", "-q")
+        self.git("config", "user.name", "Fixture")
+        self.git("config", "user.email", "fixture@example.invalid")
+        self.write("sample.rs", "field\n" * 1000)
+        self.write("xtask/src/oversized.rs", "// fixture policy\n")
+        self.ratchet([{"path": "sample.rs", "lines": 1100}])
+        self.base = self.commit()
+        self.baseline = json.loads((ROOT / "xtask/refactoring-audit-baseline.json").read_text(encoding="utf-8"))
+        b = self.baseline
+        b.update(baseline_commit=self.base, audit_start_commit=self.base, audit_date="2026-09-08")
+        b["code_tree_oids"] = {"xtask": self.git("rev-parse", f"{self.base}:xtask").strip()}
+        scope = b["scope"]
+        scope["source_policy_blob"] = self.git("rev-parse", f"{self.base}:xtask/src/oversized.rs").strip()
+        paths = self.git("ls-tree", "-r", "--name-only", self.base).splitlines()
+        scope["tracked_candidate_count"] = len(paths)
+        scope["tracked_candidate_paths_sha256"] = audit.digest(paths)
+        for group in scope["groups"]:
+            group.update(selector_regex="^sample\\.rs$", before_count=1, member_count=1,
+                         member_paths_sha256=audit.digest(["sample.rs"]), added_paths=[], removed_paths=[])
+        b["oversized"].update(count=1, ratchet_blob=self.git("rev-parse", f"{self.base}:xtask/oversized-baseline.json").strip(),
+                              files=[dict(path="sample.rs", before_lines=1000, observed_lines=1000, ratchet_lines=1100)])
+        b["structural_metrics"] = [dict(id="fixture_fields", before=1000, after=1000,
+            before_paths=["sample.rs"], after_paths=["sample.rs"], measurement_regex="^field$",
+            issues=[872], meaning="fixture measurement", measurement_scope=dict(kind="whole_file", before_symbol=None, after_symbol=None))]
+        self.write("xtask/refactoring-audit-baseline.json", json.dumps(b))
+        self.head = self.commit()
+
+    def git(self, *args):
+        return subprocess.check_output(["git", *args], cwd=self.root).decode("utf-8")
+
+    def write(self, path, value):
+        dest = self.root / path
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text(value, encoding="utf-8", newline="\n")
+
+    def ratchet(self, files):
+        self.write("xtask/oversized-baseline.json", json.dumps(dict(files=files)))
+
+    def commit(self):
+        self.git("add", ".")
+        self.git("commit", "-qm", "fixture")
+        return self.git("rev-parse", "HEAD").strip()
+
+    def check(self, **options):
+        return audit.check(self.root, now="2026-09-09T00:00:00Z", **options)
+
+    def test_equal_and_dirty_state_are_read_only_and_deterministic(self):
+        self.write("sample.rs", "dirty\n")
+        self.write("untracked.rs", "untracked\n")
+        before = self.git("status", "--porcelain=v1")
+        first = self.check()
+        self.assertFalse(first["audit_required"])
+        self.assertEqual(first, self.check())
+        self.assertEqual(first["baseline_commit"], self.base)
+        self.assertEqual(first["current_commit"], self.head)
+        self.assertEqual(before, self.git("status", "--porcelain=v1"))
+        self.assertEqual((self.root / "sample.rs").read_text(), "dirty\n")
+
+    def test_new_path_and_increased_cap_trigger_any(self):
+        self.ratchet([dict(path="sample.rs", lines=1101), dict(path="new.rs", lines=1000)])
+        self.write("new.rs", "new\n" * 1000)
+        self.commit()
+        result = self.check()
+        self.assertTrue(result["audit_required"])
+        self.assertEqual([s["value"] for s in result["signals"]], [1, 1])
+        self.assertEqual(set(result["candidate_paths"]), {"sample.rs", "new.rs"})
+
+    def test_removal_and_shrink_do_not_trigger(self):
+        self.ratchet([dict(path="sample.rs", lines=1000)])
+        self.commit()
+        self.assertFalse(self.check()["audit_required"])
+        self.ratchet([])
+        self.commit()
+        self.assertFalse(self.check()["audit_required"])
+
+    def test_force_requires_reason_and_keeps_it(self):
+        with self.assertRaises(audit.AuditError):
+            self.check(force=True, reason="  ")
+        result = self.check(force=True, reason="release\n$(touch injected)")
+        self.assertTrue(result["audit_required"])
+        self.assertIn("$(touch injected)", result["markdown"])
+        self.assertFalse((self.root / "injected").exists())
+
+    def test_baseline_corruption_semantics_and_unknown_schema(self):
+        for mutate in [lambda b: b.update(schema_version=99),
+                       lambda b: b.update(baseline_commit="0" * 40),
+                       lambda b: b["scope"].update(tracked_candidate_count=999),
+                       lambda b: b["structural_metrics"][0].update(after=999),
+                       lambda b: b["scope"]["groups"][0].update(id="INV-2"),
+                       lambda b: b["oversized"]["files"][0].update(ratchet_lines=1001)]:
+            with self.subTest(mutate=mutate):
+                bad = copy.deepcopy(self.baseline)
+                mutate(bad)
+                self.write("xtask/refactoring-audit-baseline.json", json.dumps(bad))
+                self.commit()
+                with self.assertRaises(audit.AuditError):
+                    self.check(force=True, reason="force cannot bypass corruption")
+
+    def test_invalid_ratchet_and_nonancestor_fail(self):
+        self.ratchet([dict(path="sample.rs", lines=1000)] * 2)
+        self.commit()
+        with self.assertRaises(audit.AuditError):
+            self.check()
+        with self.assertRaises(audit.AuditError):
+            self.check(current=self.base)
+
+    def test_each_signal_independently_triggers_and_paths_remain_data(self):
+        path = "space 日本語" + (" " if os.name == "nt" else "\n") + "$(touch nope).rs"
+        self.write(path, "new\n" * 1000)
+        self.ratchet([dict(path="sample.rs", lines=1100), dict(path=path, lines=1000)])
+        self.commit()
+        report = self.check()
+        self.assertEqual([s["value"] for s in report["signals"]], [1, 0])
+        self.assertEqual(report["diagnostics"]["max_path_change_commits"], 1)
+        self.assertIn("$(touch nope)", report["markdown"])
+        self.assertTrue(report["audit_required"])
+        self.ratchet([dict(path="sample.rs", lines=1101)])
+        self.commit()
+        self.assertEqual([s["value"] for s in self.check()["signals"]], [0, 1])
+
+    def test_nonancestor_history_is_rejected(self):
+        self.git("checkout", "--orphan", "disconnected")
+        self.commit()
+        with self.assertRaises(audit.AuditError):
+            self.check()
+
+    def test_reviewed_baseline_update_is_accepted_without_automatic_advancement(self):
+        self.ratchet([dict(path="sample.rs", lines=1101)])
+        current = self.commit()
+        self.assertTrue(self.check()["audit_required"])
+        b = copy.deepcopy(self.baseline)
+        b["baseline_commit"] = current
+        b["code_tree_oids"]["xtask"] = self.git("rev-parse", f"{current}:xtask").strip()
+        paths = self.git("ls-tree", "-r", "--name-only", current).splitlines()
+        b["scope"].update(tracked_candidate_count=len(paths), tracked_candidate_paths_sha256=audit.digest(paths))
+        b["oversized"]["ratchet_blob"] = self.git("rev-parse", f"{current}:xtask/oversized-baseline.json").strip()
+        b["oversized"]["files"][0]["ratchet_lines"] = 1101
+        self.write("xtask/refactoring-audit-baseline.json", json.dumps(b))
+        self.commit()
+        before = (self.root / audit.BASELINE).read_bytes()
+        result = self.check()
+        self.assertFalse(result["audit_required"])
+        self.assertEqual(result["baseline_commit"], current)
+        self.assertEqual((self.root / audit.BASELINE).read_bytes(), before)
+
+    def test_missing_git_repo_and_duplicate_json_keys_fail(self):
+        with tempfile.TemporaryDirectory() as empty:
+            with self.assertRaises(audit.AuditError):
+                audit.check(Path(empty))
+        with self.assertRaises(audit.AuditError):
+            audit.json_value('{"a":1,"a":2}')
+
+    def test_threshold_boundaries_and_invalid_negative(self):
+        self.assertFalse(audit.evaluate(1, 2))
+        self.assertFalse(audit.evaluate(2, 2))
+        self.assertTrue(audit.evaluate(3, 2))
+        with self.assertRaises(audit.AuditError):
+            audit.evaluate(-1, 0)
+
+    def test_bad_time_and_management_marker_reason(self):
+        with self.assertRaises(audit.AuditError):
+            audit.check(self.root, now="2026-09-09T00:00:00")
+        with self.assertRaises(audit.AuditError):
+            audit.check(self.root, now="2026-09-07T00:00:00Z")
+        result = self.check(force=True, reason="<!-- kukuri-refactoring-audit:v1 -->")
+        self.assertNotIn("<!-- kukuri-refactoring-audit:v1 -->", result["markdown"])
+
+    def test_real_evaluator_output_drives_upsert_without_network(self):
+        # Exercise the actual Python -> JSON -> Node contract, without a token.
+        program = """
+          import { upsert } from './scripts/refactoring-audit/upsert.mjs';
+          let input = '';
+          for await (const chunk of process.stdin) input += chunk;
+          const writes = [];
+          const api = { list: async () => [], create: async body => {
+            writes.push(body); return { number: 1 }; }, update: async () => { throw Error('unexpected update'); } };
+          const outcome = await upsert(JSON.parse(input), api);
+          process.stdout.write(JSON.stringify({outcome, writes}));
+        """
+        for force in [False, True]:
+            report = self.check(force=force, reason="release\n$(touch nope)" if force else "")
+            result = subprocess.run(["node", "--input-type=module", "-e", program], cwd=ROOT,
+                                    input=json.dumps(report), capture_output=True, text=True, encoding="utf-8", check=True)
+            payload = json.loads(result.stdout)
+            self.assertEqual(len(payload["writes"]), int(force))
+            self.assertEqual(payload["outcome"]["action"], "created" if force else "none")
+
+    def test_cli_exit_and_json(self):
+        for args, code in [([], 0), (["--force-audit", "--reason", "release"], 0),
+                           (["--force-audit"], 1), (["--current", "0" * 40], 1)]:
+            entry = [os.environ["KUKURI_AUDIT_XTASK"], "refactoring-audit-check"] if os.environ.get("KUKURI_AUDIT_XTASK") else [sys.executable, str(HERE / "check.py")]
+            result = subprocess.run([*entry, "--repo", str(self.root),
+                                     "--now", "2026-09-09T00:00:00Z", "--format", "json", *args], capture_output=True, text=True, encoding="utf-8")
+            self.assertEqual(result.returncode, code, result.stderr)
+            if code == 0:
+                self.assertIsInstance(json.loads(result.stdout)["audit_required"], bool)
+            else:
+                self.assertEqual(result.stdout, "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/refactoring-audit/test_workflow_check.py
+++ b/scripts/refactoring-audit/test_workflow_check.py
@@ -1,0 +1,69 @@
+import importlib.util
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+from unittest.mock import patch
+
+SPEC = importlib.util.spec_from_file_location("workflow_check", Path(__file__).with_name("workflow_check.py"))
+workflow = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(workflow)
+
+
+class WorkflowContract(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name)
+        self.env = dict(RUNNER_TEMP=str(self.root), GITHUB_SHA="a" * 40,
+                        GITHUB_OUTPUT=str(self.root / "output"), GITHUB_STEP_SUMMARY=str(self.root / "summary"))
+
+    def test_arguments_preserve_manual_input_and_outputs_are_fixed(self):
+        reason = "release\n$(touch injected)\ntrue\n<!-- marker -->"
+        report = dict(audit_required=True, current_commit="a" * 40, markdown="summary\n")
+        with patch.dict(os.environ, {**self.env, "AUDIT_FORCE": "true", "AUDIT_REASON": reason}, clear=True):
+            with patch.object(workflow.subprocess, "run", return_value=subprocess.CompletedProcess([], 0, json.dumps(report).encode())) as run:
+                workflow.main()
+                args = run.call_args.args[0]
+                self.assertEqual(args[-1], f"--reason={reason}")
+                self.assertIn("--no-default-features", args)
+                self.assertNotIn("shell", run.call_args.kwargs)
+        self.assertEqual((self.root / "output").read_text(), "audit_required=true\n")
+        self.assertEqual((self.root / "summary").read_text(), "summary\n")
+        self.assertEqual(json.loads((self.root / "refactoring-audit.json").read_text()), report)
+
+    def test_failure_never_publishes_success_output_or_artifact(self):
+        with patch.dict(os.environ, self.env, clear=True):
+            with patch.object(workflow.subprocess, "run", side_effect=subprocess.CalledProcessError(1, ["cargo"])):
+                with self.assertRaises(subprocess.CalledProcessError):
+                    workflow.main()
+        self.assertEqual(list(self.root.iterdir()), [])
+
+    def test_invalid_force_and_mismatched_commit_never_publish(self):
+        with patch.dict(os.environ, {**self.env, "AUDIT_FORCE": "true\naudit_required=true"}, clear=True):
+            with patch.object(workflow.subprocess, "run") as run:
+                with self.assertRaises(ValueError):
+                    workflow.main()
+                run.assert_not_called()
+        for payload in [dict(audit_required=True, current_commit="b" * 40),
+                        dict(audit_required=True, current_commit="a" * 40)]:
+            with patch.dict(os.environ, self.env, clear=True):
+                bad = json.dumps(payload).encode()
+                with patch.object(workflow.subprocess, "run", return_value=subprocess.CompletedProcess([], 0, bad)):
+                    with self.assertRaises(ValueError):
+                        workflow.main()
+        self.assertEqual(list(self.root.iterdir()), [])
+
+    def test_scheduled_false_only_publishes_false_and_summary(self):
+        report = dict(audit_required=False, current_commit="a" * 40, markdown="false summary")
+        with patch.dict(os.environ, self.env, clear=True):
+            with patch.object(workflow.subprocess, "run", return_value=subprocess.CompletedProcess([], 0, json.dumps(report).encode())) as run:
+                workflow.main()
+                self.assertNotIn("--force-audit", run.call_args.args[0])
+        self.assertEqual((self.root / "output").read_text(), "audit_required=false\n")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/refactoring-audit/upsert.mjs
+++ b/scripts/refactoring-audit/upsert.mjs
@@ -1,0 +1,155 @@
+import { readFile, appendFile } from 'node:fs/promises';
+import { pathToFileURL } from 'node:url';
+
+export const MARKER = '<!-- kukuri-refactoring-audit:v1 -->';
+export const BEGIN = '<!-- kukuri-refactoring-audit:latest:start -->';
+export const END = '<!-- kukuri-refactoring-audit:latest:end -->';
+
+function require(value, message) {
+  if (!value) throw new Error(message);
+}
+
+export function validateResult(result) {
+  require(result?.schema_version === 1 && typeof result.audit_required === 'boolean', 'invalid audit result');
+  require(/^[a-f0-9]{40}$/.test(result.baseline_commit) && /^[a-f0-9]{40}$/.test(result.current_commit), 'invalid commit');
+  require(typeof result.evaluated_at === 'string' && /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/.test(result.evaluated_at)
+    && Number.isFinite(Date.parse(result.evaluated_at)), 'invalid evaluation time');
+  require(Number.isSafeInteger(result.tracking_issue) && result.tracking_issue > 0, 'invalid tracking issue');
+  require(typeof result.force_audit === 'boolean' && typeof result.manual_reason === 'string', 'invalid manual input');
+  require(!result.force_audit || result.manual_reason.trim(), 'force reason required');
+  require(Array.isArray(result.signals) && result.signals.length === 2, 'invalid signals');
+  const names = ['ratchet_new_paths', 'ratchet_increased_caps'];
+  for (const [index, signal] of result.signals.entries()) {
+    require(signal.id === names[index] && Number.isSafeInteger(signal.value) && signal.value >= 0
+      && signal.threshold === 0 && signal.triggered === (signal.value > 0)
+      && Array.isArray(signal.paths) && signal.paths.length === signal.value
+      && signal.paths.every(path => typeof path === 'string') && new Set(signal.paths).size === signal.paths.length,
+    'invalid signal value');
+  }
+  require(result.audit_required === (result.force_audit || result.signals.some(signal => signal.triggered)), 'inconsistent audit_required');
+  require(Array.isArray(result.candidate_paths) && result.candidate_paths.every(path => typeof path === 'string'), 'invalid candidate paths');
+  require(Array.isArray(result.human_only_triggers) && result.human_only_triggers.every(item => typeof item === 'string'), 'invalid human triggers');
+  require(typeof result.markdown === 'string' && result.markdown.length > 0
+    && ![MARKER, BEGIN, END].some(marker => result.markdown.includes(marker)), 'invalid markdown/management marker');
+}
+
+function escape(text) {
+  return text.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;').replaceAll('\r', '').replaceAll('\n', '<br>');
+}
+
+function region(result) {
+  return `${BEGIN}\n${result.markdown.trimEnd()}\n${END}`;
+}
+
+function newIssue(result) {
+  const scope = result.candidate_paths.map(path => `- ${escape(path)}`).join('\n') || '- 手動理由を確認して担当者が対象path／責務を固定する。';
+  return {
+    title: `リファクタリング監査: ${result.evaluated_at.slice(0, 10)}のtrigger判定`,
+    body: `${MARKER}
+## Current status
+- 判定: Planned（読み取り中心の監査から開始）
+- Scope revision: audit-${result.baseline_commit.slice(0, 12)}
+- In scope: 下記の開始時候補から担当者が有限scopeを固定する。
+- Non-goals: 自動実装、直接PR作成、候補の無条件採用。
+- 所有: 本Issueは監査と候補分類を所有し、実装は必要な個別Issueへ分ける。
+
+## 対象と開始trigger
+規範は #871 と REFACTORING.md、直前の監査／campaignは #${result.tracking_issue}。
+開始理由: ${escape(result.manual_reason) || 'ratchetの増加を観測したため。'}
+
+## 有限scopeと終了条件
+以下は開始時の候補であり、以後の自動判定はこのscopeを変更しない。
+${scope}
+
+担当者が対象path／責務と確認集合または時間枠を固定してから読み取り中心の監査を行う。
+- [ ] AC-1: 固定したscopeの全候補を、実施／延期／却下／別種別へ根拠付きで分類する。
+- [ ] AC-2: 実施候補は一つの構造上の成果ごとに個別Issueへ渡す。変更しない結論も正常な完了とする。
+- [ ] INVAR-1: この監査ではproduct code、baseline、製品契約を自動変更しない。
+Issue lifecycleのリスク区分と必要なinventory／transitionはscope確定時に担当者が記録する。
+
+## 変更前baseline
+比較起点: ${result.baseline_commit}、開始時評価commit: ${result.current_commit}。
+
+## 候補一覧
+| 候補 | 観測した問題と根拠 | 目標成果 | 優先順位 | 分類 | 理由 / 個別Issue |
+| --- | --- | --- | --- | --- | --- |
+
+## 監査終了判定
+担当者が固定scopeの分類結果と終了根拠を記録する。baseline更新は監査完了後のreview付きPRで行う。
+
+## 最新の機械観測（上記scopeを拡張しない）
+${region(result)}
+`,
+  };
+}
+
+function replaceRegion(body, result) {
+  require(body.split(BEGIN).length === 2 && body.split(END).length === 2, 'ambiguous or missing managed region');
+  const start = body.indexOf(BEGIN), end = body.indexOf(END);
+  require(start < end, 'invalid managed region order');
+  return body.slice(0, start) + region(result) + body.slice(end + END.length);
+}
+
+/** Caller must serialize all runs using one repository-wide Actions concurrency group. */
+export async function upsert(result, api) {
+  validateResult(result);
+  if (!result.audit_required) return { action: 'none' };
+  const matches = [];
+  for (let page = 1; ; page++) {
+    const issues = await api.list(page);
+    require(Array.isArray(issues), 'invalid issue listing');
+    for (const issue of issues) {
+      if (issue.state === 'open' && !issue.pull_request && typeof issue.body === 'string'
+        && issue.body.split(/\r?\n/).includes(MARKER)) matches.push(issue);
+    }
+    if (issues.length < 100) break;
+  }
+  require(matches.length <= 1, 'multiple open audit issues: resolve markers manually; no writes made');
+  if (matches.length === 0) {
+    const payload = newIssue(result);
+    require(payload.body.length <= 65000, 'audit body too large; no writes made');
+    const created = await api.create(payload);
+    return { action: 'created', number: created.number, url: created.html_url };
+  }
+  const issue = matches[0];
+  require(Number.isSafeInteger(issue.number) && issue.number > 0, 'invalid issue number');
+  const body = replaceRegion(issue.body, result);
+  require(body.length <= 65000, 'audit body too large; no writes made');
+  if (body === issue.body) return { action: 'unchanged', number: issue.number, url: issue.html_url };
+  await api.update(issue.number, { body });
+  return { action: 'updated', number: issue.number, url: issue.html_url };
+}
+
+export function githubApi(repository, token, fetcher = fetch) {
+  require(/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repository) && token, 'repository and token required');
+  const base = `https://api.github.com/repos/${repository}/issues`;
+  async function request(method, suffix = '', body) {
+    // No shell, search query, automatic retry, or redirects for token-bearing requests.
+    const response = await fetcher(base + suffix, {
+      method, redirect: 'error', signal: AbortSignal.timeout(30000),
+      headers: { Authorization: `Bearer ${token}`, Accept: 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28', 'Content-Type': 'application/json' },
+      ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+    });
+    require(response.ok, `GitHub ${method} failed (${response.status}); inspect before rerun`);
+    return response.json();
+  }
+  return {
+    list: page => request('GET', `?state=open&per_page=100&page=${page}`),
+    create: payload => request('POST', '', payload),
+    update: (number, payload) => request('PATCH', `/${number}`, payload),
+  };
+}
+
+async function main() {
+  const result = JSON.parse(await readFile(process.argv[2], 'utf8'));
+  const outcome = await upsert(result, githubApi(process.env.GITHUB_REPOSITORY, process.env.GH_TOKEN));
+  process.stdout.write(`${JSON.stringify(outcome)}\n`);
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    await appendFile(process.env.GITHUB_STEP_SUMMARY, `\nIssue: ${outcome.action}${outcome.number ? ` #${outcome.number}` : ''}\n`);
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch(error => { process.stderr.write(`refactoring_audit_upsert_error: ${error.message}\n`); process.exitCode = 1; });
+}

--- a/scripts/refactoring-audit/upsert.test.mjs
+++ b/scripts/refactoring-audit/upsert.test.mjs
@@ -1,0 +1,117 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { MARKER, BEGIN, END, upsert, githubApi } from './upsert.mjs';
+
+const result = (required = true) => ({
+  schema_version: 1, audit_required: required,
+  baseline_commit: 'a'.repeat(40), current_commit: 'b'.repeat(40),
+  evaluated_at: '2026-09-08T00:00:00Z', tracking_issue: 872,
+  force_audit: false, manual_reason: '',
+  signals: [{ id: 'ratchet_new_paths', value: 1, threshold: 0, triggered: true, paths: ['a.rs'], reason: 'new path' },
+    { id: 'ratchet_increased_caps', value: 0, threshold: 0, triggered: false, paths: [], reason: 'cap growth' }],
+  candidate_paths: ['a.rs'], human_only_triggers: ['release'],
+  markdown: '## 監査トリガー判定\n\nテストの判定結果\n',
+});
+const existing = (number = 1) => ({ number, state: 'open', body: `${MARKER}\n人間のscope\n${BEGIN}\nold\n${END}\n人間の判断`, html_url: `https://github.com/o/r/issues/${number}` });
+function api(pages = [[]]) {
+  const writes = [], reads = [];
+  return {
+    writes, reads,
+    async list(page) { reads.push(page); return pages[page - 1] ?? []; },
+    async create(body) { writes.push(['create', body]); return { number: 10, html_url: 'https://github.com/o/r/issues/10' }; },
+    async update(number, body) { writes.push(['update', number, body]); return { number, html_url: `https://github.com/o/r/issues/${number}` }; },
+  };
+}
+
+test('false does not even enter the issue API path', async () => {
+  const mock = api();
+  const report = result(false);
+  report.signals[0] = { ...report.signals[0], value: 0, triggered: false, paths: [] };
+  report.candidate_paths = [];
+  assert.equal((await upsert(report, mock)).action, 'none');
+  assert.deepEqual(mock.writes, []);
+  assert.deepEqual(mock.reads, []);
+});
+test('true creates a finite read-only audit with fixed marker', async () => {
+  const mock = api();
+  assert.equal((await upsert(result(), mock)).action, 'created');
+  assert.equal(mock.writes.length, 1);
+  assert.ok(mock.writes[0][1].body.includes(MARKER));
+  assert.ok(mock.writes[0][1].body.includes('読み取り中心'));
+  assert.ok(mock.writes[0][1].body.includes('#871'));
+});
+test('update preserves human scope and is idempotent', async () => {
+  const issue = existing();
+  const mock = api([[issue]]);
+  await upsert(result(), mock);
+  const body = mock.writes[0][2].body;
+  assert.ok(body.startsWith(`${MARKER}\n人間のscope\n${BEGIN}`));
+  assert.ok(body.endsWith(`${END}\n人間の判断`));
+  issue.body = body;
+  await upsert(result(), mock);
+  assert.equal(mock.writes.length, 1);
+});
+test('pagination excludes PRs, unrelated and closed issues', async () => {
+  const page = Array.from({ length: 100 }, (_, i) => ({ number: i + 50, state: 'open', body: 'unrelated' }));
+  page[0] = { ...existing(40), pull_request: {} };
+  page[1] = { ...existing(41), state: 'closed' };
+  const mock = api([page, [existing(2)]]);
+  await upsert(result(), mock);
+  assert.deepEqual(mock.reads, [1, 2]);
+  assert.equal(mock.writes[0][1], 2);
+});
+test('duplicate open marker or malformed management region fails without writes', async () => {
+  for (const issues of [[existing(1), existing(2)], [{ ...existing(), body: `${MARKER}\nmissing region` }],
+    [{ ...existing(), body: `${MARKER}\n${BEGIN}\n${BEGIN}\n${END}` }]]) {
+    const mock = api([issues]);
+    await assert.rejects(upsert(result(), mock));
+    assert.equal(mock.writes.length, 0);
+  }
+});
+test('lookup failure is not an empty search', async () => {
+  const mock = api();
+  mock.list = async () => { throw new Error('503'); };
+  await assert.rejects(upsert(result(), mock), /503/);
+  assert.equal(mock.writes.length, 0);
+});
+test('lost create response is not retried; next run finds the committed issue', async () => {
+  let saved;
+  const mock = api();
+  mock.list = async () => saved ? [saved] : [];
+  mock.create = async ({ body }) => { saved = { ...existing(10), body }; mock.writes.push('create'); throw new Error('response lost'); };
+  await assert.rejects(upsert(result(), mock), /response lost/);
+  assert.equal((await upsert(result(), mock)).action, 'unchanged');
+  assert.deepEqual(mock.writes, ['create']);
+});
+test('update failure does not fall back to creation', async () => {
+  const mock = api([[existing()]]);
+  mock.update = async () => { throw new Error('403'); };
+  await assert.rejects(upsert(result(), mock), /403/);
+  assert.equal(mock.writes.length, 0);
+});
+test('malformed result and injected management markers fail before API', async () => {
+  for (const report of [{}, { ...result(), audit_required: 'true' }, { ...result(), markdown: BEGIN },
+    { ...result(), force_audit: true }, { ...result(), current_commit: 'bad' }]) {
+    const mock = api();
+    await assert.rejects(upsert(report, mock));
+    assert.equal(mock.writes.length, 0);
+    assert.equal(mock.reads.length, 0);
+  }
+});
+test('REST adapter uses JSON data, pagination and no automatic write retry', async () => {
+  const calls = [];
+  const fetcher = async (url, options) => {
+    calls.push([url, options]);
+    return { ok: true, status: 200, json: async () => options.method === 'GET' ? [] : { number: 8, html_url: 'https://github.com/o/r/issues/8' } };
+  };
+  const adapter = githubApi('o/r', 'test-token', fetcher);
+  await adapter.list(2);
+  await adapter.create({ title: 'audit', body: '$(touch nope)\n`code`' });
+  assert.ok(calls[0][0].endsWith('state=open&per_page=100&page=2'));
+  assert.equal(JSON.parse(calls[1][1].body).body, '$(touch nope)\n`code`');
+  assert.equal(calls[1][1].headers.Authorization, 'Bearer test-token');
+  let failedCalls = 0;
+  const failed = githubApi('o/r', 'test-token', async () => { failedCalls++; return { ok: false, status: 503 }; });
+  await assert.rejects(failed.create({}), /503/);
+  assert.equal(failedCalls, 1);
+});

--- a/scripts/refactoring-audit/workflow_check.py
+++ b/scripts/refactoring-audit/workflow_check.py
@@ -1,0 +1,39 @@
+"""Actions adapter: arguments in, validated JSON/summary/artifact out."""
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+
+def main():
+    force = os.environ.get("AUDIT_FORCE", "false") or "false"
+    if force not in ("true", "false"):
+        raise ValueError("AUDIT_FORCE must be true or false")
+    args = ["cargo", "run", "--locked", "--quiet", "--package", "xtask", "--no-default-features", "--",
+            "refactoring-audit-check", "--format", "json", "--current", os.environ["GITHUB_SHA"]]
+    reason = os.environ.get("AUDIT_REASON", "")
+    if force == "true":
+        args.append("--force-audit")
+    if reason:
+        args.append(f"--reason={reason}")
+    try:
+        result = subprocess.run(args, check=True, capture_output=True)
+    except subprocess.CalledProcessError as error:
+        if error.stderr:
+            sys.stderr.buffer.write(error.stderr)
+        raise
+    report = json.loads(result.stdout)
+    if (type(report.get("audit_required")) is not bool
+            or report.get("current_commit") != os.environ["GITHUB_SHA"]
+            or not isinstance(report.get("markdown"), str) or not report["markdown"]):
+        raise ValueError("invalid command result")
+    Path(os.environ["RUNNER_TEMP"], "refactoring-audit.json").write_bytes(result.stdout)
+    with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+        output.write(f"audit_required={str(report['audit_required']).lower()}\n")
+    with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as summary:
+        summary.write(report["markdown"])
+
+
+if __name__ == "__main__":
+    main()

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -4,6 +4,10 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[features]
+default = ["harness"]
+harness = ["dep:kukuri-harness", "dep:tokio"]
+
 [dependencies]
 anyhow.workspace = true
 base64.workspace = true
@@ -12,8 +16,8 @@ minisign-verify = "0.2"
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
-tokio.workspace = true
-kukuri-harness = { path = "../crates/harness" }
+tokio = { workspace = true, optional = true }
+kukuri-harness = { path = "../crates/harness", optional = true }
 
 [lints]
 workspace = true

--- a/xtask/src/exec.rs
+++ b/xtask/src/exec.rs
@@ -25,6 +25,7 @@ pub(crate) fn desktop_dir() -> PathBuf {
     root_dir().join("apps").join("desktop")
 }
 
+#[cfg(feature = "harness")]
 pub(crate) fn artifacts_dir(name: &str) -> PathBuf {
     root_dir()
         .join("test-results")

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -9,8 +9,10 @@ mod ipc;
 mod operator_neutrality;
 mod oversized;
 mod packages;
+mod refactoring_audit;
 mod release;
 mod rust;
+#[cfg(feature = "harness")]
 mod scenario;
 
 pub(crate) use assets::*;
@@ -23,6 +25,7 @@ pub(crate) use oversized::*;
 pub(crate) use packages::*;
 pub(crate) use release::*;
 pub(crate) use rust::*;
+#[cfg(feature = "harness")]
 pub(crate) use scenario::*;
 
 fn main() -> Result<()> {
@@ -67,6 +70,7 @@ fn main() -> Result<()> {
             oversized_files(update_baseline)
         }
         "operator-neutrality-check" => operator_neutrality_check(),
+        "refactoring-audit-check" => refactoring_audit::refactoring_audit_check(args),
         "ipc-types" => {
             let check = match args.next().as_deref() {
                 None => false,
@@ -78,11 +82,15 @@ fn main() -> Result<()> {
             };
             ipc_types(check)
         }
+        #[cfg(feature = "harness")]
         "e2e-smoke" => e2e_smoke("desktop_smoke_post_persist"),
+        #[cfg(feature = "harness")]
         "scenario" => {
             let name = args.next().context("scenario name is required")?;
             scenario(name.as_str())
         }
+        #[cfg(not(feature = "harness"))]
+        "e2e-smoke" | "scenario" => bail!("this command requires the default harness feature"),
         _ => {
             print_usage();
             bail!("unsupported xtask command: {command}");
@@ -115,6 +123,6 @@ fn doctor() -> Result<()> {
 
 fn print_usage() {
     eprintln!(
-        "usage: cargo xtask <doctor|check|test|rust-check|rust-test|app-api-slow-test|tauri-check|desktop-lint|desktop-test|desktop-storybook|desktop-browser-test|desktop-visual-test|desktop-ui-check|cn-check|cn-test|cn-e2e|desktop-package|asset-check|release-check [tag]|oversized-files [--update-baseline]|operator-neutrality-check|ipc-types [--check]|e2e-smoke|scenario <name>>"
+        "usage: cargo xtask <doctor|check|test|rust-check|rust-test|app-api-slow-test|tauri-check|desktop-lint|desktop-test|desktop-storybook|desktop-browser-test|desktop-visual-test|desktop-ui-check|cn-check|cn-test|cn-e2e|desktop-package|asset-check|release-check [tag]|oversized-files [--update-baseline]|operator-neutrality-check|refactoring-audit-check [--help]|ipc-types [--check]|e2e-smoke|scenario <name>>"
     );
 }

--- a/xtask/src/refactoring_audit.rs
+++ b/xtask/src/refactoring_audit.rs
@@ -1,0 +1,20 @@
+use std::process::Command;
+
+use anyhow::{Context, Result, bail};
+
+/// Run the same small, read-only evaluator used by the scheduled workflow.
+/// Invoke the interpreter directly, including on Windows: reasons are arguments,
+/// never shell command text. Do not use run(), which writes timing to stdout.
+pub(crate) fn refactoring_audit_check(args: impl Iterator<Item = String>) -> Result<()> {
+    let python = std::env::var("KUKURI_AUDIT_PYTHON")
+        .unwrap_or_else(|_| if cfg!(windows) { "python" } else { "python3" }.to_string());
+    let status = Command::new(python)
+        .arg(crate::root_dir().join("scripts/refactoring-audit/check.py"))
+        .args(args)
+        .status()
+        .context("failed to run audit checker; see docs/runbooks/dev.md for Python setup")?;
+    if !status.success() {
+        bail!("refactoring-audit-check failed: {status}");
+    }
+    Ok(())
+}


### PR DESCRIPTION
## 概要

#872で確定したbaseline以後のratchetへの新規path追加・許容上限増加を読み取り専用で判定し、監査が必要な場合だけOpen監査Issueを一件に集約します。毎週月曜00:00 UTCとmainの手動実行に対応し、手動forceの理由もsummary／Issueへ残します。

## 対象と条件

- Refs #873 / 種別: feature（開発支援）。
- リスク区分C / Scope revision: `2026-09-04-issue-873-refactoring-audit-trigger-v1`。
- 実装開始: `188c1df4ab81301a6eafb40645ffb24a4aaa931e`。比較起点は引き続き `e98d2025e01332a6dbd4b13f5f4712654a931c65`。
- 固定AC-1〜5／INVAR-1〜3／INV-1〜5／TR-1〜5と実装・test・sink逆引きは [作業記録](https://github.com/KingYoSun/kukuri/blob/81648573c1993ea788191e39f25c341f8b22eb64/docs/progress/2026-09-08-873-refactoring-audit-trigger.md) に集約しています。
- 変更はxtask入口・既定有効harness feature、Python判定／Node upsert、専用workflow、運用記録。baseline/schema/ratchet設定・製品コード・既存nightly/required設定は変更しません。

## 変更前後の証拠

command/workflow未実装を開始HEADで確認し、Git fixture／upsert契約testを先に追加して未実装での失敗を記録しました。判定は確定Git objectを使用し、dirty/untrackedを除外します。schemaのほかcommit祖先・集合digest・ratchet実測/上限・metric scopeを検証します。

GitHub mutationは成功かつtrueからのみ到達します。全ページのmarker検索、共通concurrency、重複拒否、機械領域だけの更新により既存の人間scopeを保持します。検索失敗を新規作成で回避せず、作成応答喪失後のrerunも同じIssueへ収束させます。通常jobはcontents:read、upsert jobだけissues:writeです。

## 検証とリスク

- Python Git fixture／実CLI／workflow adapter／実JSON→Node接続: 18 tests PASS（Windows、追加変更はtargeted再実行）。
- Node API mock／REST adapter: 10 tests PASS。
- 軽量xtask: 44 tests PASS、既存のAppImage署名metadata test 1 ignored。clippy `-D warnings` PASS。
- actionlint 1.7.7: 専用2workflow PASS。
- `cargo xtask check`: PASS。
- `cargo xtask test`: PASS。Rust 886 PASS（既存skip 4）、harness 22 PASS、doctest成功、frontend 152 files / 1,209 tests PASS。
- `cargo xtask oversized-files`: PASS（16件、violation 0）。初回はWindowsの実行中exeロックでbuildに失敗しましたが、全体test終了後の同command再実行で成功。
- CI: 対象headの12 checksすべて成功（Fast、専用contracts、AppImage/Deb、GitGuardian）。
- 製品UI/protocol/storage/P2Pの変更はありません。週次はharnessなしで製品crateをbuildしません。baseline更新は監査完了後のreview付きPRのみです。

## 独立監査

- head `81648573c1993ea788191e39f25c341f8b22eb64` の[独立監査はPASS](https://github.com/KingYoSun/kukuri/pull/944#issuecomment-5578848662)。inventory 5/5適合、transition 5/5適合、不適合・未分類・blocker 0件。監査後の実装差分は0です。
- 必須CI成功と独立監査PASS後にmerge `a5ebf1abdb1071c0d32b73bc30ae6d0477883e57` を作成。全tree一致と[main手動check成功](https://github.com/KingYoSun/kukuri/actions/runs/34186464573)を確認して#873をClose済み。



