### PR TITLE
docs: record v0.2.2-preview.1 release and VM rollout

### DIFF
--- a/docs/progress/2026-09-12-v0.2.2-preview.1-release-rollout.md
+++ b/docs/progress/2026-09-12-v0.2.2-preview.1-release-rollout.md
@@ -1,13 +1,68 @@
 # v0.2.2-preview.1 リリース・Community Node 更新
 
-進行中: クライアント全種とCommunity Nodeの公開、既存VM更新を実施する。
+完了: クライアント5種とCommunity Node4イメージを公開し、VM更新・公開後検証まで完了した。
 
 - 依頼: `0.2.2-preview.1` として全クライアント・Community Nodeをリリースし、VMを更新する。
 - 開始時source: 最新main `f7a86a0d23cc46ebf59e5949cd450b44126db3ce`。
-- バージョン同期は区分A（機械的保守）。workspace、Tauri、frontend、両Cargo.lockの自プロジェクトversionだけを0.2.2へ更新する。
+- バージョン同期は区分A（機械的保守）。workspace、Tauri、frontend、両Cargo.lockの自プロジェクトversionだけを0.2.2へ更新した。
 - 受入条件: 同一sourceからWindows NSIS、Linux AppImage／Deb、CLI x86_64／aarch64を公開。3 updater entryの実署名・公開後検証。CN4イメージのregistry digest／revision確認。backup取得後にVMを非置換更新し、readiness／公開境界を確認する。
 - 維持条件: 既存tag／公開assetは上書きせず、署名・公開guardを維持する。VM／PD／利用者データ／秘密値を保持する。
 - 手順: `docs/runbooks/release.md`、`docs/runbooks/community-node-production-rollout.md`。
-- 開始時のFast CI `34663293879` はUIテスト1件の5000ms timeout（1506件成功）。同source・条件で失敗jobを再実行し、結果を確認する。
+- 開始時のFast CI `34663293879` はUIテスト1件の5000ms timeout（1506件成功）。同source・条件で失敗jobを再実行し、成功を確認した。
 - 事前確認: VMの7 containersは正常稼働、backup／readiness timerはactive、Docker領域の空き4.2GB。Terraform validate成功。
