### PR TITLE
chore: prepare v0.2.1-preview.1 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3133,7 +3133,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-app-api"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3165,7 +3165,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-blob-service"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3183,7 +3183,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cli"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3204,7 +3204,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-cli"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3226,7 +3226,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-core"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3260,7 +3260,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-e2e"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3293,7 +3293,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-indexer"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3323,7 +3323,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-iroh-relay"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "iroh-relay",
@@ -3337,7 +3337,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-operator"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "blake3",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-protocol"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "kukuri-cn-safety",
@@ -3367,14 +3367,14 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-runtime-support"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "tracing-subscriber",
 ]
 
 [[package]]
 name = "kukuri-cn-safety"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "kukuri-cn-safety",
@@ -3387,7 +3387,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-safety-arachnid"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "kukuri-cn-safety",
@@ -3402,7 +3402,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-safety-runtime"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3421,7 +3421,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-safety-vlm"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -3437,7 +3437,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-trust"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3451,7 +3451,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-user-api"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -3487,7 +3487,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-core"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "argon2",
@@ -3508,7 +3508,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-desktop-runtime"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3547,7 +3547,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-docs-sync"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3572,7 +3572,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-harness"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -3599,7 +3599,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-iroh-node"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -3618,7 +3618,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-metaverse-host"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "kukuri-core",
@@ -3629,7 +3629,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-store"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3646,7 +3646,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-test-support"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "thiserror 2.0.20",
@@ -3655,7 +3655,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-transport"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8105,7 +8105,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "base64 0.23.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 license = "MIT"
-version = "0.2.0"
+version = "0.2.1"
 
 [workspace.dependencies]
 anyhow = "1.0.104"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kukuri-desktop",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -3849,7 +3849,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-app-api"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3873,7 +3873,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-blob-service"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3890,7 +3890,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-protocol"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "kukuri-cn-safety",
@@ -3902,7 +3902,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-safety"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "serde",
@@ -3912,7 +3912,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-core"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "argon2",
@@ -3932,7 +3932,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-desktop-runtime"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3961,7 +3961,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-desktop-tauri"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "ashpd",
@@ -3991,7 +3991,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-docs-sync"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4014,7 +4014,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-iroh-node"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -4032,7 +4032,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-metaverse-host"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "kukuri-core",
@@ -4043,7 +4043,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-store"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4057,7 +4057,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-transport"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kukuri-desktop-tauri"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 default-run = "kukuri-desktop-tauri"
 

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "kukuri",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "identifier": "app.kukuri.desktop",
   "build": {
     "beforeDevCommand": "npx pnpm@10.16.1 vite --host 127.0.0.1 --port 5173 --strictPort",

--- a/docs/THIRD_PARTY_NOTICES.md
+++ b/docs/THIRD_PARTY_NOTICES.md
@@ -1133,7 +1133,7 @@ Total packages: 1074
 
 ## Desktop npm packages
 
-Total packages: 137
+Total packages: 136
 
 | Package | Version | License | Source |
 | --- | --- | --- | --- |
@@ -1224,7 +1224,6 @@ Total packages: 137
 | hls.js | 1.6.18 | Apache-2.0 | https://github.com/video-dev/hls.js |
 | html-parse-stringify | 4.0.1 | MIT | https://github.com/i18next/html-parse-stringify |
 | i18next | 26.3.6 | MIT | https://www.i18next.com |
-| i18next-browser-languagedetector | 8.2.1 | MIT | https://github.com/i18next/i18next-browser-languageDetector |
 | ieee754 | 1.2.1 | BSD-3-Clause | https://github.com/feross/ieee754#readme |
 | immediate | 3.0.6 | MIT | https://github.com/calvinmetcalf/immediate#readme |
 | is-promise | 2.2.2 | MIT | https://github.com/then/is-promise#readme |

--- a/docs/progress/2026-09-09-v0.2.1-preview.1-release-rollout.md
+++ b/docs/progress/2026-09-09-v0.2.1-preview.1-release-rollout.md
@@ -1,0 +1,10 @@
+# v0.2.1-preview.1 リリース・Community Node 更新
+
+- 依頼: 最新mainからクライアント全種、Community Nodeを公開し、既存VMを更新する。
+- 開始時main: `f333939767efc8b83dbd52ef05b78de073f0a90c`。Fast CI `34340109015` 成功。
+- バージョン更新は区分A（機械的保守）。workspace、Tauri、frontendと両Cargo.lockの自プロジェクトversionのみ0.2.1へ同期。依存、製品コード、schemaは変更しない。
+- 受入条件: 同一sourceのWindows／AppImage／Deb／CLI x86_64／aarch64公開、3 updater entryの実署名・公開後検証、CN4imageのregistry digest・revision一致、backup取得後の非置換VM更新とreadiness／公開境界確認。
+- 維持条件: 既存tag／公開assetを上書きしない。署名と公開guardを維持。VM／PD／利用者データ／秘密値を保持。
+- 手順: `docs/runbooks/release.md`、`docs/runbooks/community-node-production-rollout.md`。
+- 更新前Terraform validate成功、planはNo changes。既存VMはrunning、API／indexer／DBはhealthy、backup／readiness timerはactive。
+- バージョン同期の確認: `cargo xtask release-check v0.2.1-preview.1`、lockfileの自プロジェクト以外の差分なし、`git diff --check`。CIと公開・VM更新の結果は完了時に追記する。

--- a/docs/progress/2026-09-09-v0.2.1-preview.1-release-rollout.md
+++ b/docs/progress/2026-09-09-v0.2.1-preview.1-release-rollout.md
@@ -8,3 +8,5 @@
 - 手順: `docs/runbooks/release.md`、`docs/runbooks/community-node-production-rollout.md`。
 - 更新前Terraform validate成功、planはNo changes。既存VMはrunning、API／indexer／DBはhealthy、backup／readiness timerはactive。
 - バージョン同期の確認: `cargo xtask release-check v0.2.1-preview.1`、lockfileの自プロジェクト以外の差分なし、`git diff --check`。CIと公開・VM更新の結果は完了時に追記する。
+
+- 配布告知の既存不整合: mainのpackage.json／pnpm-lockから削除済みのi18next-browser-languagedetectorが告知に残り、notice生成の -Check が失敗した。生成スクリプトで再生成し、npm package数137→136と当該1行だけを同期。依存の追加・更新はない。再生成後の -Check は成功。


### PR DESCRIPTION
最新mainを基準に、Windows／Linux GUI（AppImage・Deb）／Linux CLI 2archとCommunity Nodeのv0.2.1-preview.1公開を準備します。workspace・frontend・Tauri・両Cargo.lockの自プロジェクトversionを0.2.1へ同期します。

配布告知には、mainで削除済みのi18next-browser-languagedetectorが残っていたため、既存生成スクリプトで再生成しました。npm一覧の該当1行と件数137→136だけを修正します。製品コード・依存・DB schemaは不変です。

区分A。受入条件はversion・同梱告知の整合と依存差分なし。`cargo xtask release-check v0.2.1-preview.1`、`generate-third-party-notices.ps1 -Check`、`git diff --check`成功。公開／VM更新の承認は今回のユーザー依頼に含まれます。CI成功後にmergeし、同一sourceから配布物を検証・公開します。

運用記録: docs/progress/2026-09-09-v0.2.1-preview.1-release-rollout.md