### PR TITLE
docs: record v0.2.1-preview.1 release and VM rollout

### DIFF
--- a/docs/progress/2026-09-09-v0.2.1-preview.1-release-rollout.md
+++ b/docs/progress/2026-09-09-v0.2.1-preview.1-release-rollout.md
@@ -1,5 +1,7 @@
 # v0.2.1-preview.1 リリース・Community Node 更新
 
+完了: クライアント5種とCommunity Node4イメージを公開し、VM更新・公開後検証まで完了した。
+
 - 依頼: 最新mainからクライアント全種、Community Nodeを公開し、既存VMを更新する。
 - 開始時main: `f333939767efc8b83dbd52ef05b78de073f0a90c`。Fast CI `34340109015` 成功。
 - バージョン更新は区分A（機械的保守）。workspace、Tauri、frontendと両Cargo.lockの自プロジェクトversionのみ0.2.1へ同期。依存、製品コード、schemaは変更しない。
@@ -7,6 +9,61 @@
 - 維持条件: 既存tag／公開assetを上書きしない。署名と公開guardを維持。VM／PD／利用者データ／秘密値を保持。
 - 手順: `docs/runbooks/release.md`、`docs/runbooks/community-node-production-rollout.md`。
 - 更新前Terraform validate成功、planはNo changes。既存VMはrunning、API／indexer／DBはhealthy、backup／readiness timerはactive。
-- バージョン同期の確認: `cargo xtask release-check v0.2.1-preview.1`、lockfileの自プロジェクト以外の差分なし、`git diff --check`。CIと公開・VM更新の結果は完了時に追記する。
+- バージョン同期の確認: `cargo xtask release-check v0.2.1-preview.1`、lockfileの自プロジェクト以外の差分なし、`git diff --check`。CI・公開・VM更新の結果は以下に記録した。
 
 - 配布告知の既存不整合: mainのpackage.json／pnpm-lockから削除済みのi18next-browser-languagedetectorが告知に残り、notice生成の -Check が失敗した。生成スクリプトで再生成し、npm package数137→136と当該1行だけを同期。依存の追加・更新はない。再生成後の -Check は成功。
