### PR TITLE
fix: ScoreGameの旧hydrationによるprojection退行を防ぐ

### DIFF
--- a/.codex.plans/2026-09-09-issue-942-score-game-projection-freshness.md
+++ b/.codex.plans/2026-09-09-issue-942-score-game-projection-freshness.md
@@ -12,7 +12,7 @@
 ## 前提・完了条件
 
 - 計画作成日: 2026-09-09。
-- 状態: 実装中。T1の制御可能な再現はMemory／SQLite、一括／個別の4ケースで失敗を確認。現在の証跡は [作業記録](../docs/progress/2026-09-09-942-score-game-projection-freshness.md) に集約する。
+- 状態: T1～T6の実装・ローカル検証を完了。現在の証跡は [作業記録](../docs/progress/2026-09-09-942-score-game-projection-freshness.md)、T7の独立監査・CI・merge判定は [PR #951](https://github.com/KingYoSun/kukuri/pull/951) に集約する。
 - リスク区分: C（共有 projection／永続 cache と拒否更新の mutation 境界）。
 - Scope revision: Issue の `2026-09-08-score-game-projection-freshness-v1` を維持。
 - Issue の基準 commit: `e98d2025e01332a6dbd4b13f5f4712654a931c65`。
@@ -162,4 +162,4 @@ git diff --check
 - 作業仮定: blob await による旧 record 遅着を T1 で制御できる。T1 が成立しない場合は、固定した入口の trace に調査を戻す。
 - T2で決めること: room 単位の共有排他の配置と全 writer の包含、canonical照合後の再取得／fallbackの扱い。比較と書込みを別々の非atomic操作で終わらせない。
 - ユーザー判断が必要な条件: 調査の結果、固定した API／wire／schema／時刻／Metaverse の対象外を変更する必要が判明した場合のみ。現時点で計画作成を妨げる質問はない。
-- 次の一手: 実装が依頼・承認されたら HEAD／差分を確認し、T1 の修正前再現から開始する。追加発見は Existing-gap／Regression／New-requirement／Optional-hardening に分類し、固定 scope にない要件を完了条件へ追加しない。
+- 次の一手: 最終PR headの独立監査と必須CIの成功を確認し、承認済みのマージ・対象tree照合・Issue Closeを行う。追加発見は Existing-gap／Regression／New-requirement／Optional-hardening に分類し、固定 scope にない要件を完了条件へ追加しない。

--- a/.codex.plans/2026-09-09-issue-942-score-game-projection-freshness.md
+++ b/.codex.plans/2026-09-09-issue-942-score-game-projection-freshness.md
@@ -1,0 +1,165 @@
+# Issue #942: ScoreGame projection の退行防止 実装プラン
+
+## 目的・対象外
+
+有効な更新を一覧で確認した後、遅着した古い hydration が ScoreGame の状態・score・manifest 参照を以前の値へ戻さないようにする。無効 roster／非 owner の更新拒否では、対象の manifest・docs state・projection を変更しない。
+
+- 対象 Issue: [#942](https://github.com/KingYoSun/kukuri/issues/942)。#872／PR #941 の構造整理とは独立した既存不具合として扱う。
+- 対象: ScoreGame の create/update/list、bootstrap・docs event・hint・再取得の hydration、Memory／SQLite projection、および共有 writer の互換確認。
+- 対象外: public API／wire／署名／DB schema、時刻の意味、Metaverse lifecycle／readiness、CLI command 形状の変更。LiveSession など別機能への一般化、大型ファイル分割、任意の性能改善も含めない。
+- 計画作成時の依頼は調査と計画ファイル作成まで。その後、2026-09-09 にユーザーが本計画の実行、コミット、PR作成、CI成功後のマージを承認した。区分Cの独立監査も必須条件として実施する。
+
+## 前提・完了条件
+
+- 計画作成日: 2026-09-09。
+- 状態: 実装中。T1の制御可能な再現はMemory／SQLite、一括／個別の4ケースで失敗を確認。現在の証跡は [作業記録](../docs/progress/2026-09-09-942-score-game-projection-freshness.md) に集約する。
+- リスク区分: C（共有 projection／永続 cache と拒否更新の mutation 境界）。
+- Scope revision: Issue の `2026-09-08-score-game-projection-freshness-v1` を維持。
+- Issue の基準 commit: `e98d2025e01332a6dbd4b13f5f4712654a931c65`。
+- 今回の調査 HEAD: `58328f035a391f8f321bffdf6287cd339228fec7`。調査開始時の tracked 差分はなし。Issue 基準からこの HEAD までの `crates/app-api`、`crates/store`、`crates/kukuri-cli/tests/content_live.rs` に差分なし。
+- 規約: [PLANS.md](../PLANS.md)、[Issue lifecycle](../docs/runbooks/issue-lifecycle.md)、[path 別検証](../REFACTORING.md#path別検証マトリクス)、[開発手順](../docs/runbooks/dev.md)。
+- 製品契約: [ADR 0006](../docs/adr/0006-game-room-data-classification.md) の docs pointer + manifest blob が正本、cache は再構築可能、owner 限定更新と固定 participant。[ADR 0036](../docs/adr/0036-spatial-context-dome-instance-move.md) の Dome 専用 authority と共有 read model の境界を維持する。
+
+AC／INVAR の正本は Issue 本文。以下は作業と証跡の対応に使う要約であり、独立した完了 checkbox は設けない。
+
+| 条件 | 固定する内容 | 対応 Task |
+| --- | --- | --- |
+| AC-1 | old record 取得 → 有効 update → old hydration write の順を制御した修正前失敗と writer 特定 | T1 |
+| AC-2 | 同じ再現条件で、最新の正当な projection を old hydration が上書きしない | T2、T3 |
+| AC-3 | CLI の before/after 不変 assert を維持し、無効／非 owner 更新による禁止 mutation が 0 | T4 |
+| AC-4 | writer 全 caller、Memory／SQLite、再取得、複数 room、必須 validation、独立監査 | T2、T5、T6、T7 |
+| INVAR-1 | API／wire／schema、owner／roster guard、同 timestamp の既存有効更新を維持 | T2～T7 |
+| INVAR-2 | test の削除／skip／弱体化・任意 sleep を使わず、version の意味は既存 canonical state から定める | T1～T7 |
+
+## 調査結果
+
+### 確認できた事実
+
+1. [game.rs](../crates/app-api/src/game.rs) の `update_game_room` は `ensure_topic_subscription` → canonical state／manifest 取得 → owner、transition、roster の検証 → manifest 保存 → projection upsert → hint publish の順。roster 拒否は保存より前であり、拒否処理自体を古い値の writer と断定できない。
+2. [hydration_support.rs](../crates/app-api/src/service/hydration_support.rs) の `hydrate_game_rooms_from_replica`（471行～）と `hydrate_game_room_from_record`（515行～）は別々の upsert 経路。どちらも取得済み record を保持し、blob status／manifest fetch の await 後にその record 由来の row を書く。片方だけの修正では不足する。
+3. [Memory writer](../crates/store/src/memory/live_game.rs) は map に無条件 insert、[SQLite writer](../crates/store/src/sqlite/live_game.rs) は `ON CONFLICT(room_id) DO UPDATE` に freshness 条件を持たない。古い状態で新しい row を置換できる構造である。
+4. [object_persistence_support.rs](../crates/app-api/src/service/object_persistence_support.rs) の `game_projection_row_from_state` は `updated_at = state.updated_at`、`derived_at = 現在時刻`、`projection_version = 1`。`derived_at` は hydration 実行時刻、`projection_version` は固定値で、更新の新旧を表さない。実際の key は `sessions/game/<room_id>/state`。
+5. [live_game_support.rs](../crates/app-api/src/service/live_game_support.rs) の `persist_game_room_manifest` は state の `updated_at` をミリ秒で採番する。manifest 側の時刻とは別の採時で、同一ミリ秒になり得る。[backend_parity/live_game.rs](../crates/store/src/tests/backend_parity/live_game.rs) は同一 room・同一 timestamp `100` の `Waiting` → `Paused` 上書きを既に検査する。単純な `incoming.updated_at > existing.updated_at` は既存契約を壊す。
+6. [DocRecord](../crates/docs-sync/src/types.rs) は key/value/content_hash/content_len を持つが、順序付け可能な revision は公開していない。manifest hash や content hash は同一性の判定に使えても、辞書順を更新順として扱えない。
+7. `list_game_rooms_scoped` は既存 row があれば原則 cache を返し、空の場合に `hydrate_scope_projection` を呼ぶ。したがって常時 list 再取得や CLI 側の待機追加ではなく、writer 境界を修正する必要がある。
+8. bootstrap は `spawn_subscription_task` → `hydrate_subscription_state`、docs event／hint は `hydrate_subscription_event`／`hydrate_subscription_hint` → key retry に流れる。event／hint の hydrate 件数が 0 の場合には一括 hydration へ戻る経路もある。個別 hydration の戻り値変更はこの fallback と合わせて確認する。
+
+### 仮説・未確認
+
+- Issue 記載の CI では score7 確認後に Waiting／score0／旧 manifest／古い updated_at へ退行した。旧 record hydration の遅着と整合するが、CI で実際に走った writer の順序を今回独立には確定していない。
+- Issue にある「ローカル1回＋20回 PASS」は過去の観測であり、今回の実行結果ではない。今回は静的調査のみで、CLI test・追加再現・製品 suite は未実行。
+- 制御可能な fixture でこの候補が失敗しなければ AC-1 未達として writer の trace を調べ直す。CI の原因が証明されたと見なして見込み修正を進めない。
+
+## 実装方針
+
+まず T1 の再現を確定し、T2 で「何を新しい状態とするか」と「比較から書込みまでの競合防止」を一緒に決める。正本は現在の docs state が指す manifest とし、時刻を version に置換する設計や schema 追加は行わない。
+
+第一候補は、ScoreGame の同一 room に対するローカルの更新と hydration commit を共通の排他境界に置き、hydration の blob await 後に現在の docs state と候補を照合してから projection を書く方法とする。更新側は canonical persist と projection 反映を同じ境界で扱い、hydration 側の「照合後、upsert 前」に新しい writer が割り込めないようにする。初回 record 取得や遅い blob fetch を全 room 共通の lock で囲まない。同じ timestamp でも canonical pointer が変わった正当な更新は反映する。
+
+T2 で AppService と subscription task の共有状態の持ち方を確認し、既存 public constructor／ServiceHandles の公開形状を維持できる最小配置を選ぶ。既存 writer と fresh read を共通境界で扱えない場合は、既存 row の同一性を条件にした atomic な書込みなどと比較し、採用理由を残す。新しい public store API が必要になった場合は、対象外との衝突を隠して進めず判断点として示す。
+
+採用案は次を全て満たすことを T2 の終了条件とする。
+
+- 同じ room の old hydration と local update／別 hydration が、比較と write の間でも競合しない。docs の remote 更新自体をローカル lock が止めるとは仮定しない。
+- 古い候補を破棄した場合、latest の再取得または既に最新であることの確認へ進む。単なる成功扱いで missing cache を残したり、fallback で古い候補を再適用したりしない。
+- 初回 cache 作成、再取得、同 timestamp の異なる manifest、restart 後の保存済み cache、room 間の独立性を維持する。
+- `updated_at >=` にするだけでは同 timestamp の旧 hydration を判別できず、docs 再確認だけでは確認後の割込みが残る。どちらも単独では競合対策の根拠にしない。
+- ScoreGame に必要な制御を最小限に置き、Dome／Metaverse の共有 upsert の既存契約を維持する。共有関数の重複をまとめる場合も、同じ bug の両 write 経路を保護するための範囲に限定する。
+
+## 固定 surface inventory
+
+Issue の INV-1～3 を以下に展開する。追加の製品要件ではなく、既存 caller の名前と副作用を具体化したもの。
+
+| ID | 入口・trigger | shared helper | 読み書き・外部副作用 | guard／invariant | transition | test／証跡 |
+| --- | --- | --- | --- | --- | --- | --- |
+| INV-1a | CLI `commands/live_game.rs`、Tauri `commands/live_game.rs` → Runtime `runtime/sync_live_api.rs`／`runtime/private_channels_game_api.rs` → create/update | `create_game_room_in_channel`、`update_game_room`、`persist_game_room_manifest` | blob put/pin、docs apply、blob status、room cache、hint publish | owner／transition／roster 検証が mutation より前。canonical persist と cache の競合防止 | TR-1、3、4 | CLI 2本、T1／T4 の spy、既存 AppService game tests |
+| INV-1b | `list_game_rooms`／`list_game_rooms_scoped`、空一覧、scope 再取得 | `ensure_scope_subscriptions`、`hydrate_scope_projection` | cache read、必要時 bootstrap／docs/blob 取得と cache write | audience／mute filtering 維持、再取得で退行しない | TR-1、2、4 | T3／T5、persist scenario |
+| INV-2a | startup／restart／public・private subscription bootstrap、明示再取得、一括 fallback | `hydrate_topic_state` → `hydrate_subscription_state` → `hydrate_game_rooms_from_replica` | docs prefix query、各 blob fetch/status、room cache write | 取得済み records の遅着を拒否し、別 room を変更しない | TR-2、4、5 | 一括経路の制御可能 test、restart／private channel 回帰 |
+| INV-2b | docs event、`SessionChanged(game-session)` hint、retry | `hydrate_subscription_event`／`hydrate_subscription_hint` → `hydrate_game_room_from_key_with_retry` → key → record | exact query、blob fetch/status、room cache write、0件時 fallback | retry／早期 return と排他解除、古い候補破棄後の収束 | TR-2、4、5 | 個別経路の制御可能 test、hint 再取得 test |
+| INV-3a | 全 `upsert_game_room_cache` caller | `game_projection_row_from_state`、`LiveGameProjectionStore`、Memory／SQLite 実装 | room_id 単位の map／DB row mutation | 同 timestamp、異なる room、restart 後の同じ契約 | TR-1～5 | backend parity、row roundtrip、T5 |
+| INV-3b | 共有する Metaverse create/update/event/asset、Dome move | 下記 production caller 一覧 | 同じ cache、関連 canonical state／blob | 今回の制御で既存 Dome lifecycle／readiness を変更しない | TR-4 | AppService game／dome_listing／dome_move tests、該当 scenario |
+
+### writer の逆引き基準
+
+調査 HEAD の production upsert は次の11箇所。test fixture の直接書込みは別に分類する。
+
+- `crates/app-api/src/game.rs`: `create_game_room_in_channel`、`create_metaverse_room_in_channel`、`update_game_room`、`update_metaverse_room`、`publish_metaverse_room_event`、`import_metaverse_room_asset`（6箇所）。
+- `crates/app-api/src/dome_move.rs`: `move_dome` 内の3箇所（258／313／371行）。各分岐の意味・source／target の副作用は T2 で確認する。
+- `crates/app-api/src/service/hydration_support.rs`: `hydrate_game_rooms_from_replica`、`hydrate_game_room_from_record`（2箇所）。
+- test の直接 upsert: `tests/dome_listing.rs`、store の `tests/row_mapping_roundtrip_live_game.rs`、`tests/backend_parity/live_game.rs`。`tests/row_mapping_edge.rs` は SQL による読み戻しの異常値確認も行うため store writer 変更時に確認する。
+
+再列挙は CodeGraph を優先し、trait 経由の自由関数 caller も拾うため `rg -n 'upsert_game_room_cache|hydrate_game_room(s)?_from|game_projection_row_from_state' crates -g '*.rs'` を併用する。forward は subscription の登録点と CLI／Tauri／Runtime、reverse は upsert と `persist_game_room_manifest` → `store_manifest_blob`／`persist_game_room_state` から辿る。数だけで適合判定しない。
+
+期待する inventory 差分は、ScoreGame writer の共通制御と2つの hydration 経路の同じ freshness 判定への接続。公開入口・room 種別・DB table の追加／削除はない。内部 helper の増減と実際の caller を T3 後に更新する。
+
+### sensitive sink と拒否時の測定
+
+- `store_manifest_blob` 経由の対象 manifest の `BlobService::put_blob`／pin。
+- `persist_game_room_state` 経由の対象 state key への `DocsSync::apply_doc_op`。
+- `upsert_game_room_cache` 経由の対象 `game_room_cache` mutation。
+- 更新成功後の game-session hint publish と blob status 更新も観測する。
+
+拒否 test は初期 hydration を同期してから計測区間を切り、対象 room の docs bytes／hash、manifest ref／bytes、projection 全列と各 sink の呼出し数を比較する。背景 hydration に許される read／blob status refresh と、拒否された操作由来の mutation を区別する。別 test では old hydration を並走させても projection が退行しないことを確認する。単なる一覧一致だけを「blob／DB 書込みゼロ」の証拠にしない。
+
+## 状態遷移と再現
+
+| ID | 事前状態 | event／sequence | 期待状態 | 許可する I/O | 禁止する副作用 | test／証跡 |
+| --- | --- | --- | --- | --- | --- | --- |
+| TR-1 | room／cache なし → Waiting | Alice/Bob create → Running／round1／Alice7 → list | 正当な state・manifest・score7 | 正当な manifest／docs／cache write と hint | 他 room 更新 | 既存 CLI、game replicate、T1 |
+| TR-2 | old record A を取得済み | A の blob await を停止 → valid update B 完了 → list B 確認 → A を再開 | B の全 projection／manifest 参照を維持 | A の read、必要な最新 state read | A による対象 row の退行 | 一括／個別の Memory／SQLite 再現。別 hydration B との競合も確認 |
+| TR-3 | B が保存・表示済み | 空 roster／重複・未知 participant 等の既存拒否条件／非 owner update → list | 対象 canonical と projection が不変 | 既存 state／manifest read | 拒否操作による対象 manifest put/pin、docs apply、cache mutation、更新 hint | CLI 2本＋sink spy。TR-2 と並走する場合も別に検査 |
+| TR-4 | 同 timestamp A/B、複数 room、保存済み cache | 正当な B 更新、A 遅着、別 room 更新、再取得、restart | canonical B を採用し、他 room は不変。restart から最新を復元 | 対象の read／正当 write | 時刻 tie だけで B 拒否、他 room の巻込み、Dome の互換破壊 | store parity、AppService 制御 test、Runtime restart、persist scenario |
+| TR-5 | missing/corrupt state、blob 未到着、I/O 失敗 | hydrate → 早期 return／error／既存 retry → blob 到着・再取得、または task cancel | 古い候補を反映せず、成功時に最新へ収束。排他が解放される | 既存方針の read／retry、成功時 cache write | 失敗時の部分的な旧 row 適用、無限待機、fallback による再退行 | T3／T5 の fault injection、同期点と timeout による失敗判定 |
+
+TR-5 は AC-4 の既存 retry／再取得への影響確認として TR-4 を展開したもの。新しい retry 方針や一般的な障害回復機能は追加しない。
+
+T1 の fixture は blob service のラッパーで旧 hash の fetch だけを `Notify`／channel 等の明示的な同期点で止め、新 hash は通す。test 側で「旧 record が確実に読み終わった」「B が cache に反映された」「旧 write を再開した」を順に確認する。timeout はハング検出にのみ使い、sleep／確率的な反復を再現の根拠にしない。writer trace は入口名、room／source key、state updated_at、manifest hash、write 順を記録し、payload や秘密値を出さない。
+
+## 作業
+
+| ID／Phase | AC／INVAR・inventory／transition | 作業・対象 path | 受入条件 | 検証・証跡 | 依存 |
+| --- | --- | --- | --- | --- | --- |
+| T1／1 再現 | AC-1、INVAR-2、INV-1a／2、TR-1／2 | `crates/app-api/src/tests/` に ScoreGame freshness 専用 test module と必要最小の test double を追加。既存 CLI test も変更前に実行 | 一括／個別で A取得→B確定→A再開を制御し、修正前に B 不変 assert が失敗。writer を記録 | Memory／SQLite の失敗ログ、fixture の同期点、旧／新 row。CI原因と再現できた競合を区別 | なし |
+| T2／1 方針確定 | AC-2／4、INVAR-1／2、INV-1～3、TR-2／4／5 | hydration、`service/mod.rs`、subscription、game、store、Dome move の caller と candidate freshness を照合。上記第一候補の境界・共有方法を確定 | canonical 同一性、排他／atomic write、同 timestamp、戻り値と fallback、全 caller の適用／非適用が根拠付きで決まる | この計画または issue progress に判断を追記。未分類0、schema／public API変更なし | T1 |
+| T3／2 修正 | AC-2、INVAR-1／2、INV-1～3、TR-2／4／5 | `crates/app-api/src/game.rs`、`service/hydration_support.rs` と内部 coordination／subscription 配線を必要最小限変更。store 修正は T2 で必要と判定した場合だけ | T1 の同じ test が PASS。同 timestamp の古い候補、確認後の割込み、fallback、cancel でも退行しない | T1＋比較直後にも同期点を置いた競合 test。writer inventory 差分 | T2 |
+| T4／2 拒否契約 | AC-3、INVAR-1／2、INV-1a／3、TR-3 | AppService test double で blob／docs／projection mutation を計測し、`crates/kukuri-cli/tests/content_live.rs` の既存 assert を保持 | invalid／非 owner で禁止 mutation0、対象全列不変。背景 old hydration があっても退行しない | CLI invalid roster／non-owner、sink counter と before/after | T3 |
+| T5／3 互換・永続化 | AC-4、INVAR-1／2、INV-1b／2／3、TR-1／4／5 | store parity／row mapping、AppService game／Dome、hint retry、Runtime restart と private scope を確認。必要な regression test のみ追加 | Memory／SQLite、同 timestamp、複数 room、再取得／restart、Dome shared writer の契約が維持 | 下記 targeted tests、game persist、共有 writer 変更に応じた Dome scenario | T3、T4 |
+| T6／3 検証・記録 | AC-1～4、INVAR-1／2、全INV／TR | path別 validation、`docs/progress/2026-09-09-942-score-game-projection-freshness.md`（新規予定）へ before/after・判断・証跡を集約。実装した freshness 契約を ADR 0006 に最小限追記 | AC/INVAR→Task→test/evidence の孤立0、必須検証の成功／失敗／未実行を区別 | diff、test結果、inventory適合／未分類、正本文書との対応 | T5 |
+| T7／4 独立監査・完了判定 | AC-4、INVAR-1／2、全INV／TR | PR 作成が依頼された段階で固定 PR head を別担当または別コンテキストで監査。実装時の自己点検と分離 | PASS＋必須CI成功。merge承認がある場合のみmergeし、対象tree一致／delta監査後にIssue更新・Close | commit、Scope revision、全入口／sink逆引き、blocker0。PRは `Refs #942` | T6、PR作成／mergeの依頼範囲 |
+
+## 検証コマンドと選定
+
+実装開始時は既存 CLI contract を1回実行し、T1 の制御可能 test の失敗を先に保存する。その後は修正した同じ条件を再実行し、次の関連検証へ広げる。下記は実行予定であり、今回の PASS 報告ではない。
+
+```powershell
+cargo test -p kukuri-cli --test content_live game_lifecycle_rejects_invalid_roster_without_mutation -- --exact --nocapture
+cargo test -p kukuri-cli --test content_live game_update_by_non_owner_is_rejected_without_changing_replicated_state -- --exact --nocapture
+cargo test -p kukuri-app-api --lib game_projection_freshness -- --nocapture
+cargo test -p kukuri-app-api --lib tests::game -- --nocapture
+cargo test -p kukuri-app-api --lib tests::dome_listing -- --nocapture
+cargo test -p kukuri-store game_rooms_match_between_backends -- --nocapture
+cargo test -p kukuri-store game_room_roundtrip_preserves_all_columns -- --nocapture
+cargo test -p kukuri-desktop-runtime restart_restores_game_room_manifest -- --nocapture
+cargo xtask scenario desktop_smoke_game_room_persist
+cargo xtask rust-test
+cargo xtask oversized-files
+git diff --check
+```
+
+- `game_projection_freshness` は T1 で追加する module 名の予定。他は調査した既存 symbol／scenario。新規 test filter が実際に test を実行したことを件数と名前で確認する。
+- `crates/app-api/**` の必須は `cargo xtask rust-test`。store の永続化挙動も変更する場合は game persist scenario を必須とする。本件では再取得／restart の証拠として app 層だけの変更でも同 scenario を実行する。
+- 共有 store writer／Dome 経路へ変更が波及した場合は `tests::dome_move`、`desktop_smoke_metaverse_dome_persist`／`desktop_smoke_metaverse_dome_move` も実行する。private／hint／failure の新規 test 名は T5 で evidence に固定する。
+- `game_room_score_update_replicates` は `iroh-integration-tests` feature が必要であることを確認済み。`cargo test -p kukuri-app-api --features iroh-integration-tests game_room_score_update_replicates -- --nocapture` で実 peer の互換性を確認する。0 tests を成功証拠にしない。実行前の追加確認で、`xtask/src/rust.rs` の feature 指定は `app-api-slow-test` 専用と判明したため、通常の `rust-test` と分けてこの targeted command を実行する。
+- ADR 0006 に記載の `late_joiner_backfills_game_room_manifest` は今回の `crates` 検索では同名 test を確認できなかった。T5 で既存 replication test の実際の sequence に late join 相当の検証があるか確認し、不足分のみ freshness test または対応 contract に補う。
+- payload／UI／Tauri、docs-sync の実装、connectivity を変更しない想定。変更が必要になれば REFACTORING.md の対応行を追加適用する。
+- `game.rs` は現時点で990行であり、1000行以上への増加は oversized-files の対象。無関係な分割を混ぜず、必要な helper を既存責務に置く。baseline 緩和を黙って行わない。
+- PR前には可能なら `cargo xtask check` + `cargo xtask test`。重い検証の中断／未実行は開発手順と REFACTORING.md に従って理由・完了済み範囲・CI等での補完方法を記録する。
+
+## 未決事項と次の一手
+
+- 計画ファイルの確認: repository 内リンクの存在確認と `git diff --check`、新規ファイルの `git diff --no-index --check` を実施し、エラーなし。製品 test の実行証拠とは区別する。
+- 既知: 無条件 upsert の2つの hydration writer、拒否が保存前に行われること、同 timestamp の既存 parity 契約。
+- 作業仮定: blob await による旧 record 遅着を T1 で制御できる。T1 が成立しない場合は、固定した入口の trace に調査を戻す。
+- T2で決めること: room 単位の共有排他の配置と全 writer の包含、canonical照合後の再取得／fallbackの扱い。比較と書込みを別々の非atomic操作で終わらせない。
+- ユーザー判断が必要な条件: 調査の結果、固定した API／wire／schema／時刻／Metaverse の対象外を変更する必要が判明した場合のみ。現時点で計画作成を妨げる質問はない。
+- 次の一手: 実装が依頼・承認されたら HEAD／差分を確認し、T1 の修正前再現から開始する。追加発見は Existing-gap／Regression／New-requirement／Optional-hardening に分類し、固定 scope にない要件を完了条件へ追加しない。

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3154,6 +3154,7 @@ dependencies = [
  "n0-mainline",
  "serde",
  "serde_json",
+ "sqlx",
  "tempfile",
  "thiserror 2.0.20",
  "tokio",

--- a/crates/app-api/Cargo.toml
+++ b/crates/app-api/Cargo.toml
@@ -31,6 +31,7 @@ ts = ["dep:ts-rs", "kukuri-core/ts", "kukuri-store/ts", "kukuri-transport/ts"]
 iroh-integration-tests = []
 
 [dev-dependencies]
+sqlx.workspace = true
 kukuri-test-support = { path = "../test-support" }
 kukuri-iroh-node = { path = "../iroh-node" }
 tempfile.workspace = true

--- a/crates/app-api/src/game.rs
+++ b/crates/app-api/src/game.rs
@@ -189,6 +189,7 @@ impl AppService {
                 "status": "waiting",
             }),
         )?;
+        let projection_guard = self.services.game_room_projections.lock(&room_id).await;
         let state = self
             .persist_game_room_manifest(
                 &source_replica_id,
@@ -207,6 +208,7 @@ impl AppService {
                 &source_replica_id,
             ))
             .await?;
+        drop(projection_guard);
         self.services
             .hint_transport
             .publish_hint(
@@ -386,6 +388,7 @@ impl AppService {
         input: UpdateGameRoomInput,
     ) -> Result<()> {
         self.ensure_topic_subscription(topic_id).await?;
+        let projection_guard = self.services.game_room_projections.lock(room_id).await;
         let (source_replica_id, state, mut manifest) = self
             .fetch_game_room_state_and_manifest(topic_id, room_id)
             .await?
@@ -441,6 +444,7 @@ impl AppService {
                 &source_replica_id,
             ))
             .await?;
+        drop(projection_guard);
         self.services
             .hint_transport
             .publish_hint(

--- a/crates/app-api/src/service/game_projection_support.rs
+++ b/crates/app-api/src/service/game_projection_support.rs
@@ -1,0 +1,107 @@
+//! ScoreGame の canonical state と projection の書込み順を揃える。
+
+use super::*;
+use std::sync::Weak;
+use tokio::sync::OwnedMutexGuard;
+
+/// Store の一意キー(room_id)と同じ単位。handles の clone 間でも共有する。
+#[derive(Default)]
+pub(crate) struct GameRoomProjectionLocks {
+    rooms: Mutex<HashMap<String, Weak<Mutex<()>>>>,
+}
+
+impl GameRoomProjectionLocks {
+    pub(crate) async fn lock(&self, room_id: &str) -> OwnedMutexGuard<()> {
+        let lock = {
+            let mut rooms = self.rooms.lock().await;
+            rooms.retain(|_, lock| lock.strong_count() > 0);
+            match rooms.get(room_id).and_then(Weak::upgrade) {
+                Some(lock) => lock,
+                None => {
+                    let lock = Arc::new(Mutex::new(()));
+                    rooms.insert(room_id.to_string(), Arc::downgrade(&lock));
+                    lock
+                }
+            }
+        };
+        lock.lock_owned().await
+    }
+}
+
+pub(crate) async fn hydrate_game_room_from_record(
+    services: &ServiceHandles,
+    topic_id: &str,
+    replica: &ReplicaId,
+    mut record: DocRecord,
+) -> Result<bool> {
+    // A moving docs pointer may invalidate more than one fetch. Bound re-resolution;
+    // false keeps the existing caller's retry/recovery path, rather than claiming success.
+    for _ in 0..session_projection_retry_attempts() {
+        let state: GameRoomStateDocV1 = serde_json::from_slice(&record.value)?;
+        services
+            .projection_store
+            .mark_blob_status(
+                &state.current_manifest.hash,
+                blob_status(
+                    services
+                        .blob_service
+                        .blob_status(&state.current_manifest.hash)
+                        .await?,
+                ),
+            )
+            .await?;
+        let Some(manifest) = fetch_manifest_blob::<GameRoomManifestBlobV1>(
+            services.blob_service.as_ref(),
+            &state.current_manifest,
+        )
+        .await?
+        else {
+            return Ok(false);
+        };
+        // Slow blob I/O precedes the room lock. Other rooms never wait for it.
+        // Metaverse keeps its existing projection/lifecycle behavior.
+        let projection_guard = if manifest.room_kind == GameRoomKind::ScoreGame {
+            Some(services.game_room_projections.lock(&state.room_id).await)
+        } else {
+            None
+        };
+        let row = game_projection_row_from_state(&state, &manifest, topic_id, replica);
+        if projection_guard.is_some() {
+            let Some(current) = query_replica_local_only(
+                services.docs_sync.as_ref(),
+                replica,
+                DocQuery::Exact(record.key.clone()),
+            )
+            .await?
+            .into_iter()
+            .next() else {
+                return Ok(false);
+            };
+            if current.value != record.value {
+                // Neither timestamps nor hash ordering decide freshness: docs does.
+                // Drop this guard before fetching the current candidate's blob.
+                record = current;
+                continue;
+            }
+            if let Some(mut cached) = services
+                .projection_store
+                .list_topic_game_rooms(topic_id)
+                .await?
+                .into_iter()
+                .find(|cached| cached.room_id == row.room_id)
+            {
+                cached.derived_at = row.derived_at;
+                if cached == row {
+                    return Ok(true);
+                }
+            }
+        }
+        // For ScoreGame, canonical comparison and commit share the local writer lock.
+        services
+            .projection_store
+            .upsert_game_room_cache(row)
+            .await?;
+        return Ok(true);
+    }
+    Ok(false)
+}

--- a/crates/app-api/src/service/hydration_support.rs
+++ b/crates/app-api/src/service/hydration_support.rs
@@ -1,3 +1,4 @@
+use super::game_projection_support::hydrate_game_room_from_record;
 use super::*;
 
 fn scrub_withdrawn_header(mut header: CanonicalPostHeader) -> CanonicalPostHeader {
@@ -332,15 +333,7 @@ pub(crate) async fn hydrate_subscription_state(
         policy,
     )
     .await?;
-    let game_count = hydrate_game_rooms_from_replica(
-        docs_sync,
-        blob_service,
-        projection_store,
-        topic_id,
-        replica,
-        policy,
-    )
-    .await?;
+    let game_count = hydrate_game_rooms_from_replica(services, topic_id, replica, policy).await?;
     Ok(withdrawal_count + post_count + reaction_count + live_count + game_count)
 }
 
@@ -469,15 +462,13 @@ pub(crate) async fn hydrate_live_session_from_key_with_retry(
 }
 
 pub(crate) async fn hydrate_game_rooms_from_replica(
-    docs_sync: &dyn DocsSync,
-    blob_service: &dyn BlobService,
-    projection_store: &dyn ProjectionStore,
+    services: &ServiceHandles,
     topic_id: &str,
     replica: &ReplicaId,
     policy: DocFetchPolicy,
 ) -> Result<usize> {
     let records = query_replica_with_fetch_policy(
-        docs_sync,
+        services.docs_sync.as_ref(),
         replica,
         DocQuery::Prefix("sessions/game/".into()),
         policy,
@@ -485,74 +476,20 @@ pub(crate) async fn hydrate_game_rooms_from_replica(
     .await?;
     let mut hydrated = 0usize;
     for record in records {
-        let state: GameRoomStateDocV1 = serde_json::from_slice(&record.value)?;
-        projection_store
-            .mark_blob_status(
-                &state.current_manifest.hash,
-                blob_status(
-                    blob_service
-                        .blob_status(&state.current_manifest.hash)
-                        .await?,
-                ),
-            )
-            .await?;
-        let Some(manifest) =
-            fetch_manifest_blob::<GameRoomManifestBlobV1>(blob_service, &state.current_manifest)
-                .await?
-        else {
-            continue;
-        };
-        projection_store
-            .upsert_game_room_cache(game_projection_row_from_state(
-                &state, &manifest, topic_id, replica,
-            ))
-            .await?;
-        hydrated += 1;
+        hydrated +=
+            usize::from(hydrate_game_room_from_record(services, topic_id, replica, record).await?);
     }
     Ok(hydrated)
 }
 
-pub(crate) async fn hydrate_game_room_from_record(
-    blob_service: &dyn BlobService,
-    projection_store: &dyn ProjectionStore,
-    topic_id: &str,
-    replica: &ReplicaId,
-    record: DocRecord,
-) -> Result<bool> {
-    let state: GameRoomStateDocV1 = serde_json::from_slice(&record.value)?;
-    projection_store
-        .mark_blob_status(
-            &state.current_manifest.hash,
-            blob_status(
-                blob_service
-                    .blob_status(&state.current_manifest.hash)
-                    .await?,
-            ),
-        )
-        .await?;
-    let Some(manifest) =
-        fetch_manifest_blob::<GameRoomManifestBlobV1>(blob_service, &state.current_manifest)
-            .await?
-    else {
-        return Ok(false);
-    };
-    projection_store
-        .upsert_game_room_cache(game_projection_row_from_state(
-            &state, &manifest, topic_id, replica,
-        ))
-        .await?;
-    Ok(true)
-}
-
 pub(crate) async fn hydrate_game_room_from_key(
-    docs_sync: &dyn DocsSync,
-    blob_service: &dyn BlobService,
-    projection_store: &dyn ProjectionStore,
+    services: &ServiceHandles,
     topic_id: &str,
     replica: &ReplicaId,
     key: &str,
 ) -> Result<bool> {
-    let Some(record) = docs_sync
+    let Some(record) = services
+        .docs_sync
         .query_replica(replica, DocQuery::Exact(key.to_string()))
         .await?
         .into_iter()
@@ -560,28 +497,17 @@ pub(crate) async fn hydrate_game_room_from_key(
     else {
         return Ok(false);
     };
-    hydrate_game_room_from_record(blob_service, projection_store, topic_id, replica, record).await
+    hydrate_game_room_from_record(services, topic_id, replica, record).await
 }
 
 pub(crate) async fn hydrate_game_room_from_key_with_retry(
-    docs_sync: &dyn DocsSync,
-    blob_service: &dyn BlobService,
-    projection_store: &dyn ProjectionStore,
+    services: &ServiceHandles,
     topic_id: &str,
     replica: &ReplicaId,
     key: &str,
 ) -> Result<usize> {
     for attempt in 0..session_projection_retry_attempts() {
-        if hydrate_game_room_from_key(
-            docs_sync,
-            blob_service,
-            projection_store,
-            topic_id,
-            replica,
-            key,
-        )
-        .await?
-        {
+        if hydrate_game_room_from_key(services, topic_id, replica, key).await? {
             return Ok(1);
         }
         if attempt + 1 < session_projection_retry_attempts() {
@@ -628,15 +554,7 @@ pub(crate) async fn hydrate_subscription_event(
         .await;
     }
     if key.starts_with("sessions/game/") && key.ends_with("/state") {
-        return hydrate_game_room_from_key_with_retry(
-            docs_sync,
-            blob_service,
-            projection_store,
-            topic_id,
-            replica,
-            key,
-        )
-        .await;
+        return hydrate_game_room_from_key_with_retry(services, topic_id, replica, key).await;
     }
     Ok(0)
 }
@@ -728,9 +646,7 @@ pub(crate) async fn hydrate_subscription_hint(
             }
             "game-session" => {
                 hydrate_game_room_from_key_with_retry(
-                    docs_sync,
-                    blob_service,
-                    projection_store,
+                    services,
                     topic_id,
                     replica,
                     stable_key("sessions/game", &format!("{session_id}/state")).as_str(),

--- a/crates/app-api/src/service/mod.rs
+++ b/crates/app-api/src/service/mod.rs
@@ -125,8 +125,10 @@ mod direct_messages_subscription_support;
 mod dome_connection_support;
 pub(crate) use dome_connection_support::*;
 mod errors;
+mod game_projection_support;
 mod gossip_subscription_support;
 mod hydration_support;
+use game_projection_support::GameRoomProjectionLocks;
 #[cfg(test)]
 pub(crate) use hydration_support::{hydrate_game_room_from_key, hydrate_game_rooms_from_replica};
 mod live_game_support;
@@ -348,6 +350,7 @@ pub struct ServiceHandles {
     pub(crate) docs_sync: Arc<dyn DocsSync>,
     pub(crate) blob_service: Arc<dyn BlobService>,
     pub(crate) keys: Arc<KukuriKeys>,
+    pub(crate) game_room_projections: Arc<GameRoomProjectionLocks>,
 }
 
 impl ServiceHandles {
@@ -368,6 +371,7 @@ impl ServiceHandles {
             docs_sync,
             blob_service,
             keys: Arc::new(keys),
+            game_room_projections: Arc::default(),
         }
     }
 }

--- a/crates/app-api/src/service/mod.rs
+++ b/crates/app-api/src/service/mod.rs
@@ -127,6 +127,8 @@ pub(crate) use dome_connection_support::*;
 mod errors;
 mod gossip_subscription_support;
 mod hydration_support;
+#[cfg(test)]
+pub(crate) use hydration_support::{hydrate_game_room_from_key, hydrate_game_rooms_from_replica};
 mod live_game_support;
 pub(crate) use live_game_support::{DomeReadUnavailable, fetch_verified_dome_envelope};
 mod metaverse_room_event_support;

--- a/crates/app-api/src/tests/game_projection_freshness.rs
+++ b/crates/app-api/src/tests/game_projection_freshness.rs
@@ -1,0 +1,232 @@
+use super::*;
+use crate::service::{hydrate_game_room_from_key, hydrate_game_rooms_from_replica};
+use kukuri_docs_sync::DocFetchPolicy;
+use kukuri_store::GameRoomProjectionRow;
+use tokio::sync::Notify;
+
+const TOPIC: &str = "kukuri:topic:game-projection-freshness";
+
+#[derive(Default)]
+struct FetchGate {
+    entered: Notify,
+    release: Notify,
+}
+
+#[derive(Default)]
+struct GatedBlobService {
+    inner: MemoryBlobService,
+    gate: TokioMutex<Option<(kukuri_core::BlobHash, Arc<FetchGate>)>>,
+}
+
+impl GatedBlobService {
+    async fn pause_next_fetch(&self, hash: kukuri_core::BlobHash) -> Arc<FetchGate> {
+        let gate = Arc::new(FetchGate::default());
+        *self.gate.lock().await = Some((hash, gate.clone()));
+        gate
+    }
+}
+
+#[async_trait]
+impl BlobService for GatedBlobService {
+    async fn put_blob(&self, data: Vec<u8>, mime: &str) -> Result<StoredBlob> {
+        self.inner.put_blob(data, mime).await
+    }
+
+    async fn fetch_blob(&self, hash: &kukuri_core::BlobHash) -> Result<Option<Vec<u8>>> {
+        let gate = self.gate.lock().await.take_if(|(target, _)| target == hash);
+        if let Some((_, gate)) = gate {
+            gate.entered.notify_one();
+            gate.release.notified().await;
+        }
+        self.inner.fetch_blob(hash).await
+    }
+
+    async fn pin_blob(&self, hash: &kukuri_core::BlobHash) -> Result<()> {
+        self.inner.pin_blob(hash).await
+    }
+
+    async fn blob_status(&self, hash: &kukuri_core::BlobHash) -> Result<BlobStatus> {
+        self.inner.blob_status(hash).await
+    }
+
+    async fn import_peer_ticket(&self, ticket: &str) -> Result<()> {
+        self.inner.import_peer_ticket(ticket).await
+    }
+}
+
+struct Fixture {
+    app: AppService,
+    blobs: Arc<GatedBlobService>,
+    _root: tempfile::TempDir,
+}
+
+impl Fixture {
+    async fn new(sqlite: bool) -> Self {
+        let root = tempdir().unwrap();
+        let (store, projection_store): (Arc<dyn Store>, Arc<dyn ProjectionStore>) = if sqlite {
+            let store = Arc::new(
+                SqliteStore::connect_file(root.path().join("game.db"))
+                    .await
+                    .unwrap(),
+            );
+            (store.clone(), store)
+        } else {
+            let store = Arc::new(MemoryStore::default());
+            (store.clone(), store)
+        };
+        let blobs = Arc::new(GatedBlobService::default());
+        let app = AppService::from_handles(ServiceHandles::new(
+            store,
+            projection_store,
+            Arc::new(FakeTransport::new("game-fixture", FakeNetwork::default())),
+            Arc::new(NoopHintTransport),
+            Arc::new(MemoryDocsSync::default()),
+            blobs.clone(),
+            generate_keys(),
+        ));
+        // Drive bootstrap/event hydration explicitly so the test owns every writer's order.
+        app.gossip_disabled_topics.lock().await.insert(TOPIC.into());
+        Self {
+            app,
+            blobs,
+            _root: root,
+        }
+    }
+
+    async fn create(&self) -> String {
+        self.app
+            .create_game_room(
+                TOPIC,
+                CreateGameRoomInput {
+                    title: "finals".into(),
+                    description: "controlled hydration".into(),
+                    participants: vec!["Alice".into(), "Bob".into()],
+                },
+            )
+            .await
+            .unwrap()
+    }
+
+    async fn row(&self, room_id: &str) -> GameRoomProjectionRow {
+        self.app
+            .services
+            .projection_store
+            .list_topic_game_rooms(TOPIC)
+            .await
+            .unwrap()
+            .into_iter()
+            .find(|row| row.room_id == room_id)
+            .unwrap()
+    }
+
+    async fn update(&self, room_id: &str, score: i64) {
+        self.app
+            .update_game_room(TOPIC, room_id, update_input(score))
+            .await
+            .unwrap();
+    }
+}
+
+fn update_input(score: i64) -> UpdateGameRoomInput {
+    UpdateGameRoomInput {
+        status: GameRoomStatus::Running,
+        phase_label: Some("round 1".into()),
+        scores: vec![
+            GameScoreView {
+                participant_id: "participant-1".into(),
+                label: "Alice".into(),
+                score,
+            },
+            GameScoreView {
+                participant_id: "participant-2".into(),
+                label: "Bob".into(),
+                score: 0,
+            },
+        ],
+    }
+}
+
+async fn late_hydration_keeps_valid_update(sqlite: bool, batch: bool) {
+    let fixture = Fixture::new(sqlite).await;
+    let room_id = fixture.create().await;
+    let old = fixture.row(&room_id).await;
+    let gate = fixture
+        .blobs
+        .pause_next_fetch(old.manifest_blob_hash.clone())
+        .await;
+    let services = fixture.app.services.clone();
+    let key = old.source_key.clone();
+    let hydration = tokio::spawn(async move {
+        let replica = topic_replica_id(TOPIC);
+        if batch {
+            hydrate_game_rooms_from_replica(
+                services.docs_sync.as_ref(),
+                services.blob_service.as_ref(),
+                services.projection_store.as_ref(),
+                TOPIC,
+                &replica,
+                DocFetchPolicy::LocalOnly,
+            )
+            .await
+        } else {
+            hydrate_game_room_from_key(
+                services.docs_sync.as_ref(),
+                services.blob_service.as_ref(),
+                services.projection_store.as_ref(),
+                TOPIC,
+                &replica,
+                &key,
+            )
+            .await
+            .map(usize::from)
+        }
+    });
+    timeout(Duration::from_secs(5), gate.entered.notified())
+        .await
+        .expect("old record reached the blob fetch gate");
+    fixture.update(&room_id, 7).await;
+    let before = fixture.row(&room_id).await;
+    assert_eq!(before.scores[0].score, 7);
+    assert_ne!(old.manifest_blob_hash, before.manifest_blob_hash);
+    eprintln!(
+        "writer sequence: {} captured {}/{} at {}; update committed {} at {}; resume old hydration ({})",
+        if batch { "replica" } else { "record" },
+        old.source_replica_id.as_str(),
+        old.source_key,
+        old.updated_at,
+        before.manifest_blob_hash.as_str(),
+        before.updated_at,
+        old.manifest_blob_hash.as_str(),
+    );
+    gate.release.notify_one();
+    timeout(Duration::from_secs(5), hydration)
+        .await
+        .expect("old hydration completed")
+        .unwrap()
+        .unwrap();
+    let after = fixture.row(&room_id).await;
+    assert_eq!(
+        before, after,
+        "old hydration must not replace a confirmed valid update"
+    );
+}
+
+#[tokio::test]
+async fn late_record_hydration_keeps_valid_update_memory() {
+    late_hydration_keeps_valid_update(false, false).await;
+}
+
+#[tokio::test]
+async fn late_record_hydration_keeps_valid_update_sqlite() {
+    late_hydration_keeps_valid_update(true, false).await;
+}
+
+#[tokio::test]
+async fn late_replica_hydration_keeps_valid_update_memory() {
+    late_hydration_keeps_valid_update(false, true).await;
+}
+
+#[tokio::test]
+async fn late_replica_hydration_keeps_valid_update_sqlite() {
+    late_hydration_keeps_valid_update(true, true).await;
+}

--- a/crates/app-api/src/tests/game_projection_freshness.rs
+++ b/crates/app-api/src/tests/game_projection_freshness.rs
@@ -1,7 +1,9 @@
 use super::*;
+use crate::service::game_projection_support::hydrate_game_room_from_record;
 use crate::service::{hydrate_game_room_from_key, hydrate_game_rooms_from_replica};
-use kukuri_docs_sync::DocFetchPolicy;
+use kukuri_docs_sync::{DocEventStream, DocFetchPolicy, DocOp, DocQuery, DocRecord};
 use kukuri_store::GameRoomProjectionRow;
+use std::sync::atomic::AtomicUsize;
 use tokio::sync::Notify;
 
 const TOPIC: &str = "kukuri:topic:game-projection-freshness";
@@ -16,6 +18,10 @@ struct FetchGate {
 struct GatedBlobService {
     inner: MemoryBlobService,
     gate: TokioMutex<Option<(kukuri_core::BlobHash, Arc<FetchGate>)>>,
+    hidden: TokioMutex<HashSet<String>>,
+    puts: AtomicUsize,
+    pins: AtomicUsize,
+    missing_seen: Notify,
 }
 
 impl GatedBlobService {
@@ -29,6 +35,7 @@ impl GatedBlobService {
 #[async_trait]
 impl BlobService for GatedBlobService {
     async fn put_blob(&self, data: Vec<u8>, mime: &str) -> Result<StoredBlob> {
+        self.puts.fetch_add(1, Ordering::SeqCst);
         self.inner.put_blob(data, mime).await
     }
 
@@ -38,10 +45,15 @@ impl BlobService for GatedBlobService {
             gate.entered.notify_one();
             gate.release.notified().await;
         }
+        if self.hidden.lock().await.contains(hash.as_str()) {
+            self.missing_seen.notify_one();
+            return Ok(None);
+        }
         self.inner.fetch_blob(hash).await
     }
 
     async fn pin_blob(&self, hash: &kukuri_core::BlobHash) -> Result<()> {
+        self.pins.fetch_add(1, Ordering::SeqCst);
         self.inner.pin_blob(hash).await
     }
 
@@ -54,33 +66,131 @@ impl BlobService for GatedBlobService {
     }
 }
 
+#[derive(Default)]
+struct ControlledDocs {
+    inner: MemoryDocsSync,
+    writes: AtomicUsize,
+    queries: AtomicUsize,
+    fail_local_query: AtomicBool,
+    local_gate: TokioMutex<Option<(String, Arc<FetchGate>)>>,
+}
+
+#[async_trait]
+impl DocsSync for ControlledDocs {
+    async fn open_replica(&self, replica: &ReplicaId) -> Result<()> {
+        self.inner.open_replica(replica).await
+    }
+
+    async fn apply_doc_op(&self, replica: &ReplicaId, op: DocOp) -> Result<()> {
+        self.writes.fetch_add(1, Ordering::SeqCst);
+        self.inner.apply_doc_op(replica, op).await
+    }
+
+    async fn query_replica_with_policy(
+        &self,
+        replica: &ReplicaId,
+        query: DocQuery,
+        policy: DocFetchPolicy,
+    ) -> Result<Vec<DocRecord>> {
+        self.queries.fetch_add(1, Ordering::SeqCst);
+        if policy == DocFetchPolicy::LocalOnly && self.fail_local_query.load(Ordering::SeqCst) {
+            anyhow::bail!("injected canonical read failure");
+        }
+        let rows = self
+            .inner
+            .query_replica_with_policy(replica, query.clone(), policy)
+            .await?;
+        if let DocQuery::Exact(key) = query
+            && policy == DocFetchPolicy::LocalOnly
+        {
+            let gate = self
+                .local_gate
+                .lock()
+                .await
+                .take_if(|(target, _)| *target == key);
+            if let Some((_, gate)) = gate {
+                // The canonical snapshot is fixed; the caller must protect its commit.
+                gate.entered.notify_one();
+                gate.release.notified().await;
+            }
+        }
+        Ok(rows)
+    }
+
+    async fn subscribe_replica(&self, replica: &ReplicaId) -> Result<DocEventStream> {
+        self.inner.subscribe_replica(replica).await
+    }
+
+    async fn import_peer_ticket(&self, ticket: &str) -> Result<()> {
+        self.inner.import_peer_ticket(ticket).await
+    }
+}
+
+#[derive(Default)]
+struct CountingHints(AtomicUsize);
+
+#[async_trait]
+impl HintTransport for CountingHints {
+    async fn subscribe_hints(&self, _: &TopicId) -> Result<HintStream> {
+        Ok(Box::pin(futures_util::stream::pending()))
+    }
+
+    async fn unsubscribe_hints(&self, _: &TopicId) -> Result<()> {
+        Ok(())
+    }
+
+    async fn publish_hint(&self, _: &TopicId, _: GossipHint) -> Result<()> {
+        self.0.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+}
+
 struct Fixture {
     app: AppService,
     blobs: Arc<GatedBlobService>,
+    docs: Arc<ControlledDocs>,
+    hints: Arc<CountingHints>,
+    sqlite: Option<Arc<SqliteStore>>,
     _root: tempfile::TempDir,
 }
 
 impl Fixture {
     async fn new(sqlite: bool) -> Self {
         let root = tempdir().unwrap();
+        let mut sqlite_store = None;
         let (store, projection_store): (Arc<dyn Store>, Arc<dyn ProjectionStore>) = if sqlite {
             let store = Arc::new(
                 SqliteStore::connect_file(root.path().join("game.db"))
                     .await
                     .unwrap(),
             );
+            sqlx::raw_sql(
+                "CREATE TABLE game_projection_write_log (room_id TEXT, operation TEXT);
+                 CREATE TRIGGER observe_game_insert AFTER INSERT ON game_room_cache BEGIN
+                   INSERT INTO game_projection_write_log VALUES (NEW.room_id, 'insert'); END;
+                 CREATE TRIGGER observe_game_update AFTER UPDATE ON game_room_cache BEGIN
+                   INSERT INTO game_projection_write_log VALUES (NEW.room_id, 'update'); END;
+                 CREATE TRIGGER observe_game_delete AFTER DELETE ON game_room_cache BEGIN
+                   INSERT INTO game_projection_write_log VALUES (OLD.room_id, 'delete'); END;",
+            )
+            .execute(store.pool())
+            .await
+            .unwrap();
+            sqlite_store = Some(store.clone());
             (store.clone(), store)
         } else {
             let store = Arc::new(MemoryStore::default());
             (store.clone(), store)
         };
         let blobs = Arc::new(GatedBlobService::default());
+        let docs = Arc::new(ControlledDocs::default());
+        let hints = Arc::new(CountingHints::default());
         let app = AppService::from_handles(ServiceHandles::new(
             store,
             projection_store,
             Arc::new(FakeTransport::new("game-fixture", FakeNetwork::default())),
-            Arc::new(NoopHintTransport),
-            Arc::new(MemoryDocsSync::default()),
+            hints.clone(),
+            docs.clone(),
             blobs.clone(),
             generate_keys(),
         ));
@@ -89,6 +199,9 @@ impl Fixture {
         Self {
             app,
             blobs,
+            docs,
+            hints,
+            sqlite: sqlite_store,
             _root: root,
         }
     }
@@ -125,6 +238,90 @@ impl Fixture {
             .await
             .unwrap();
     }
+
+    async fn record(&self, room_id: &str) -> DocRecord {
+        self.docs
+            .query_replica(
+                &topic_replica_id(TOPIC),
+                DocQuery::Exact(stable_key("sessions/game", &format!("{room_id}/state"))),
+            )
+            .await
+            .unwrap()
+            .into_iter()
+            .next()
+            .unwrap()
+    }
+
+    async fn hydrate(&self, room_id: &str) -> Result<bool> {
+        hydrate_game_room_from_key(
+            &self.app.services,
+            TOPIC,
+            &topic_replica_id(TOPIC),
+            &stable_key("sessions/game", &format!("{room_id}/state")),
+        )
+        .await
+    }
+
+    async fn publish_state(&self, room_id: &str, score: i64, updated_at: i64) -> DocRecord {
+        let mut state: GameRoomStateDocV1 =
+            serde_json::from_slice(&self.record(room_id).await.value).unwrap();
+        let mut manifest: GameRoomManifestBlobV1 = serde_json::from_slice(
+            &self
+                .blobs
+                .inner
+                .fetch_blob(&state.current_manifest.hash)
+                .await
+                .unwrap()
+                .unwrap(),
+        )
+        .unwrap();
+        manifest.scores[0].score = score;
+        manifest.status = GameRoomStatus::Running;
+        manifest.phase_label = Some("round 1".into());
+        manifest.updated_at = updated_at;
+        let blob = store_manifest_blob(self.blobs.as_ref(), &manifest, GAME_MANIFEST_MIME)
+            .await
+            .unwrap();
+        state.status = manifest.status;
+        state.updated_at = updated_at;
+        state.current_manifest = ManifestBlobRef {
+            hash: blob.hash,
+            mime: blob.mime,
+            bytes: blob.bytes,
+        };
+        persist_game_room_state(self.docs.as_ref(), &topic_replica_id(TOPIC), &state)
+            .await
+            .unwrap();
+        self.record(room_id).await
+    }
+
+    async fn mutation_counts(&self) -> (usize, usize, usize, usize, Option<i64>) {
+        let db_writes = if let Some(store) = &self.sqlite {
+            Some(
+                sqlx::query_scalar("SELECT COUNT(*) FROM game_projection_write_log")
+                    .fetch_one(store.pool())
+                    .await
+                    .unwrap(),
+            )
+        } else {
+            None
+        };
+        (
+            self.docs.writes.load(Ordering::SeqCst),
+            self.blobs.puts.load(Ordering::SeqCst),
+            self.blobs.pins.load(Ordering::SeqCst),
+            self.hints.0.load(Ordering::SeqCst),
+            db_writes,
+        )
+    }
+
+    async fn another_author(&self) -> AppService {
+        let mut services = self.app.services.clone();
+        services.keys = Arc::new(generate_keys());
+        let app = AppService::from_handles(services);
+        app.gossip_disabled_topics.lock().await.insert(TOPIC.into());
+        app
+    }
 }
 
 fn update_input(score: i64) -> UpdateGameRoomInput {
@@ -159,26 +356,12 @@ async fn late_hydration_keeps_valid_update(sqlite: bool, batch: bool) {
     let hydration = tokio::spawn(async move {
         let replica = topic_replica_id(TOPIC);
         if batch {
-            hydrate_game_rooms_from_replica(
-                services.docs_sync.as_ref(),
-                services.blob_service.as_ref(),
-                services.projection_store.as_ref(),
-                TOPIC,
-                &replica,
-                DocFetchPolicy::LocalOnly,
-            )
-            .await
+            hydrate_game_rooms_from_replica(&services, TOPIC, &replica, DocFetchPolicy::LocalOnly)
+                .await
         } else {
-            hydrate_game_room_from_key(
-                services.docs_sync.as_ref(),
-                services.blob_service.as_ref(),
-                services.projection_store.as_ref(),
-                TOPIC,
-                &replica,
-                &key,
-            )
-            .await
-            .map(usize::from)
+            hydrate_game_room_from_key(&services, TOPIC, &replica, &key)
+                .await
+                .map(usize::from)
         }
     });
     timeout(Duration::from_secs(5), gate.entered.notified())
@@ -229,4 +412,471 @@ async fn late_replica_hydration_keeps_valid_update_memory() {
 #[tokio::test]
 async fn late_replica_hydration_keeps_valid_update_sqlite() {
     late_hydration_keeps_valid_update(true, true).await;
+}
+
+async fn rejected_updates_do_not_mutate(sqlite: bool) {
+    let fixture = Fixture::new(sqlite).await;
+    let room_id = fixture.create().await;
+    fixture.update(&room_id, 7).await;
+    let before = fixture.row(&room_id).await;
+    let record = fixture.record(&room_id).await;
+    let manifest = fixture
+        .blobs
+        .inner
+        .fetch_blob(&before.manifest_blob_hash)
+        .await
+        .unwrap();
+    let writes = fixture.mutation_counts().await;
+    assert!(writes.0 >= 2 && writes.1 >= 2 && writes.3 >= 2);
+    if sqlite {
+        assert_eq!(
+            writes.4,
+            Some(2),
+            "the trigger observes both successful cache writes"
+        );
+    }
+
+    let mut empty = update_input(8);
+    empty.scores.clear();
+    let mut unknown = update_input(8);
+    unknown.scores[1].participant_id = "unknown".into();
+    let mut duplicate = update_input(8);
+    duplicate.scores[1] = duplicate.scores[0].clone();
+    let mut renamed = update_input(8);
+    renamed.scores[0].label = "renamed".into();
+    for input in [empty, unknown, duplicate, renamed] {
+        fixture
+            .app
+            .update_game_room(TOPIC, &room_id, input)
+            .await
+            .expect_err("invalid roster");
+        assert_eq!(fixture.mutation_counts().await, writes);
+        assert_eq!(fixture.record(&room_id).await, record);
+        assert_eq!(fixture.row(&room_id).await, before);
+    }
+    let non_owner = fixture.another_author().await;
+    let error = non_owner
+        .update_game_room(TOPIC, &room_id, update_input(8))
+        .await
+        .unwrap_err();
+    assert!(error.to_string().contains("only the game room owner"));
+    assert_eq!(fixture.mutation_counts().await, writes);
+    assert_eq!(fixture.record(&room_id).await, record);
+    assert_eq!(fixture.row(&room_id).await, before);
+    assert_eq!(
+        fixture
+            .blobs
+            .inner
+            .fetch_blob(&before.manifest_blob_hash)
+            .await
+            .unwrap(),
+        manifest
+    );
+}
+
+#[tokio::test]
+async fn rejected_updates_do_not_mutate_memory() {
+    rejected_updates_do_not_mutate(false).await;
+}
+
+#[tokio::test]
+async fn rejected_updates_do_not_mutate_sqlite() {
+    rejected_updates_do_not_mutate(true).await;
+}
+
+async fn refresh_trigger(services: &ServiceHandles, room_id: &str, hint: bool) -> Result<usize> {
+    let replica = topic_replica_id(TOPIC);
+    if hint {
+        hydrate_subscription_hint(
+            services,
+            TOPIC,
+            &replica,
+            &GossipHint::SessionChanged {
+                topic_id: TopicId::new(TOPIC),
+                session_id: room_id.into(),
+                object_kind: "game-session".into(),
+            },
+        )
+        .await
+    } else {
+        hydrate_subscription_event(
+            services,
+            TOPIC,
+            &replica,
+            &stable_key("sessions/game", &format!("{room_id}/state")),
+        )
+        .await
+    }
+}
+
+async fn current_pointer_wins_at_same_timestamp(hint: bool) {
+    for sqlite in [false, true] {
+        let fixture = Fixture::new(sqlite).await;
+        let room_id = fixture.create().await;
+        let old_record = fixture.publish_state(&room_id, 1, 100).await;
+        assert!(fixture.hydrate(&room_id).await.unwrap());
+        let old_row = fixture.row(&room_id).await;
+        let gate = fixture
+            .blobs
+            .pause_next_fetch(old_row.manifest_blob_hash.clone())
+            .await;
+        let services = fixture.app.services.clone();
+        let room = room_id.clone();
+        let refresh = tokio::spawn(async move { refresh_trigger(&services, &room, hint).await });
+        timeout(Duration::from_secs(5), gate.entered.notified())
+            .await
+            .unwrap();
+        fixture.publish_state(&room_id, 7, 100).await;
+        // B exists only in canonical docs/blobs; stale A must resolve B, not merely skip.
+        assert_eq!(fixture.row(&room_id).await, old_row);
+        gate.release.notify_one();
+        assert_eq!(
+            timeout(Duration::from_secs(5), refresh)
+                .await
+                .unwrap()
+                .unwrap()
+                .unwrap(),
+            1
+        );
+        let latest = fixture.row(&room_id).await;
+        assert_eq!(latest.updated_at, old_row.updated_at);
+        assert_eq!(latest.scores[0].score, 7);
+        assert_ne!(latest.manifest_blob_hash, old_row.manifest_blob_hash);
+
+        let writes = fixture.mutation_counts().await;
+        assert!(
+            hydrate_game_room_from_record(
+                &fixture.app.services,
+                TOPIC,
+                &topic_replica_id(TOPIC),
+                old_record,
+            )
+            .await
+            .unwrap()
+        );
+        assert_eq!(
+            fixture.row(&room_id).await,
+            latest,
+            "replaying A keeps all of B's columns"
+        );
+        assert_eq!(
+            fixture.mutation_counts().await,
+            writes,
+            "replay does not rewrite B"
+        );
+    }
+}
+
+#[tokio::test]
+async fn docs_event_resolves_current_pointer_at_same_timestamp() {
+    current_pointer_wins_at_same_timestamp(false).await;
+}
+
+#[tokio::test]
+async fn hint_resolves_current_pointer_at_same_timestamp() {
+    current_pointer_wins_at_same_timestamp(true).await;
+}
+
+async fn comparison_and_commit_exclude_same_room_writer(sqlite: bool) {
+    let fixture = Fixture::new(sqlite).await;
+    let room_id = fixture.create().await;
+    let another = fixture.another_author().await;
+    let other_room = another
+        .create_game_room(
+            TOPIC,
+            CreateGameRoomInput {
+                title: "other".into(),
+                description: String::new(),
+                participants: vec!["Alice".into(), "Bob".into()],
+            },
+        )
+        .await
+        .unwrap();
+    assert_ne!(room_id, other_room);
+    let gate = Arc::new(FetchGate::default());
+    *fixture.docs.local_gate.lock().await =
+        Some((fixture.row(&room_id).await.source_key, gate.clone()));
+    let services = fixture.app.services.clone();
+    let room = room_id.clone();
+    let hydration = tokio::spawn(async move { refresh_trigger(&services, &room, false).await });
+    timeout(Duration::from_secs(5), gate.entered.notified())
+        .await
+        .unwrap();
+
+    let reads = fixture.docs.queries.load(Ordering::SeqCst);
+    let mut update = Box::pin(
+        fixture
+            .app
+            .update_game_room(TOPIC, &room_id, update_input(7)),
+    );
+    assert!(futures_util::poll!(update.as_mut()).is_pending());
+    assert_eq!(
+        fixture.docs.queries.load(Ordering::SeqCst),
+        reads,
+        "same-room update cannot even read its mutable base until hydration commits"
+    );
+    timeout(
+        Duration::from_secs(5),
+        another.update_game_room(TOPIC, &other_room, update_input(3)),
+    )
+    .await
+    .unwrap()
+    .unwrap();
+    let other_before = fixture.row(&other_room).await;
+    assert_eq!(other_before.scores[0].score, 3);
+    gate.release.notify_one();
+    timeout(Duration::from_secs(5), hydration)
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+    timeout(Duration::from_secs(5), update)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(fixture.row(&room_id).await.scores[0].score, 7);
+    assert_eq!(fixture.row(&other_room).await, other_before);
+}
+
+#[tokio::test]
+async fn comparison_and_commit_exclude_same_room_writer_memory() {
+    comparison_and_commit_exclude_same_room_writer(false).await;
+}
+
+#[tokio::test]
+async fn comparison_and_commit_exclude_same_room_writer_sqlite() {
+    comparison_and_commit_exclude_same_room_writer(true).await;
+}
+
+#[tokio::test]
+async fn canonical_read_failure_and_cancel_release_the_room() {
+    for sqlite in [false, true] {
+        let fixture = Fixture::new(sqlite).await;
+        let room_id = fixture.create().await;
+        let before = fixture.row(&room_id).await;
+        let writes = fixture.mutation_counts().await;
+        fixture.docs.fail_local_query.store(true, Ordering::SeqCst);
+        assert!(
+            fixture
+                .hydrate(&room_id)
+                .await
+                .unwrap_err()
+                .to_string()
+                .contains("canonical read failure")
+        );
+        assert_eq!(fixture.row(&room_id).await, before);
+        assert_eq!(fixture.mutation_counts().await, writes);
+        fixture.docs.fail_local_query.store(false, Ordering::SeqCst);
+
+        let gate = Arc::new(FetchGate::default());
+        *fixture.docs.local_gate.lock().await = Some((before.source_key.clone(), gate.clone()));
+        let services = fixture.app.services.clone();
+        let room = room_id.clone();
+        let hydration = tokio::spawn(async move { refresh_trigger(&services, &room, false).await });
+        timeout(Duration::from_secs(5), gate.entered.notified())
+            .await
+            .unwrap();
+        hydration.abort();
+        assert!(hydration.await.unwrap_err().is_cancelled());
+        timeout(
+            Duration::from_secs(5),
+            fixture
+                .app
+                .update_game_room(TOPIC, &room_id, update_input(7)),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        assert_eq!(fixture.row(&room_id).await.scores[0].score, 7);
+    }
+}
+
+#[tokio::test]
+async fn missing_blob_retry_refreshes_without_overwriting_the_cache() {
+    for sqlite in [false, true] {
+        let fixture = Fixture::new(sqlite).await;
+        let room_id = fixture.create().await;
+        fixture.update(&room_id, 7).await;
+        let before = fixture.row(&room_id).await;
+        let record = fixture.publish_state(&room_id, 8, before.updated_at).await;
+        let state: GameRoomStateDocV1 = serde_json::from_slice(&record.value).unwrap();
+        fixture
+            .blobs
+            .hidden
+            .lock()
+            .await
+            .insert(state.current_manifest.hash.as_str().into());
+        let writes = fixture.mutation_counts().await;
+        let services = fixture.app.services.clone();
+        let room = room_id.clone();
+        let hydration = tokio::spawn(async move { refresh_trigger(&services, &room, false).await });
+        timeout(
+            Duration::from_secs(5),
+            fixture.blobs.missing_seen.notified(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(fixture.row(&room_id).await, before);
+        assert_eq!(fixture.mutation_counts().await, writes);
+        fixture.blobs.hidden.lock().await.clear();
+        assert_eq!(
+            timeout(Duration::from_secs(15), hydration)
+                .await
+                .unwrap()
+                .unwrap()
+                .unwrap(),
+            1
+        );
+        assert_eq!(fixture.row(&room_id).await.scores[0].score, 8);
+    }
+}
+
+#[tokio::test]
+async fn missing_and_corrupt_canonical_state_do_not_apply_the_candidate() {
+    for sqlite in [false, true] {
+        let fixture = Fixture::new(sqlite).await;
+        let room_id = fixture.create().await;
+        fixture.update(&room_id, 7).await;
+        let before = fixture.row(&room_id).await;
+        let record = fixture.record(&room_id).await;
+        let replica = topic_replica_id(TOPIC);
+        fixture
+            .docs
+            .apply_doc_op(
+                &replica,
+                DocOp::DeletePrefix {
+                    prefix: record.key.clone(),
+                },
+            )
+            .await
+            .unwrap();
+        assert!(
+            !hydrate_game_room_from_record(&fixture.app.services, TOPIC, &replica, record.clone())
+                .await
+                .unwrap()
+        );
+        assert_eq!(fixture.row(&room_id).await, before);
+        fixture
+            .docs
+            .apply_doc_op(
+                &replica,
+                DocOp::SetBytes {
+                    key: record.key.clone(),
+                    value: b"invalid json".to_vec(),
+                },
+            )
+            .await
+            .unwrap();
+        assert!(fixture.hydrate(&room_id).await.is_err());
+        assert_eq!(fixture.row(&room_id).await, before);
+        fixture
+            .docs
+            .apply_doc_op(
+                &replica,
+                DocOp::SetBytes {
+                    key: record.key,
+                    value: record.value,
+                },
+            )
+            .await
+            .unwrap();
+        let writes = fixture.mutation_counts().await;
+        assert!(fixture.hydrate(&room_id).await.unwrap());
+        assert_eq!(fixture.row(&room_id).await, before);
+        assert_eq!(fixture.mutation_counts().await, writes);
+    }
+}
+
+#[tokio::test]
+async fn cache_write_failure_is_recoverable_from_canonical_state() {
+    let fixture = Fixture::new(true).await;
+    let room_id = fixture.create().await;
+    let before = fixture.row(&room_id).await;
+    let store = fixture.sqlite.as_ref().unwrap();
+    sqlx::raw_sql(
+        "CREATE TRIGGER fail_game_cache BEFORE INSERT ON game_room_cache BEGIN
+        SELECT RAISE(ABORT, 'injected cache write failure'); END;",
+    )
+    .execute(store.pool())
+    .await
+    .unwrap();
+    assert!(
+        fixture
+            .app
+            .update_game_room(TOPIC, &room_id, update_input(7))
+            .await
+            .unwrap_err()
+            .to_string()
+            .contains("injected cache write failure")
+    );
+    assert_eq!(fixture.row(&room_id).await, before);
+    sqlx::raw_sql("DROP TRIGGER fail_game_cache")
+        .execute(store.pool())
+        .await
+        .unwrap();
+    assert!(
+        timeout(Duration::from_secs(5), fixture.hydrate(&room_id))
+            .await
+            .unwrap()
+            .unwrap()
+    );
+    assert_eq!(fixture.row(&room_id).await.scores[0].score, 7);
+}
+
+#[tokio::test]
+async fn restart_and_missing_cache_resolve_docs_at_the_same_timestamp() {
+    let fixture = Fixture::new(true).await;
+    let room_id = fixture.create().await;
+    fixture.publish_state(&room_id, 1, 100).await;
+    assert!(fixture.hydrate(&room_id).await.unwrap());
+    fixture.publish_state(&room_id, 7, 100).await;
+    let path = fixture._root.path().join("game.db");
+    let mut services = fixture.app.services.clone();
+    fixture.app.shutdown().await;
+    fixture.sqlite.as_ref().unwrap().close().await;
+    let reopened = Arc::new(SqliteStore::connect_file(&path).await.unwrap());
+    services.store = reopened.clone();
+    services.projection_store = reopened.clone();
+    services.game_room_projections = Arc::default();
+    assert_eq!(
+        hydrate_game_rooms_from_replica(
+            &services,
+            TOPIC,
+            &topic_replica_id(TOPIC),
+            DocFetchPolicy::LocalOnly
+        )
+        .await
+        .unwrap(),
+        1
+    );
+    let row = reopened
+        .list_topic_game_rooms(TOPIC)
+        .await
+        .unwrap()
+        .remove(0);
+    assert_eq!(row.updated_at, 100);
+    assert_eq!(row.scores[0].score, 7);
+    sqlx::query("DELETE FROM game_room_cache")
+        .execute(reopened.pool())
+        .await
+        .unwrap();
+    assert_eq!(
+        hydrate_game_rooms_from_replica(
+            &services,
+            TOPIC,
+            &topic_replica_id(TOPIC),
+            DocFetchPolicy::LocalOnly
+        )
+        .await
+        .unwrap(),
+        1
+    );
+    let rebuilt = reopened
+        .list_topic_game_rooms(TOPIC)
+        .await
+        .unwrap()
+        .remove(0);
+    assert_eq!(rebuilt.manifest_blob_hash, row.manifest_blob_hash);
+    assert_eq!(rebuilt.scores, row.scores);
+    reopened.close().await;
 }

--- a/crates/app-api/src/tests/mod.rs
+++ b/crates/app-api/src/tests/mod.rs
@@ -60,6 +60,7 @@ mod dome_hosting;
 mod dome_listing;
 mod dome_move;
 mod game;
+mod game_projection_freshness;
 mod live;
 mod media;
 mod media_adult_gating;

--- a/docs/adr/0006-game-room-data-classification.md
+++ b/docs/adr/0006-game-room-data-classification.md
@@ -26,6 +26,8 @@ Accepted
 - game room manifest 本体は JSON blob として `iroh-blobs` に保存し、score/status 更新のたびに新しい blob hash を払い出す。
 - participant は create 時に固定し、v1 では add/remove や owner handoff を許可しない。
 - room 更新は owner のみ許可し、`Finished` 遷移後は immutable にする。
+- ScoreGame の local update と hydration の projection commit は room 単位で直列化する。hydration は blob 取得後に現在の local docs state を再確認し、取得中に pointer が変わった候補を cache へ書かない。新旧の判断に timestamp の大小や hash の辞書順を使わず、同 timestamp の正当な pointer 更新も反映する。
+- 同じ canonical state から同じ ScoreGame projection を再取得した場合は、`derived_at` だけを更新する書込みも行わない。Metaverse の専用 lifecycle／authority はこの ScoreGame の制御で変更しない。
 
 ## Consequences
 - late joiner と restart 後の復元は `docs state + manifest blob` だけで成立しなければならない。

--- a/docs/progress/2026-09-09-942-score-game-projection-freshness.md
+++ b/docs/progress/2026-09-09-942-score-game-projection-freshness.md
@@ -2,7 +2,7 @@
 
 ## 現在の状態
 
-- 状態: 修正とtargeted contract追加が完了し、関連validationを実行中。
+- 状態: 実装・ローカル必須検証を完了。本書はその時点の証跡であり、PR head監査・CI・mergeの最終判定は [PR #951](https://github.com/KingYoSun/kukuri/pull/951) とIssueの`Current status`に記録する。
 - Issue: [#942](https://github.com/KingYoSun/kukuri/issues/942)。区分C。
 - Scope revision: `2026-09-08-score-game-projection-freshness-v1`。
 - 調査・実装開始基準: `58328f035a391f8f321bffdf6287cd339228fec7`。
@@ -74,6 +74,25 @@ production upsert呼出しは11→10箇所。一括／個別hydrateの2 sinkを�
 
 ## 検証・監査
 
-- `cargo test -p kukuri-app-api --lib game_projection_freshness -- --nocapture`: 15 passed、0 failed、0 ignored（1.05秒）。
-- CLI／store parity／既存game・Dome／Runtime restart、scenario、path別validationは実行中。独立監査、CI、merge tree照合は未実施。
+検証対象の実装commitは`9ef60ddff285008b9ad288d09af8ed23fd2d5412`。この後の計画・本記録の更新は文書のみで、製品とtestのtreeを変更していない。
+
+| 実行command | 結果 |
+| --- | --- |
+| `cargo test -p kukuri-app-api --lib game_projection_freshness -- --nocapture` | 15 PASS、0 failed、0 ignored（1.05秒） |
+| `cargo test -p kukuri-cli --test content_live game_ -- --nocapture` | invalid roster／nonownerの2 PASS。元のassertは無変更 |
+| `cargo test -p kukuri-store game_room -- --nocapture` | backend parity／row mapping／migrationを含む11 PASS |
+| `cargo test -p kukuri-app-api --lib tests::game -- --nocapture` | 26 PASS（新規15件を含む） |
+| `cargo test -p kukuri-app-api --lib tests::dome_ -- --nocapture` | listing／connection／hosting／moveの17 PASS |
+| `cargo test -p kukuri-desktop-runtime restart_restores_game_room_manifest -- --nocapture` | 1 PASS |
+| `cargo clippy -p kukuri-app-api --all-targets -- -D warnings` | PASS |
+| `cargo test -p kukuri-app-api --features iroh-integration-tests game_room_score_update_replicates -- --nocapture` | 実peerで1 PASS |
+| `cargo xtask scenario desktop_smoke_game_room_persist` | 7 steps PASS |
+| `cargo xtask rust-test` | exit 0。non-CN主suite 902 PASS／4 skipped、serial harness 22 PASS、doctest処理正常終了（対象内のdoctestは0件）。skip設定の追加／変更なし |
+| `cargo xtask oversized-files` | exit 0。既存大型fileのwarningのみ。baseline変更なし |
+| `git diff --check` | PASS |
+
+`rust-test`のharnessにはDome persist／moveとprivate-channel関連の既存scenarioも含まれる。full suite完了後の同じtestの重複実行は行わない。frontend/Tauri、docs-syncの実装・connectivity契約に変更はなく、追加のローカルUI gateやCN全suiteは変更path別の必須対象ではない。PRで起動したCIは別途すべての結果を確認する。
+
 - ADR 0006の`late_joiner_backfills_game_room_manifest`という同名testは現行にはない。現行`game_room_score_update_replicates`はsender側create/update完了後にreceiverが初めて`list_game_rooms`でsubscribeするsequenceを持つため、latest stateのlate-join取得証跡として同testをfeature有効で実行する。
+
+独立監査の初回は`9ef60ddf`を対象に別コンテキストで実施し、固定INV-1～3は合計3／適合3／不適合0／未分類0、code blocker 0と報告された。その時点ではRust suite実行中のため総合判定を`INCONCLUSIVE`として保留した。上表の完了ログと最終PR headの文書deltaを追加監査し、その最終判定をPRに記録する。CI前・監査保留中の状態をmerge可能とは扱わない。

--- a/docs/progress/2026-09-09-942-score-game-projection-freshness.md
+++ b/docs/progress/2026-09-09-942-score-game-projection-freshness.md
@@ -2,7 +2,7 @@
 
 ## 現在の状態
 
-- 状態: 実装中。修正前の制御可能な再現を確認済み。
+- 状態: 修正とtargeted contract追加が完了し、関連validationを実行中。
 - Issue: [#942](https://github.com/KingYoSun/kukuri/issues/942)。区分C。
 - Scope revision: `2026-09-08-score-game-projection-freshness-v1`。
 - 調査・実装開始基準: `58328f035a391f8f321bffdf6287cd339228fec7`。
@@ -10,6 +10,8 @@
 - 計画とAC／INVAR・固定inventory／transition: [実装プラン](../../.codex.plans/2026-09-09-issue-942-score-game-projection-freshness.md)。
 
 ## 修正前の再現（AC-1）
+
+修正前test commit: `681ef2361502dba50b3bb23f60a337077f46174d`。製品の書込み処理は実装開始基準と同一で、test用のcrate内re-export以外はtestと文書のみ。
 
 `crates/app-api/src/tests/game_projection_freshness.rs` のfixtureは、対象topicの自動購読を停止し、一括／個別hydrationを明示的に実行する。実際のAppService create/updateと実際のMemory／SQLite storeを使い、旧manifestのblob fetchだけを`Notify`で停止する。旧record取得 → blob待機 → Running／round1／Alice7更新 → row確認 → 旧fetch再開の順をtestが所有する。
 
@@ -34,6 +36,44 @@
 - storeの公開trait・Memory／SQLite writer・DB schemaは変更せず、既存production ScoreGame callerの前段を保護する。Metaverse用hydrateは既存の無条件upsertを維持する。
 - 共有Dome moveの3 writerはsource relationship detach、target active化、source tombstone化。ScoreGameの制御対象には入れず、既存Dome testsで互換性を確認する。
 
+## 実装・inventory差分
+
+- `service/game_projection_support.rs`: room単位の共有排他とhydrate commitを所有。使用中のroomだけを`Weak`で保持し、処理完了／cancel後に使われていないlockを再利用対象から除く。
+- `service/mod.rs`: privateな`ServiceHandles.game_room_projections`を追加し、constructor内部で初期化。公開引数・wire・DB schemaは不変。
+- `game.rs`: ScoreGame create/updateの保存～cache writeに同じ排他を適用し、hint publish前に解放。updateは更新元のstate読込みより前に排他を取得する。
+- `service/hydration_support.rs`: 一括／個別のgame hydrationを同じrecord helperに接続。各既存entryのfetch policyと、未取得時の既存key retry／fallbackを維持する。
+- `service/game_projection_support.rs` の再照合でpointerが動いた場合、現在のrecordを再解決する。移動し続けるpointerへの再解決は既存`session_projection_retry_attempts()`で上限を付け、未完了は`false`で既存retry/recoveryに返す。実際に最新rowを確立するか、既存rowの一致を確認するまで成功扱いにしない。
+- `crates/store`、Dome move、Metaverse writerは変更なし。新しいSQLx dev dependencyは既存workspace依存を使ったtest用SQLite triggerの観測だけに使用し、production依存は増やさない。
+
+production upsert呼出しは11→10箇所。一括／個別hydrateの2 sinkを新helperの1 sinkへ統合し、game.rsの6箇所とdome_move.rsの3箇所は残る。ScoreGame制御はcreate/updateと新helperのScoreGame分岐、Metaverseの残り4+3 callerと新helperのMetaverse分岐は互換確認対象。公開入口の追加／削除はない。
+
+| 固定inventory | 実装上の適用・互換確認 |
+| --- | --- |
+| INV-1a | `create_game_room_in_channel`／`update_game_room`のroom排他。owner／transition／roster guard後に保存。CLI／Tauri／Runtime登録点に変更なし |
+| INV-1b | listの空cache hydrationが共通helperに到達。public/private scope・mute・Dome readinessの判定は変更なし |
+| INV-2a | bootstrap／scope再取得／fallback→一括helper→同じrecord commit。prefix query policyは維持 |
+| INV-2b | docs event／hint→key retry→同じrecord commit。current確認の追加readはLocalOnly。早期return／error／cancelはguardを解放 |
+| INV-3a | Memory／SQLiteのwriter契約は維持。app層の同じ境界で両backendを検証 |
+| INV-3b | Metaverse create/update/event/asset、Dome source-detach／target-active／source-tombstoneは既存writerのまま |
+
+## 条件と追加testの対応
+
+以下のtest名は`service::tests::game_projection_freshness::`配下。両backendをloopするtestは個別に明記する。
+
+| AC／INVAR・TR | test／観測 |
+| --- | --- |
+| AC-1／2、INVAR-2、TR-2 | `late_{record,replica}_hydration_keeps_valid_update_{memory,sqlite}`。修正前4 FAIL→修正後4 PASS、同じsequence／全row assert |
+| AC-3、INVAR-1、TR-3 | `rejected_updates_do_not_mutate_{memory,sqlite}`。空／未知／重複／label変更と非owner。docs apply、blob put/pin、hint、SQLite insert/update/delete回数不変。canonical bytes・manifest bytes・全row不変。成功create/updateがtriggerで2 writeとして観測されることも確認 |
+| AC-2／4、INVAR-1／2、TR-4 | `docs_event_resolves_current_pointer_at_same_timestamp`／`hint_resolves_current_pointer_at_same_timestamp`（両backend）。旧fetch停止中にtimestamp100の新manifestをdocsに置き、cache未反映から最新へ収束。その後の旧record replayで全rowとmutation回数不変 |
+| AC-2／4、TR-2／4 | `comparison_and_commit_exclude_same_room_writer_{memory,sqlite}`。canonical snapshot取得を止めた状態で同room updateをpollし、更新元readに進めないことを確認。別owner・別roomのupdateは完了し、そのrowを巻き込まない |
+| AC-4、TR-5 | `canonical_read_failure_and_cancel_release_the_room`（両backend）。LocalOnly再照合のエラー／cancelでrow不変、次updateが完了 |
+| AC-4、TR-5 | `missing_blob_retry_refreshes_without_overwriting_the_cache`（両backend）。実際の既存key retryを通し、未取得の観測通知後にblobを利用可能にする。任意sleepは追加しない |
+| AC-4、TR-5 | `missing_and_corrupt_canonical_state_do_not_apply_the_candidate`（両backend）。消失／破損は旧rowを変更せず、正しいstateへ戻した再取得はwrite不要 |
+| AC-4、TR-5 | `cache_write_failure_is_recoverable_from_canonical_state`。SQLite書込み拒否triggerでvalid updateがcache保存に失敗してもlockが残らず、docs/blobから再取得可能 |
+| AC-4、TR-4 | `restart_and_missing_cache_resolve_docs_at_the_same_timestamp`。SQLite接続を閉じ、lockを新規作成して再open。同timestampの最新canonicalから保存済み旧cacheを更新し、cache削除後も再構築 |
+
 ## 検証・監査
 
-修正後のtest、path別validation、独立監査、CI、merge tree照合は未実施。結果は実行後にこの記録へ追加する。
+- `cargo test -p kukuri-app-api --lib game_projection_freshness -- --nocapture`: 15 passed、0 failed、0 ignored（1.05秒）。
+- CLI／store parity／既存game・Dome／Runtime restart、scenario、path別validationは実行中。独立監査、CI、merge tree照合は未実施。
+- ADR 0006の`late_joiner_backfills_game_room_manifest`という同名testは現行にはない。現行`game_room_score_update_replicates`はsender側create/update完了後にreceiverが初めて`list_game_rooms`でsubscribeするsequenceを持つため、latest stateのlate-join取得証跡として同testをfeature有効で実行する。

--- a/docs/progress/2026-09-09-942-score-game-projection-freshness.md
+++ b/docs/progress/2026-09-09-942-score-game-projection-freshness.md
@@ -1,0 +1,39 @@
+# #942 ScoreGame projection の退行防止
+
+## 現在の状態
+
+- 状態: 実装中。修正前の制御可能な再現を確認済み。
+- Issue: [#942](https://github.com/KingYoSun/kukuri/issues/942)。区分C。
+- Scope revision: `2026-09-08-score-game-projection-freshness-v1`。
+- 調査・実装開始基準: `58328f035a391f8f321bffdf6287cd339228fec7`。
+- 承認: 2026-09-09 のユーザー指示により、計画の実行、コミット、PR、CI成功後のマージを実施する。独立監査PASSとmerge対象一致をClose条件とする。
+- 計画とAC／INVAR・固定inventory／transition: [実装プラン](../../.codex.plans/2026-09-09-issue-942-score-game-projection-freshness.md)。
+
+## 修正前の再現（AC-1）
+
+`crates/app-api/src/tests/game_projection_freshness.rs` のfixtureは、対象topicの自動購読を停止し、一括／個別hydrationを明示的に実行する。実際のAppService create/updateと実際のMemory／SQLite storeを使い、旧manifestのblob fetchだけを`Notify`で停止する。旧record取得 → blob待機 → Running／round1／Alice7更新 → row確認 → 旧fetch再開の順をtestが所有する。
+
+| test suffix | backend／writer | 修正前の結果 |
+| --- | --- | --- |
+| `late_record_hydration_keeps_valid_update_memory` | Memory／record | FAIL: score7 → score0、Running → Waiting、manifest hash退行 |
+| `late_record_hydration_keeps_valid_update_sqlite` | SQLite／record | 同じFAIL |
+| `late_replica_hydration_keeps_valid_update_memory` | Memory／replica | 同じFAIL |
+| `late_replica_hydration_keeps_valid_update_sqlite` | SQLite／replica | 同じFAIL |
+
+実行: `cargo test -p kukuri-app-api --lib game_projection_freshness -- --nocapture`。`0 passed; 4 failed; 0 ignored`、exit 101。SQLite／recordの例は`updated_at=1788931230591`→`1788931230583`、replicaは`1788931230591`→`1788931230582`。どちらも`metaverse: None`、`room_kind: ScoreGame`で、全row一致assertが失敗した。sleep・確率的反復・既存assert変更は使っていない。
+
+既存CLI baseline: `cargo test -p kukuri-cli --test content_live game_lifecycle_rejects_invalid_roster_without_mutation -- --exact --nocapture` は1 passed（0.18秒）。自然発生のCI実行順そのものを同定したとは主張せず、CI観測と一致する退行を生む2 writerの実行順をfixtureで確定した。
+
+## 採用判断（T2）
+
+- canonical sourceは既存のdocs stateが指すmanifest。stateのミリ秒timestampやhashの辞書順を新しいversionとみなさない。
+- `ServiceHandles`の既存フィールドは`pub(crate)`で、公開constructorは引数を維持したまま内部のroom単位排他を追加できる。cloneされるhandlesを通してAppServiceとsubscription taskで同じ排他を共有する。
+- ScoreGame create/updateのcanonical保存からprojection書込みまでと、hydrationのcanonical再照合からprojection書込みまでを共通のroom境界で保護する。hydrateの最初のblob fetchは境界外で行い、違うroomを止めない。
+- hydrationの再照合は`LocalOnly`。現在のrecordと候補が違えば、古い候補は書かず現在のrecordを取得・照合し直す。同timestampでも正当なcurrent pointerの更新を採用する。
+- 同じprojectionの再取得は`derived_at`だけを更新しない。最新rowを保持し、既存のCLI before/after全値一致契約を維持する。
+- storeの公開trait・Memory／SQLite writer・DB schemaは変更せず、既存production ScoreGame callerの前段を保護する。Metaverse用hydrateは既存の無条件upsertを維持する。
+- 共有Dome moveの3 writerはsource relationship detach、target active化、source tombstone化。ScoreGameの制御対象には入れず、既存Dome testsで互換性を確認する。
+
+## 検証・監査
+
+修正後のtest、path別validation、独立監査、CI、merge tree照合は未実施。結果は実行後にこの記録へ追加する。


### PR DESCRIPTION
## 概要

ScoreGameの旧manifestを取得中のhydrationが、新しい有効更新の後からcacheを書き戻し、一覧がRunning／score7からWaiting／score0へ退行する問題を修正します。一括・個別hydrationの両方で修正前の失敗を再現しました。

同じroomのlocal updateとhydration commitに共有排他を適用し、blob取得後に現在のlocal docs stateを確認します。古い候補は現在のpointerから解決し直し、同timestampの有効更新も反映します。同じprojectionの再取得は書込みを行いません。

## 対象と条件

- Refs #942
- 種別: fix、区分C、Scope revision: `2026-09-08-score-game-projection-freshness-v1`
- 実装開始基準: `58328f035a391f8f321bffdf6287cd339228fec7`
- 公開API／wire／署名／DB schema／store writerの契約、Metaverse lifecycle／readinessは維持します。
- [計画・固定AC/INVAR・inventory/transition](https://github.com/KingYoSun/kukuri/blob/fa5274f7a0cd6dab47a7a07f62e070c3902cc542/.codex.plans/2026-09-09-issue-942-score-game-projection-freshness.md)
- [実装・再現・条件ごとの検証証跡](https://github.com/KingYoSun/kukuri/blob/fa5274f7a0cd6dab47a7a07f62e070c3902cc542/docs/progress/2026-09-09-942-score-game-projection-freshness.md)
- 本番upsertは11→10箇所（一括／個別hydrateの2 sinkを統合）。ScoreGame create/update/共通hydrateの3箇所を保護し、Dome専用7箇所を互換確認します。登録点からの順引きと全sinkからの逆引きを記録しています。

## 変更前後の証拠

- 修正前test commit `681ef2361502dba50b3bb23f60a337077f46174d` でMemory／SQLite × 一括／個別の4ケースすべてFAIL。旧blob fetch停止→score7更新・確認→旧fetch再開の順をNotifyで固定しています。
- 同じ4ケースは修正後にPASS。既存CLIのbefore/after全値一致assertを変更していません。
- 新規15契約は同timestamp、docs event／hint、別room、再照合失敗／cancel、missing blobの既存retry、cache書込み失敗、SQLite再open／cache再構築を確認します。
- 無効roster／非owner拒否はdocs apply、blob put/pin、hint publish、SQLite insert/update/deleteの回数が不変で、対象canonical／manifest／projectionの内容も不変です。

## 検証とリスク

- 新規freshness契約15件、CLI2件、store関連11件、AppService game26件（新規15件を含む）、Dome17件、Runtime restart1件: PASS。
- `cargo clippy -p kukuri-app-api --all-targets -- -D warnings`: PASS。
- feature有効の `game_room_score_update_replicates`: PASS（sender更新後にreceiverがsubscribeするlate joinを含む）。
- `cargo xtask scenario desktop_smoke_game_room_persist`: PASS（7 steps）。
- `cargo xtask oversized-files`、`git diff --check`: PASS。
- `cargo xtask rust-test`: PASS（主suite902 PASS/4 skipped、harness22 PASS/0 skipped、doctest処理正常終了）。skip設定は変更していません。
- CI: 最終headの18 checksすべてSUCCESS。Desktop UI初回timeoutはコード/設定無変更の再実行で成功（経緯はPRコメントに記録）。
- 残存範囲: ローカル排他はremoteのdocs更新自体を止めません。現在のdocs pointerと同じroomのprojection writerの順序を基準にし、protocolやtimestampの意味を追加しません。

## 独立監査

最終head fa5274f7a0cd6dab47a7a07f62e070c3902cc542 の独立監査は **PASS**。固定inventoryは合計3/適合3/不適合0/未分類0、blocker0です。

[独立監査記録](https://github.com/KingYoSun/kukuri/pull/951#issuecomment-5596522812)。監査後の製品差分はありません。最終headのCI成功後、d2610af4467f6a91fefa208952abc5728496dc29としてマージ済み。PR headとmerge commitの全tree一致（差分0）を確認しました。

