### PR TITLE
chore: prepare v0.2.2-preview.1 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3133,7 +3133,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-app-api"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3165,7 +3165,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-blob-service"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3183,7 +3183,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cli"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3204,7 +3204,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-cli"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3226,7 +3226,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-core"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3260,7 +3260,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-e2e"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3293,7 +3293,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-indexer"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3323,7 +3323,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-iroh-relay"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "iroh-relay",
@@ -3337,7 +3337,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-operator"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "blake3",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-protocol"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "kukuri-cn-safety",
@@ -3367,14 +3367,14 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-runtime-support"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "tracing-subscriber",
 ]
 
 [[package]]
 name = "kukuri-cn-safety"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "async-trait",
  "kukuri-cn-safety",
@@ -3387,7 +3387,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-safety-arachnid"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "async-trait",
  "kukuri-cn-safety",
@@ -3402,7 +3402,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-safety-runtime"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3421,7 +3421,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-safety-vlm"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -3437,7 +3437,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-trust"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3451,7 +3451,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-user-api"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -3487,7 +3487,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-core"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "argon2",
@@ -3508,7 +3508,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-desktop-runtime"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3547,7 +3547,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-docs-sync"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3572,7 +3572,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-harness"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -3599,7 +3599,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-iroh-node"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -3618,7 +3618,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-metaverse-host"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "kukuri-core",
@@ -3629,7 +3629,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-store"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3646,7 +3646,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-test-support"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "async-trait",
  "thiserror 2.0.20",
@@ -3655,7 +3655,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-transport"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8105,7 +8105,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "base64 0.23.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 license = "MIT"
-version = "0.2.1"
+version = "0.2.2"
 
 [workspace.dependencies]
 anyhow = "1.0.104"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kukuri-desktop",
   "private": true,
-  "version": "0.2.1",
+  "version": "0.2.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -3849,7 +3849,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-app-api"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3873,7 +3873,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-blob-service"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3890,7 +3890,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-protocol"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "kukuri-cn-safety",
@@ -3902,7 +3902,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-cn-safety"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "async-trait",
  "serde",
@@ -3912,7 +3912,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-core"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "argon2",
@@ -3932,7 +3932,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-desktop-runtime"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3961,7 +3961,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-desktop-tauri"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "ashpd",
@@ -3993,7 +3993,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-docs-sync"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4016,7 +4016,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-iroh-node"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -4034,7 +4034,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-metaverse-host"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "kukuri-core",
@@ -4045,7 +4045,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-store"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4059,7 +4059,7 @@ dependencies = [
 
 [[package]]
 name = "kukuri-transport"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kukuri-desktop-tauri"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2024"
 default-run = "kukuri-desktop-tauri"
 

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "kukuri",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "identifier": "app.kukuri.desktop",
   "build": {
     "beforeDevCommand": "npx pnpm@10.16.1 vite --host 127.0.0.1 --port 5173 --strictPort",

--- a/docs/progress/2026-09-12-v0.2.2-preview.1-release-rollout.md
+++ b/docs/progress/2026-09-12-v0.2.2-preview.1-release-rollout.md
@@ -1,0 +1,13 @@
+# v0.2.2-preview.1 リリース・Community Node 更新
+
+進行中: クライアント全種とCommunity Nodeの公開、既存VM更新を実施する。
+
+- 依頼: `0.2.2-preview.1` として全クライアント・Community Nodeをリリースし、VMを更新する。
+- 開始時source: 最新main `f7a86a0d23cc46ebf59e5949cd450b44126db3ce`。
+- バージョン同期は区分A（機械的保守）。workspace、Tauri、frontend、両Cargo.lockの自プロジェクトversionだけを0.2.2へ更新する。
+- 受入条件: 同一sourceからWindows NSIS、Linux AppImage／Deb、CLI x86_64／aarch64を公開。3 updater entryの実署名・公開後検証。CN4イメージのregistry digest／revision確認。backup取得後にVMを非置換更新し、readiness／公開境界を確認する。
+- 維持条件: 既存tag／公開assetは上書きせず、署名・公開guardを維持する。VM／PD／利用者データ／秘密値を保持する。
+- 手順: `docs/runbooks/release.md`、`docs/runbooks/community-node-production-rollout.md`。
+- 開始時のFast CI `34663293879` はUIテスト1件の5000ms timeout（1506件成功）。同source・条件で失敗jobを再実行し、結果を確認する。
+- 事前確認: VMの7 containersは正常稼働、backup／readiness timerはactive、Docker領域の空き4.2GB。Terraform validate成功。
+- 対象pathと検証: 上記versionファイル6件、本文書。release-check、notice生成のCheck、lockfileの自プロジェクト以外の不変確認、diff check、PR／release CIで検証する。


### PR DESCRIPTION
クライアント全5種とCommunity Nodeを v0.2.2-preview.1 として公開するため、自プロジェクトのversionを0.2.2へ同期します。依存・製品コード・schemaは変更していません。

検証: `cargo xtask release-check v0.2.2-preview.1`、third-party noticesの`-Check`、両lockfileが自プロジェクトversionだけの変更であること、`git diff --check`が成功しました。公開・VM更新の受入条件と証跡は `docs/progress/2026-09-12-v0.2.2-preview.1-release-rollout.md` に記録します。