+
+## 公開ソースと検証
+
+- PR [#953](https://github.com/KingYoSun/kukuri/pull/953) の head `154e5cbc5dae10e96265d8d8a8a9441721c54edc` は18 checks成功。merge `f2cdb5cacf02218b34291a35754b55a15c2f564e` とtree一致を確認し、同commitへ `v0.2.1-preview.1` を固定した。
+- ローカルではrelease-check、noticeの再生成後のCheck、Tauriの `cargo metadata --locked --offline`、diff checkが成功。
+- main Fast [34363187290](https://github.com/KingYoSun/kukuri/actions/runs/34363187290) の初回はWindows packageだけ25分制限で停止。通常コンパイル中に外部から停止されており、他8 jobsは成功。同sourceで失敗したWindows jobだけ再実行し、attempt 2で成功した。
+- tag pushによるdraft用run `34363200135` はpackage生成前に停止。公開指定の [34363228150](https://github.com/KingYoSun/kukuri/actions/runs/34363228150) を同tagから実行。異なるrunの資材は混ぜない。
+
+## Community Node公開と更新前確認
+
+- latest [34363187123](https://github.com/KingYoSun/kukuri/actions/runs/34363187123) とversion [34363199913](https://github.com/KingYoSun/kukuri/actions/runs/34363199913) は4 imagesずつ成功。registryの8 refsはすべてlinux/amd64、OCI revisionは公開source `f2cdb5ca` と一致。VM用には次のversion digestを選んだ。
+
+| image（ghcr.io/kingyosun配下） | version digest |
+| --- | --- |
+| kukuri-cn-user-api | sha256:1e8ab6ddf50b565f075376901b58ad0f7f5be2b7f79f7260d488b6418430bbb8 |
+| kukuri-cn-iroh-relay | sha256:b83788810bdfcefca99ca079693ca0c772a65d2982c0c84368bde732b3f02877 |
+| kukuri-cn-cli | sha256:9c3e7a488062badb387565621a18c9acd23942c82671617417b6524295475e70 |
+| kukuri-cn-indexer | sha256:0e318f73952dc2e52111b52deabe2f9b3e46e93507ab3a1693ec39b8e2ec04f4 |
+
+- operator config／tfvarsの4 refsだけを同期し、他の設定のbytes不変、設定validation成功を確認した。Secret Managerの現行署名鍵から導出した公開識別子と、稼働VMの鍵から新CLIで導出した識別子は、公開manifestのnode_idと一致。秘密値は作業ログ・作業記録へ出力・保存していない。
+- 更新前は24 migrations成功、API／indexer／DB healthy、4 timers enabled/active、readiness成功、truth=projection=0。全7 containersのimage IDとrollback用4 refsを非公開運用記録へ保存した。
+- candidate planは41 resources中40 no-op、8 outputs no-op。唯一のreplacement理由はVMのmetadata_startup_script。Terraform構成は不変、variables差分は4 image fieldsだけ。base64を展開したscript全体も4 refsと派生deployment revision以外は一致することを検査した。
+- desired startup SHA-256: `47e391db9a4609f461c8b8b92cb7ee49350778bb416c9b535a5cb7ac54c9d971`。replacementを含むcandidate planはapply対象にしない。
+
+### 事前pull時の容量回復
+
+- indexer取得中にDocker領域の不足を検出（空き494MB）。サービス切替前で、全稼働containerは正常だった。
+- 7日以上前のdangling image 5件（旧CN4件と旧Valkey1件）のregistry manifestが再取得可能なことを確認し、`docker image prune -f --filter until=168h` で限定回収。5.548GBを回収し、空き5.8GBへ回復した。
+- 同じ4 digestのpullを再実行し、VMでも全4 imageのrevision一致を確認。新旧imageを保持して空き4.3GB。現行／rollback／今回のimage、既存稼働container、volume、PD、利用者データを削除していない。
+
+### 振る舞いが不変の部分の採用
+
+- 前回公開sourceからのCN製品差分は[#926](./2026-09-08-926-indexer-source-resolver.md)のread-only source resolver抽出だけ。core／transport／docs-sync／blob-service／schema／依存は不変。
+- 移動した3 methodsと2 helpersは、可視性と空白を除いて前回公開版と一致することを再確認。既存の39 before/after contracts、[独立監査](https://github.com/KingYoSun/kukuri/pull/939#issuecomment-5574975927)、PR #939の全17 checks成功も確認した。
+- 今回新たなlive投稿試験を行ったとは扱わず、前回の同一処理の実機証拠を採用する。新revisionではworkerの全件見直し、readiness、truth/projection、公開境界を追加確認する。
+
+## VM更新完了（2026-09-09 UTC／2026-09-10 JST）
+
+- main Fastはattempt 2で成功。初回timeoutの履歴を保持し、タグ・source・検証内容は変更していない。
+- 更新直前のbackup serviceは15:40:44 UTCに成功。GCS objectのgenerationと390,987 bytesを確認し、rollback refsとともに非公開運用記録へ保持した。
+- metadata同期後、desired／server SHA-256は上記 `47e391db...` で一致。作り直したsafe planは41 resources／8 outputsすべてno-op、置換0。safeだけをapplyし、0 added／0 changed／0 destroyed。最終planはNo changes。
+- startupは15:45:50〜15:46:17 UTC、exit 0／bootstrap complete。API／indexer healthy、relay running、稼働3 containersとCLIの参照はすべてversion digest／source `f2cdb5ca` に一致。
+- 15:48:02 UTCのreadinessはready=true／fail=0／unknown=0。provider credentialは直近の検証済み結果を再利用して全slot pass。恒久blob保存無効、4 public scopes、scan_errors=0／provider_unavailable=0、truth=projection=0、relation analysis成功を確認した。
+- indexerの全件見直し成功時刻は `1788968775`（startup開始 `1788968750` 以後）。worker／ingestは有効、last_errorはnull。24 migrationsはすべて成功済み、4 timersはenabled／active。Postgres／ArcadeDB／Valkey／Caddyの既存image・containerは継続稼働。
+- 公開health／relay ping／両manifestは200。node_idとlegal_documentsは不変、法務7 URLの本文hash／Content-Typeも更新前と一致。未認証のindex／trust／relationは401を維持。
+- 新旧imageを保持して空き4.3GB。今回配置したVM上の検証helper2本だけを削除し、不在を確認した。VM／PDの置換、volume／利用者データの削除はない。
+
+## クライアント公開完了
+
+- [v0.2.1-preview.1](https://github.com/KingYoSun/kukuri/releases/tag/v0.2.1-preview.1) は2026-09-09 16:03:40 UTCに公開。Release workflow `34363228150` は全10 jobs成功。sourceは一貫して `f2cdb5cacf02218b34291a35754b55a15c2f564e`。
+- Windows NSIS、Linux AppImage／Deb、Linux CLI x86_64／aarch64の5本体と、署名・checksum・provenance・native対応source／noticeを含む全21 assetsを公開。CLI両archは実archiveの実行検証（aarch64はQEMU）まで成功。
+- 同一runのbundleと実Rust verifierを使い、最終manifestのWindows／AppImage／Debの3 entryで署名受理と改変拒否を確認。完全性・GitHub upload digest照合も成功した。
+- 公開後jobは16:04:07 UTCに `stable_manifest=passed`、`public_files=7`、source一致を報告。安定updater URLを追加で読み、version=0.2.1、3 platform entriesを確認した。GitHub latestは本tag、draft=false／prerelease=false（runbookのupdater互換仕様）を維持する。
+- WindowsのSmartScreen案内を含むRelease notesを確認。自動生成CHANGELOGのPR #954は同runのCHANGELOG_SECTION.mdと完全一致する37行追加だけで、check成功後にmergeした。
+- 利用者データや公開済み旧assetの上書きは行っていない。今回の運用で発生した容量不足・Windows初回timeoutは上記の限定回復で解消済み。


### PR DESCRIPTION
v0.2.1-preview.1のクライアント5種・Community Node4イメージの公開と、既存VMへの非置換更新の完了記録です。同一source、署名・公開後検証、backup、Terraform差分、稼働revision／readiness／公開境界を記録します。

Windows初回ビルドのtimeoutは同sourceの失敗job再実行で回復し、Docker容量不足は再取得可能な7日以上前の未使用image5件だけを回収して解消しました。公開assetの上書きやVM／PD／利用者データの削除はありません。

区分A、文書のみ。`git diff --check`成功。公開workflow全10jobs成功、main Fast再実行成功、VMのreadiness・公開確認成功を実結果と照合済みです。