-- 対象pathと検証: 上記versionファイル6件、本文書。release-check、notice生成のCheck、lockfileの自プロジェクト以外の不変確認、diff check、PR／release CIで検証する。
+- 対象pathと検証: 上記versionファイル6件、本文書。release-check、notice生成のCheck、lockfileの自プロジェクト以外の不変確認、diff check、PR／release CIで検証した。
+
+## 公開ソースと検証
+
+- 準備PR [#987](https://github.com/KingYoSun/kukuri/pull/987) の18 checksが成功。head `005387584810ac642995bf0ed4c87b0649b219ab` とmerge `60e7ab8a8ff0cb7f22bbe85eb596661659258559` のtree一致を確認し、後者へ `v0.2.2-preview.1` を固定した。
+- ローカルのrelease-check、third-party noticesのCheck、diff checkが成功。両Cargo.lockは自プロジェクト27／12 packageのversionのみ更新し、他のフィールド・依存が不変であることを解析して確認した。
+- 開始時mainのFast `34663293879` は同条件の再実行で成功。
+- 公開sourceのmain Fast [34668251564](https://github.com/KingYoSun/kukuri/actions/runs/34668251564) は初回UI2件が5000ms timeout（1505件成功）。他8 jobsは成功。失敗jobだけを同source・条件で再実行し、attempt 2で全9 jobs成功を確認した。初回失敗の履歴は保持し、閾値・テスト・sourceは変更していない。
+- tag pushによるdraft用run `34668301957` は資材生成前に停止し、公開指定の [34668327830](https://github.com/KingYoSun/kukuri/actions/runs/34668327830) へ統一した。別runの資材を混ぜない。
+
+## Community Node公開
+
+- version [34668301858](https://github.com/KingYoSun/kukuri/actions/runs/34668301858)、main [34668251563](https://github.com/KingYoSun/kukuri/actions/runs/34668251563) は4 imagesずつ成功。
+- registryでversion tagと `sha-60e7ab8a8ff0` の8 refsを解決し、全imageのlinux/amd64、OCI revisionの公開source一致、digest manifestの取得成功を確認した。version／SHA tagのdigestは各imageで一致した。
+
+| image（ghcr.io/kingyosun配下） | 配置digest |
+| --- | --- |
+| kukuri-cn-user-api | sha256:56a3021db70aaeb02f955058ae934991476b55a510e0c4964ca1f5ff2c73a1b6 |
+| kukuri-cn-iroh-relay | sha256:d0145904919f7e29ece48c14d2b4c2fef16e5de31d13212afba4fc805a91683d |
+| kukuri-cn-cli | sha256:142d8e944e72885fd408fcee264bed12cd4a7943446b3fb2c7decbd8e5fd275b |
+| kukuri-cn-indexer | sha256:f949e4497d17a1b57a3066d8748a296167310c8be8182bd5ac45e9db47030e2e |
+
+- operator config／tfvarsの4 refsだけを同期し、他設定のbytes不変、設定validation、Terraform fmt／validate成功を確認した。
+- Secret Managerの署名鍵から導出した識別子と、VMの鍵を新CLIで読み取って導出した識別子は、公開manifestのnode_idと一致。秘密値は記録へ保存・出力していない。
+
+## 容量確保と非置換計画
+
+- 更新前の空き4.2GBに対し、新旧imageを併存させるため、96時間以上前のdangling image9件の全registry manifestを取得できることを確認した。既存稼働imageと重ならないことを照合して `docker image prune -f --filter until=96h` を実施し、11.09GBを回収、空き15GBへ回復した。
+- 削除は9月7日の旧CN8 imageと9月3日の旧Valkey image。稼働7 containersのimage ID不変を確認した。volume／PD／利用者データを容量回収対象にしていない。
+- VMで新4 digestを事前pullし、全revision一致を確認。新旧imageを保持して空き9.5GB。
+- 初期Terraform planは41 resourcesすべてno-op。candidate planの唯一のreplacement理由はVMのmetadata_startup_script。Terraform構成は不変、variablesは4 image fieldsだけ。base64展開後のstartup全体も4 refsと派生deployment revision以外は一致した。
+- desired startup SHA-256: `814ec0f01a3f61148e70344b21c210e6eecca2a7d72224719472fec3abb2c15a`。replacementを含むcandidate planは適用していない。
+
+## VM更新完了（2026-09-12 UTC／JST）
+
+- 直前のbackup service成功と、新しいGCS objectのgeneration `1789184487419643`、428,747 bytesを確認。object参照・rollback用旧4 refsは非公開運用記録へ保持した。
+- startup metadata同期後、desired／server SHA-256の一致を確認。作り直したsafe planは41 resources／8 outputsすべてno-op、置換0。safe planだけをapplyし、0 added／0 changed／0 destroyed。最終planもNo changes。
+- startupは03:43:25 UTCにbootstrap complete、03:43:26にexit 0。新API／indexerはhealthy、relayはrunning、稼働3 containersのdigest／revisionは公開sourceに一致した。
+- 03:44:36 UTCのreadinessは `ready=true fail=0 unknown=0`。provider credentialは直近の検証済み結果を再利用して全slot pass。恒久blob保存無効、4 public scopes、scan_errors=0／provider_unavailable=0、truth=projection=0、relation analysis成功を確認した。
+- worker／ingestは有効、last_errorはnull。全件見直しのsync／ingest時刻は今回のstartup開始以後。24 migrations成功、4 timersはenabled／active。Postgres／ArcadeDB／Valkey／Caddyのimage IDは更新前と一致した。
+- 公開health／relay ping／両manifestは200。manifest全体と法務7 URLの本文hash／Content-Typeは更新前と一致。未認証index／trust／relationは401を維持し、新規の `/v1/indexing/status` は旧版404から認証を要求する401へ移った。
+- VM上の今回の検証helper2本を削除し、不在を確認した。VM／PDの置換、volume／利用者データの削除はない。
+
+### 既存の実機証拠の採用範囲
+
+- 前回版からのCN製品変更は[#975](./2026-09-11-975-indexing-status-read.md)のread API追加・既存gate／query parserの共通化。cn-indexer、transport、docs-sync、blob-service、migrationは不変。PR #985の独立監査と全17 checks成功、今回のCN／接続検証を確認した。
+- 今回新たにlive mediaを投稿したとは扱わない。不変のworker／media経路には[前回の証拠](./2026-09-09-v0.2.1-preview.1-release-rollout.md)を採用し、新revisionではreadiness、全件見直し、truth/projection、公開境界を確認した。新read APIの認証・同意・私有scope非開示は既存の#975 contractsと今回CIが担保する。
+
+## クライアント公開完了
+
+- [v0.2.2-preview.1](https://github.com/KingYoSun/kukuri/releases/tag/v0.2.2-preview.1) は2026-09-12 04:35:43 UTC（13:35:43 JST）に公開。Release workflow `34668327830` は全10 jobs成功。公開sourceは一貫して `60e7ab8a8ff0cb7f22bbe85eb596661659258559`。
+- Windows NSIS、Linux AppImage／Deb、CLI x86_64／aarch64の5本体と、署名・checksum・provenance・native対応source／noticeを含む全21 assetsを公開。CLI両archは実archiveの実行検証（aarch64はQEMU）、Linuxはpackage／desktop契約・実updaterの失敗時保持と明示再試行まで成功した。
+- 同一Windows buildの実Rust verifierを使い、最終manifestのWindows／AppImage／Debの3 entryで署名受理と1 byte改変拒否を確認。完全性・全assetのGitHub upload digest照合が完了してから公開された。
+- 公開後jobは04:36:07 UTCに `stable_manifest=passed`、`public_files=7`、source一致を報告。安定updater URLを追加で読み、version=0.2.2、3 platform entriesを確認した。GitHub latestは本tag、draft=false／prerelease=false（既存updater互換）を維持する。
+- Windows SmartScreen案内を含むRelease notesを確認。CHANGELOGのPR #988は同runのCHANGELOG_SECTION.mdと一致する31行追加だけで、check成功後にmergeした。
+- 既存公開tag／assetを上書きせず、利用者データも保持した。今回のUI timeoutは同条件の再実行で解消し、公開・VM更新の未完了事項はない。


### PR DESCRIPTION
v0.2.2-preview.1 のクライアント全5種・CN4イメージ公開と、非置換VM更新の完了記録を反映します。公開source、CI、registry digest、バックアップ、起動script hash、readiness、公開API・updater検証を記録しています。

文書のみの変更です。`git diff --check` と、記録したdigest・backup generation・startup hash・公開時刻・全10 release jobs成功の証跡照合を通過しました。
